### PR TITLE
Rename SyncUser::identity() to SyncUser::user_id()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Breaking changes
 * `App::get_uncached_app(...)` and `App::get_shared_app(...)` have been replaced by `App::get_app(App::CacheMode, ...)`. The App constructor is now enforced to be unusable, use `App::get_app()` instead. ([#7237](https://github.com/realm/realm-core/issues/7237))
+* Rename `SyncUser::identity()` and friends to `SyncUser::user_id()`. `SyncUser` used the word "identity" for two separate concepts and had both `identity()` and `identities()` which did unrelated things.
 
 ### Compatibility
 * Fileformat: Generates files with format v23. Reads and automatically upgrade from fileformat v5.

--- a/bindgen/spec.yml
+++ b/bindgen/spec.yml
@@ -1139,9 +1139,8 @@ classes:
     properties:
       all_sessions: std::vector<SharedSyncSession>
       is_logged_in: bool
-      identity: const std::string&
+      user_id: const std::string&
       provider_type: const std::string&
-      local_identity: const std::string&
       access_token: std::string
       refresh_token: std::string
       device_id: std::string

--- a/src/realm.h
+++ b/src/realm.h
@@ -3278,11 +3278,11 @@ RLM_API void realm_app_sync_client_wait_for_sessions_to_terminate(realm_app_t*) 
 RLM_API char* realm_app_sync_client_get_default_file_path_for_realm(const realm_sync_config_t*,
                                                                     const char* custom_filename);
 /**
- * Return the identiy for the user passed as argument
+ * Return the unique user id for the user passed as argument
  * @param user ptr to the user for which the identiy has to be retrieved
- * @return a ptr to the identity string
+ * @return a ptr to the user id string
  */
-RLM_API const char* realm_user_get_identity(const realm_user_t* user) RLM_API_NOEXCEPT;
+RLM_API const char* realm_user_get_id(const realm_user_t* user) RLM_API_NOEXCEPT;
 
 /**
  * Retrieve the state for the user passed as argument

--- a/src/realm/object-store/audit.mm
+++ b/src/realm/object-store/audit.mm
@@ -669,7 +669,7 @@ std::shared_ptr<AuditRealmPool> AuditRealmPool::get_pool(std::shared_ptr<SyncUse
                                                          ErrorHandler error_handler) NO_THREAD_SAFETY_ANALYSIS
 {
     struct CachedPool {
-        std::string user_identity;
+        std::string user_id;
         std::string partition_prefix;
         std::string app_id;
         std::weak_ptr<AuditRealmPool> pool;
@@ -685,8 +685,7 @@ std::shared_ptr<AuditRealmPool> AuditRealmPool::get_pool(std::shared_ptr<SyncUse
 
     auto app_id = user->app().lock()->config().app_id;
     auto it = std::find_if(s_pools.begin(), s_pools.end(), [&](auto& pool) {
-        return pool.user_identity == user->identity() && pool.partition_prefix == partition_prefix &&
-               pool.app_id == app_id;
+        return pool.user_id == user->user_id() && pool.partition_prefix == partition_prefix && pool.app_id == app_id;
     });
     if (it != s_pools.end()) {
         if (auto pool = it->pool.lock()) {
@@ -696,7 +695,7 @@ std::shared_ptr<AuditRealmPool> AuditRealmPool::get_pool(std::shared_ptr<SyncUse
 
     auto pool = std::make_shared<AuditRealmPool>(Private(), user, partition_prefix, error_handler, logger, app_id);
     pool->scan_for_realms_to_upload();
-    s_pools.push_back({user->identity(), partition_prefix, app_id, pool});
+    s_pools.push_back({user->user_id(), partition_prefix, app_id, pool});
     return pool;
 }
 

--- a/src/realm/object-store/c_api/app.cpp
+++ b/src/realm/object-store/c_api/app.cpp
@@ -659,9 +659,9 @@ RLM_API char* realm_app_sync_client_get_default_file_path_for_realm(const realm_
     });
 }
 
-RLM_API const char* realm_user_get_identity(const realm_user_t* user) noexcept
+RLM_API const char* realm_user_get_id(const realm_user_t* user) noexcept
 {
-    return (*user)->identity().c_str();
+    return (*user)->user_id().c_str();
 }
 
 RLM_API realm_user_state_e realm_user_get_state(const realm_user_t* user) noexcept

--- a/src/realm/object-store/sync/impl/sync_file.hpp
+++ b/src/realm/object-store/sync/impl/sync_file.hpp
@@ -61,24 +61,23 @@ public:
     SyncFileManager(const std::string& base_path, const std::string& app_id);
 
     /// Remove the Realms at the specified absolute paths along with any associated helper files.
-    void remove_user_realms(const std::string& user_identity,
+    void remove_user_realms(const std::string& user_id,
                             const std::vector<std::string>& realm_paths) const; // throws
 
     /// A non throw version of File::exists(),  returning false if any exceptions are thrown when attempting to access
     /// this file.
     static bool try_file_exists(const std::string& path) noexcept;
 
-    util::Optional<std::string> get_existing_realm_file_path(const std::string& user_identity,
+    util::Optional<std::string> get_existing_realm_file_path(const std::string& user_id,
                                                              const std::vector<std::string>& legacy_user_identities,
                                                              const std::string& realm_file_name,
                                                              const std::string& partition) const;
     /// Return the path for a given Realm, creating the user directory if it does not already exist.
-    std::string realm_file_path(const std::string& user_identity,
-                                const std::vector<std::string>& legacy_user_identities,
+    std::string realm_file_path(const std::string& user_id, const std::vector<std::string>& legacy_user_identities,
                                 const std::string& realm_file_name, const std::string& partition) const;
 
     /// Remove the Realm at a given path for a given user. Returns `true` if the remove operation fully succeeds.
-    bool remove_realm(const std::string& user_identity, const std::vector<std::string>& legacy_user_identities,
+    bool remove_realm(const std::string& user_id, const std::vector<std::string>& legacy_user_identities,
                       const std::string& realm_file_name, const std::string& partition) const;
 
     /// Remove the Realm whose primary Realm file is located at `absolute_path`. Returns `true` if the remove
@@ -134,15 +133,15 @@ private:
         return get_special_directory(c_utility_directory);
     }
     /// Return the user directory for a given user, creating it if it does not already exist.
-    std::string user_directory(const std::string& identity) const;
+    std::string user_directory(const std::string& user_id) const;
     // Construct the absolute path to the users directory
-    std::string get_user_directory_path(const std::string& user_identity) const;
-    std::string legacy_hashed_partition_path(const std::string& user_identity, const std::string& partition) const;
+    std::string get_user_directory_path(const std::string& user_id) const;
+    std::string legacy_hashed_partition_path(const std::string& user_id, const std::string& partition) const;
     std::string legacy_realm_file_path(const std::string& local_user_identity,
                                        const std::string& realm_file_name) const;
     std::string legacy_local_identity_path(const std::string& local_user_identity,
                                            const std::string& realm_file_name) const;
-    std::string preferred_realm_path_without_suffix(const std::string& user_identity,
+    std::string preferred_realm_path_without_suffix(const std::string& user_id,
                                                     const std::string& realm_file_name) const;
     std::string fallback_hashed_realm_file_path(const std::string& preferred_path) const;
 };

--- a/src/realm/object-store/sync/impl/sync_metadata.hpp
+++ b/src/realm/object-store/sync/impl/sync_metadata.hpp
@@ -52,8 +52,8 @@ public:
 class SyncUserMetadata {
 public:
     struct Schema {
-        // The server-supplied user_id for the user. Unique per App.
-        ColKey identity_col;
+        // The server-supplied user_id for the user. Unique per server instance.
+        ColKey user_id_col;
         // Locally generated UUIDs for the user. These are tracked to be able
         // to open pre-existing Realm files, but are no longer generated or
         // used for anything else.
@@ -75,7 +75,7 @@ public:
     };
 
     // Cannot be set after creation.
-    std::string identity() const;
+    std::string user_id() const;
 
     std::vector<std::string> legacy_identities() const;
     // for testing purposes only
@@ -219,7 +219,7 @@ public:
 
     // Retrieve or create user metadata.
     // Note: if `make_is_absent` is true and the user has been marked for deletion, it will be unmarked.
-    util::Optional<SyncUserMetadata> get_or_make_user_metadata(std::string_view identity,
+    util::Optional<SyncUserMetadata> get_or_make_user_metadata(std::string_view user_id,
                                                                bool make_if_absent = true) const;
 
     // Retrieve file action metadata.
@@ -229,8 +229,8 @@ public:
     void make_file_action_metadata(StringData original_name, StringData partition_key_value, StringData local_uuid,
                                    SyncFileActionMetadata::Action action, StringData new_name = {}) const;
 
-    util::Optional<std::string> get_current_user_identity() const;
-    void set_current_user_identity(std::string_view identity);
+    std::optional<std::string> get_current_user_id() const;
+    void set_current_user_id(std::string_view user_id);
 
     util::Optional<SyncAppMetadata> get_app_metadata();
     /// Set or update the cached app server metadata. The metadata will not be updated if it has already been

--- a/src/realm/object-store/sync/realm_backing_store.hpp
+++ b/src/realm/object-store/sync/realm_backing_store.hpp
@@ -85,7 +85,7 @@ struct RealmBackingStore final : public app::BackingStore {
     }
 
 private:
-    std::shared_ptr<SyncUser> get_user_for_identity(std::string_view identity) const noexcept REQUIRES(m_user_mutex);
+    std::shared_ptr<SyncUser> get_user_for_id(std::string_view user_id) const noexcept REQUIRES(m_user_mutex);
     bool run_file_action(SyncFileActionMetadata&) REQUIRES(m_file_system_mutex);
     void initialize() REQUIRES(!m_file_system_mutex, !m_user_mutex);
 

--- a/src/realm/object-store/sync/sync_session.cpp
+++ b/src/realm/object-store/sync/sync_session.cpp
@@ -428,8 +428,8 @@ void SyncSession::update_error_and_mark_file_for_deletion(SyncError& error, Shou
     backing_store->perform_metadata_update([action, original_path = std::move(original_path),
                                             recovery_path = std::move(recovery_path),
                                             partition_value = m_config.sync_config->partition_value,
-                                            identity = m_config.sync_config->user->identity()](const auto& manager) {
-        manager.make_file_action_metadata(original_path, partition_value, identity, action, recovery_path);
+                                            user_id = m_config.sync_config->user->user_id()](const auto& manager) {
+        manager.make_file_action_metadata(original_path, partition_value, user_id, action, recovery_path);
     });
 }
 
@@ -867,7 +867,7 @@ void SyncSession::create_sync_session()
 
     sync::Session::Config session_config;
     session_config.signed_user_token = sync_config.user->access_token();
-    session_config.user_id = sync_config.user->identity();
+    session_config.user_id = sync_config.user->user_id();
     session_config.realm_identifier = sync_config.partition_value;
     session_config.verify_servers_ssl_certificate = sync_config.client_validate_ssl;
     session_config.ssl_trust_certificate_path = sync_config.ssl_trust_certificate_path;

--- a/src/realm/object-store/sync/sync_user.hpp
+++ b/src/realm/object-store/sync/sync_user.hpp
@@ -194,9 +194,10 @@ public:
     /// Returns true if the user's only identity is anonymous.
     bool is_anonymous() const REQUIRES(!m_mutex, !m_tokens_mutex);
 
-    const std::string& identity() const noexcept
+    /// Server-supplied unique id for this user.
+    const std::string& user_id() const noexcept
     {
-        return m_identity;
+        return m_user_id;
     }
 
     const std::vector<std::string>& legacy_identities() const noexcept
@@ -294,7 +295,7 @@ private:
     mutable util::CheckedMutex m_mutex;
 
     // Set by the server. The unique ID of the user account on the Realm Application.
-    const std::string m_identity;
+    const std::string m_user_id;
 
     mutable util::CheckedMutex m_tokens_mutex;
 

--- a/test/object-store/audit.cpp
+++ b/test/object-store/audit.cpp
@@ -1775,7 +1775,7 @@ TEST_CASE("audit integration tests", "[sync][pbs][audit][baas]") {
         auto audit_user = session.app()->current_user();
         config.audit_config->audit_user = audit_user;
         auto realm = Realm::get_shared_realm(config);
-        session.app()->backing_store()->remove_user(audit_user->identity());
+        session.app()->backing_store()->remove_user(audit_user->user_id());
 
         auto audit = realm->audit_context();
         auto scope = audit->begin_scope("scope");

--- a/test/object-store/c_api/c_api.cpp
+++ b/test/object-store/c_api/c_api.cpp
@@ -5780,7 +5780,6 @@ TEST_CASE("C API app: link_user integration w/c_api transport", "[sync][app][c_a
         realm_release(sync_user);
     }
     SECTION("realm_app_get_all_users integration") {
-
         AutoVerifiedEmailCredentials creds;
         realm_user_t* sync_user_1 = nullptr;
         realm_string_t password{creds.password.c_str(), creds.password.length()};

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -2040,28 +2040,28 @@ TEST_CASE("app: user_semantics", "[sync][app][user]") {
 
     SECTION("current user is populated") {
         const auto user1 = login_user_anonymous();
-        CHECK(app->current_user()->identity() == user1->identity());
+        CHECK(app->current_user()->user_id() == user1->user_id());
         CHECK(event_processed == 1);
     }
 
     SECTION("current user is updated on login") {
         const auto user1 = login_user_anonymous();
-        CHECK(app->current_user()->identity() == user1->identity());
+        CHECK(app->current_user()->user_id() == user1->user_id());
         const auto user2 = login_user_email_pass();
-        CHECK(app->current_user()->identity() == user2->identity());
-        CHECK(user1->identity() != user2->identity());
+        CHECK(app->current_user()->user_id() == user2->user_id());
+        CHECK(user1->user_id() != user2->user_id());
         CHECK(event_processed == 2);
     }
 
     SECTION("current user is updated to last used user on logout") {
         const auto user1 = login_user_anonymous();
-        CHECK(app->current_user()->identity() == user1->identity());
+        CHECK(app->current_user()->user_id() == user1->user_id());
         CHECK(app->all_users()[0]->state() == SyncUser::State::LoggedIn);
 
         const auto user2 = login_user_email_pass();
         CHECK(app->all_users()[0]->state() == SyncUser::State::LoggedIn);
         CHECK(app->all_users()[1]->state() == SyncUser::State::LoggedIn);
-        CHECK(app->current_user()->identity() == user2->identity());
+        CHECK(app->current_user()->user_id() == user2->user_id());
         CHECK(user1 != user2);
 
         // should reuse existing session
@@ -2076,7 +2076,7 @@ TEST_CASE("app: user_semantics", "[sync][app][user]") {
         app->log_out([](auto) {});
         CHECK(user_events_processed == 1);
 
-        CHECK(app->current_user()->identity() == user2->identity());
+        CHECK(app->current_user()->user_id() == user2->user_id());
 
         CHECK(app->all_users().size() == 1);
         CHECK(app->all_users()[0]->state() == SyncUser::State::LoggedIn);
@@ -2086,14 +2086,14 @@ TEST_CASE("app: user_semantics", "[sync][app][user]") {
 
     SECTION("anon users are removed on logout") {
         const auto user1 = login_user_anonymous();
-        CHECK(app->current_user()->identity() == user1->identity());
+        CHECK(app->current_user()->user_id() == user1->user_id());
         CHECK(app->all_users()[0]->state() == SyncUser::State::LoggedIn);
 
         const auto user2 = login_user_anonymous();
         CHECK(app->all_users()[0]->state() == SyncUser::State::LoggedIn);
         CHECK(app->all_users().size() == 1);
-        CHECK(app->current_user()->identity() == user2->identity());
-        CHECK(user1->identity() == user2->identity());
+        CHECK(app->current_user()->user_id() == user2->user_id());
+        CHECK(user1->user_id() == user2->user_id());
 
         app->log_out([](auto) {});
         CHECK(app->all_users().size() == 0);
@@ -2135,14 +2135,14 @@ TEST_CASE("app: user_semantics", "[sync][app][user]") {
         app->unsubscribe(token);
 
         const auto user1 = login_user_anonymous();
-        CHECK(app->current_user()->identity() == user1->identity());
+        CHECK(app->current_user()->user_id() == user1->user_id());
         CHECK(app->all_users()[0]->state() == SyncUser::State::LoggedIn);
 
         const auto user2 = login_user_anonymous();
         CHECK(app->all_users()[0]->state() == SyncUser::State::LoggedIn);
         CHECK(app->all_users().size() == 1);
-        CHECK(app->current_user()->identity() == user2->identity());
-        CHECK(user1->identity() == user2->identity());
+        CHECK(app->current_user()->user_id() == user2->user_id());
+        CHECK(user1->user_id() == user2->user_id());
 
         app->log_out([](auto) {});
         CHECK(app->all_users().size() == 0);
@@ -2398,7 +2398,7 @@ TEST_CASE("app: link_user", "[sync][app][user]") {
         app->link_user(sync_user, custom_credentials, [&](std::shared_ptr<SyncUser> user, Optional<AppError> error) {
             REQUIRE_FALSE(error);
             REQUIRE(user);
-            CHECK(user->identity() == sync_user->identity());
+            CHECK(user->user_id() == sync_user->user_id());
             processed = true;
         });
         CHECK(processed);

--- a/test/object-store/sync/app_backing_store.cpp
+++ b/test/object-store/sync/app_backing_store.cpp
@@ -51,7 +51,7 @@ struct TestBackingStore final : public app::BackingStore {
         {
             util::CheckedLockGuard guard(m_user_mutex);
             auto it = std::find_if(m_users.begin(), m_users.end(), [&](const auto& user) {
-                return user->identity() == user_id && user->state() != SyncUser::State::Removed;
+                return user->user_id() == user_id && user->state() != SyncUser::State::Removed;
             });
             if (it == m_users.end()) {
                 // No existing user.
@@ -71,7 +71,7 @@ struct TestBackingStore final : public app::BackingStore {
     {
         util::CheckedLockGuard lock(m_user_mutex);
         auto matcher = [user_id](auto& el) {
-            return el->identity() == user_id && el->state() == SyncUser::State::LoggedIn;
+            return el->user_id() == user_id && el->state() == SyncUser::State::LoggedIn;
         };
         auto it = std::find_if(m_users.begin(), m_users.end(), matcher);
         return it == m_users.end() ? nullptr : *it;
@@ -117,19 +117,19 @@ struct TestBackingStore final : public app::BackingStore {
     void set_current_user(std::string_view user_id) override REQUIRES(!m_user_mutex)
     {
         util::CheckedLockGuard lock(m_user_mutex);
-        m_current_user = get_user_for_identity(user_id);
+        m_current_user = get_user_for_id(user_id);
     }
     void remove_user(std::string_view user_id) override REQUIRES(!m_user_mutex)
     {
         util::CheckedLockGuard lock(m_user_mutex);
-        if (auto user = get_user_for_identity(user_id))
+        if (auto user = get_user_for_id(user_id))
             user->invalidate();
     }
     void delete_user(std::string_view user_id) override REQUIRES(!m_user_mutex)
     {
         util::CheckedLockGuard lock(m_user_mutex);
         auto it = std::find_if(m_users.begin(), m_users.end(), [&user_id](auto& user) {
-            return user->identity() == user_id;
+            return user->user_id() == user_id;
         });
         auto user = it == m_users.end() ? nullptr : *it;
 
@@ -141,7 +141,7 @@ struct TestBackingStore final : public app::BackingStore {
         m_users.erase(it);
         user->detach_from_backing_store();
 
-        if (m_current_user && m_current_user->identity() == user->identity())
+        if (m_current_user && m_current_user->user_id() == user->user_id())
             m_current_user = nullptr;
     }
     void reset_for_testing() override REQUIRES(!m_user_mutex)
@@ -177,14 +177,14 @@ struct TestBackingStore final : public app::BackingStore {
             return *partition_value;
         }();
 
-        auto ident = user->identity();
+        auto ident = user->user_id();
         auto app_id = user->app().lock()->config().app_id;
         return util::format("%1/%2/%3/%4", m_file_path_root, app_id, ident, file_name);
     }
     std::string audit_path_root(std::shared_ptr<SyncUser> user, std::string_view app_id,
                                 std::string_view partition_prefix) const override
     {
-        auto ident = user->identity();
+        auto ident = user->user_id();
         return util::format("%1/%2/realm-audit/%3/%4", m_file_path_root, app_id, ident, partition_prefix);
     }
 
@@ -198,10 +198,10 @@ struct TestBackingStore final : public app::BackingStore {
     }
 
 private:
-    std::shared_ptr<SyncUser> get_user_for_identity(std::string_view identity) const noexcept REQUIRES(m_user_mutex)
+    std::shared_ptr<SyncUser> get_user_for_id(std::string_view identity) const noexcept REQUIRES(m_user_mutex)
     {
         auto is_active_user = [identity](auto& el) {
-            return el->identity() == identity;
+            return el->user_id() == identity;
         };
         auto it = std::find_if(m_users.begin(), m_users.end(), is_active_user);
         return it == m_users.end() ? nullptr : *it;
@@ -235,7 +235,7 @@ TEST_CASE("app: custom backing store without sync", "[app][backing store]") {
     auto user2 = log_in(app, creds);
     auto user3 = log_in(app, creds);
     CHECK(user3 == test_store->get_current_user());
-    CHECK(user1 == test_store->get_existing_logged_in_user(user1->identity()));
+    CHECK(user1 == test_store->get_existing_logged_in_user(user1->user_id()));
     REQUIRE(test_store->all_users().size() == 3);
     CHECK(test_store->all_users()[0] == user3);
     CHECK(test_store->all_users()[1] == user2);

--- a/test/object-store/sync/file.cpp
+++ b/test/object-store/sync/file.cpp
@@ -134,7 +134,7 @@ TEST_CASE("sync_file: URL manipulation APIs", "[sync][file]") {
 TEST_CASE("sync_file: SyncFileManager APIs", "[sync][file]") {
     TestSyncManager tsm;
 
-    const std::string identity = "abcdefghi";
+    const std::string user_id = "abcdefghi";
     const std::vector<std::string> legacy_identities = {"legacy1", "legacy2"};
     const auto& local_identity = legacy_identities[0];
     const std::string app_id = "test_app_id*$#@!%1";
@@ -148,22 +148,22 @@ TEST_CASE("sync_file: SyncFileManager APIs", "[sync][file]") {
 
     SECTION("Realm path APIs") {
         auto relative_path = "s_" + partition_str;
-        ExpectedRealmPaths expected_paths(manager_base_path.string(), app_id, identity, legacy_identities, partition);
+        ExpectedRealmPaths expected_paths(manager_base_path.string(), app_id, user_id, legacy_identities, partition);
 
         SECTION("getting a Realm path") {
-            auto actual = manager.realm_file_path(identity, legacy_identities, relative_path, partition);
+            auto actual = manager.realm_file_path(user_id, legacy_identities, relative_path, partition);
             REQUIRE(expected_paths.current_preferred_path == actual);
         }
 
         SECTION("deleting a Realm for a valid user") {
-            manager.realm_file_path(identity, legacy_identities, relative_path, partition);
+            manager.realm_file_path(user_id, legacy_identities, relative_path, partition);
             // Create the required files
             REQUIRE(create_dummy_realm(expected_paths.current_preferred_path));
             REQUIRE(File::exists(expected_paths.current_preferred_path));
             REQUIRE(File::exists(expected_paths.current_preferred_path + ".lock"));
             REQUIRE_DIR_EXISTS(expected_paths.current_preferred_path + ".management");
             // Delete the Realm
-            REQUIRE(manager.remove_realm(identity, legacy_identities, relative_path, partition));
+            REQUIRE(manager.remove_realm(user_id, legacy_identities, relative_path, partition));
             // Ensure the files don't exist anymore
             REQUIRE(!File::exists(expected_paths.current_preferred_path));
             REQUIRE(!File::exists(expected_paths.current_preferred_path + ".lock"));
@@ -182,11 +182,11 @@ TEST_CASE("sync_file: SyncFileManager APIs", "[sync][file]") {
             REQUIRE(create_dummy_realm(expected_paths.fallback_hashed_path));
             REQUIRE(File::exists(expected_paths.fallback_hashed_path));
             REQUIRE(!File::exists(expected_paths.current_preferred_path));
-            auto actual = manager.realm_file_path(identity, legacy_identities, relative_path, partition);
+            auto actual = manager.realm_file_path(user_id, legacy_identities, relative_path, partition);
             REQUIRE(actual == expected_paths.fallback_hashed_path);
             REQUIRE(File::exists(expected_paths.fallback_hashed_path));
             REQUIRE(!File::exists(expected_paths.current_preferred_path));
-            manager.remove_user_realms(identity, {expected_paths.fallback_hashed_path});
+            manager.remove_user_realms(user_id, {expected_paths.fallback_hashed_path});
             REQUIRE(!File::exists(expected_paths.fallback_hashed_path));
         }
 
@@ -199,11 +199,11 @@ TEST_CASE("sync_file: SyncFileManager APIs", "[sync][file]") {
             REQUIRE(File::exists(expected_paths.legacy_local_id_path));
             REQUIRE(!File::exists(expected_paths.current_preferred_path));
 
-            auto actual = manager.realm_file_path(identity, legacy_identities, relative_path, partition);
+            auto actual = manager.realm_file_path(user_id, legacy_identities, relative_path, partition);
             REQUIRE(actual == expected_paths.legacy_local_id_path);
             REQUIRE(File::exists(expected_paths.legacy_local_id_path));
             REQUIRE(!File::exists(expected_paths.current_preferred_path));
-            manager.remove_user_realms(identity, {expected_paths.legacy_local_id_path});
+            manager.remove_user_realms(user_id, {expected_paths.legacy_local_id_path});
             REQUIRE(!File::exists(expected_paths.legacy_local_id_path));
         }
 
@@ -212,7 +212,7 @@ TEST_CASE("sync_file: SyncFileManager APIs", "[sync][file]") {
             // a second one with only the second identity
             const std::vector<std::string> legacy_identities_2 = {"legacy2"};
             const auto& local_identity_2 = legacy_identities_2[0];
-            ExpectedRealmPaths expected_paths_2(manager_base_path.string(), app_id, identity, legacy_identities_2,
+            ExpectedRealmPaths expected_paths_2(manager_base_path.string(), app_id, user_id, legacy_identities_2,
                                                 partition);
 
             util::try_make_dir(manager_path.string());
@@ -221,11 +221,11 @@ TEST_CASE("sync_file: SyncFileManager APIs", "[sync][file]") {
 
             // Note: intentionally not legacy_identities_2. We're passing both
             // in and validating that it'll open the second one.
-            auto actual = manager.realm_file_path(identity, legacy_identities, relative_path, partition);
+            auto actual = manager.realm_file_path(user_id, legacy_identities, relative_path, partition);
             REQUIRE(actual == expected_paths_2.legacy_local_id_path);
             REQUIRE(File::exists(expected_paths_2.legacy_local_id_path));
             REQUIRE(!File::exists(expected_paths_2.current_preferred_path));
-            manager.remove_user_realms(identity, {expected_paths_2.legacy_local_id_path});
+            manager.remove_user_realms(user_id, {expected_paths_2.legacy_local_id_path});
             REQUIRE(!File::exists(expected_paths_2.legacy_local_id_path));
         }
 
@@ -238,22 +238,22 @@ TEST_CASE("sync_file: SyncFileManager APIs", "[sync][file]") {
             REQUIRE(create_dummy_realm(expected_paths.legacy_sync_path));
             REQUIRE(File::exists(expected_paths.legacy_sync_path));
             REQUIRE(!File::exists(expected_paths.current_preferred_path));
-            auto actual = manager.realm_file_path(identity, legacy_identities, relative_path, partition);
+            auto actual = manager.realm_file_path(user_id, legacy_identities, relative_path, partition);
             REQUIRE(actual == expected_paths.legacy_sync_path);
             REQUIRE(File::exists(expected_paths.legacy_sync_path));
             REQUIRE(!File::exists(expected_paths.current_preferred_path));
-            manager.remove_user_realms(identity, {expected_paths.legacy_sync_path});
+            manager.remove_user_realms(user_id, {expected_paths.legacy_sync_path});
             REQUIRE(!File::exists(expected_paths.legacy_sync_path));
         }
 
         SECTION("paths have a fallback hashed location if the preferred path is too long") {
             const std::string long_path_name = std::string(500, 'a');
             REQUIRE(long_path_name.length() > 255); // linux name length limit
-            auto actual = manager.realm_file_path(identity, legacy_identities, long_path_name, partition);
+            auto actual = manager.realm_file_path(user_id, legacy_identities, long_path_name, partition);
             REQUIRE(actual.length() < 500);
             REQUIRE(create_dummy_realm(actual));
             REQUIRE(File::exists(actual));
-            manager.remove_user_realms(identity, {actual});
+            manager.remove_user_realms(user_id, {actual});
             REQUIRE(!File::exists(actual));
         }
     }

--- a/test/object-store/sync/metadata.cpp
+++ b/test/object-store/sync/metadata.cpp
@@ -49,54 +49,54 @@ TEST_CASE("sync_metadata: user metadata", "[sync][metadata]") {
     SyncMetadataManager manager(metadata_path, false);
 
     SECTION("can be properly constructed") {
-        const auto identity = "testcase1a";
-        auto user_metadata = manager.get_or_make_user_metadata(identity);
-        REQUIRE(user_metadata->identity() == identity);
+        const auto user_id = "testcase1a";
+        auto user_metadata = manager.get_or_make_user_metadata(user_id);
+        REQUIRE(user_metadata->user_id() == user_id);
         REQUIRE(user_metadata->access_token().empty());
     }
 
     SECTION("properly reflects updating state") {
-        const auto identity = "testcase1b";
+        const auto user_id = "testcase1b";
         const std::string sample_token = "this_is_a_user_token";
-        auto user_metadata = manager.get_or_make_user_metadata(identity);
+        auto user_metadata = manager.get_or_make_user_metadata(user_id);
         user_metadata->set_access_token(sample_token);
-        REQUIRE(user_metadata->identity() == identity);
+        REQUIRE(user_metadata->user_id() == user_id);
         REQUIRE(user_metadata->access_token() == sample_token);
     }
 
     SECTION("can be properly re-retrieved from the same manager") {
-        const auto identity = "testcase1c";
+        const auto user_id = "testcase1c";
         const std::string sample_token = "this_is_a_user_token";
-        auto first = manager.get_or_make_user_metadata(identity);
+        auto first = manager.get_or_make_user_metadata(user_id);
         first->set_access_token(sample_token);
-        // Get a second instance of the user metadata for the same identity.
-        auto second = manager.get_or_make_user_metadata(identity, false);
-        REQUIRE(second->identity() == identity);
+        // Get a second instance of the user metadata for the same user_id.
+        auto second = manager.get_or_make_user_metadata(user_id, false);
+        REQUIRE(second->user_id() == user_id);
         REQUIRE(second->access_token() == sample_token);
     }
 
     SECTION("properly reflects changes across different instances") {
-        const auto identity = "testcase1d";
+        const auto user_id = "testcase1d";
         const std::string sample_token_1 = "this_is_a_user_token";
-        auto first = manager.get_or_make_user_metadata(identity);
-        auto second = manager.get_or_make_user_metadata(identity);
+        auto first = manager.get_or_make_user_metadata(user_id);
+        auto second = manager.get_or_make_user_metadata(user_id);
         first->set_access_token(sample_token_1);
-        REQUIRE(first->identity() == identity);
+        REQUIRE(first->user_id() == user_id);
         REQUIRE(first->access_token() == sample_token_1);
-        REQUIRE(second->identity() == identity);
+        REQUIRE(second->user_id() == user_id);
         REQUIRE(second->access_token() == sample_token_1);
         // Set the state again.
         const std::string sample_token_2 = "this_is_another_user_token";
         second->set_access_token(sample_token_2);
-        REQUIRE(first->identity() == identity);
+        REQUIRE(first->user_id() == user_id);
         REQUIRE(first->access_token() == sample_token_2);
-        REQUIRE(second->identity() == identity);
+        REQUIRE(second->user_id() == user_id);
         REQUIRE(second->access_token() == sample_token_2);
     }
 
     SECTION("can be removed") {
-        const auto identity = "testcase1e";
-        auto user_metadata = manager.get_or_make_user_metadata(identity);
+        const auto user_id = "testcase1e";
+        auto user_metadata = manager.get_or_make_user_metadata(user_id);
         REQUIRE(user_metadata->is_valid());
         user_metadata->remove();
         REQUIRE(!user_metadata->is_valid());
@@ -106,25 +106,25 @@ TEST_CASE("sync_metadata: user metadata", "[sync][metadata]") {
         const std::string sample_token = "this_is_a_user_token";
 
         SECTION("with no prior metadata for the identifier") {
-            const auto identity = "testcase1g1";
-            auto user_metadata = manager.get_or_make_user_metadata(identity, false);
+            const auto user_id = "testcase1g1";
+            auto user_metadata = manager.get_or_make_user_metadata(user_id, false);
             REQUIRE(!user_metadata);
         }
         SECTION("with valid prior metadata for the identifier") {
-            const auto identity = "testcase1g2";
-            auto first = manager.get_or_make_user_metadata(identity);
+            const auto user_id = "testcase1g2";
+            auto first = manager.get_or_make_user_metadata(user_id);
             first->set_access_token(sample_token);
-            auto second = manager.get_or_make_user_metadata(identity, false);
+            auto second = manager.get_or_make_user_metadata(user_id, false);
             REQUIRE(second->is_valid());
-            REQUIRE(second->identity() == identity);
+            REQUIRE(second->user_id() == user_id);
             REQUIRE(second->access_token() == sample_token);
         }
         SECTION("with invalid prior metadata for the identifier") {
-            const auto identity = "testcase1g3";
-            auto first = manager.get_or_make_user_metadata(identity);
+            const auto user_id = "testcase1g3";
+            auto first = manager.get_or_make_user_metadata(user_id);
             first->set_access_token(sample_token);
             first->set_state(SyncUser::State::Removed);
-            auto second = manager.get_or_make_user_metadata(identity, false);
+            auto second = manager.get_or_make_user_metadata(user_id, false);
             REQUIRE(!second);
         }
     }
@@ -140,25 +140,25 @@ TEST_CASE("sync_metadata: user metadata APIs", "[sync][metadata]") {
     const std::string provider_type = "https://realm.example.org";
 
     SECTION("properly list all marked and unmarked users") {
-        const auto identity1 = "testcase2a1";
-        const auto identity2 = "testcase2a3";
-        auto first = manager.get_or_make_user_metadata(identity1);
-        auto second = manager.get_or_make_user_metadata(identity1);
-        auto third = manager.get_or_make_user_metadata(identity2);
+        const auto user_id1 = "testcase2a1";
+        const auto user_id2 = "testcase2a3";
+        auto first = manager.get_or_make_user_metadata(user_id1);
+        auto second = manager.get_or_make_user_metadata(user_id1);
+        auto third = manager.get_or_make_user_metadata(user_id2);
         auto unmarked_users = manager.all_unmarked_users();
         REQUIRE(unmarked_users.size() == 2);
-        REQUIRE(results_contains_user(unmarked_users, identity1));
-        REQUIRE(results_contains_user(unmarked_users, identity2));
+        REQUIRE(results_contains_user(unmarked_users, user_id1));
+        REQUIRE(results_contains_user(unmarked_users, user_id2));
         auto marked_users = manager.all_users_marked_for_removal();
         REQUIRE(marked_users.size() == 0);
         // Now, mark a few users for removal.
         first->set_state(SyncUser::State::Removed);
         unmarked_users = manager.all_unmarked_users();
         REQUIRE(unmarked_users.size() == 1);
-        REQUIRE(results_contains_user(unmarked_users, identity2));
+        REQUIRE(results_contains_user(unmarked_users, user_id2));
         marked_users = manager.all_users_marked_for_removal();
         REQUIRE(marked_users.size() == 1);
-        REQUIRE(results_contains_user(marked_users, identity1));
+        REQUIRE(results_contains_user(marked_users, user_id1));
     }
 }
 
@@ -249,32 +249,32 @@ TEST_CASE("sync_metadata: results", "[sync][metadata]") {
     });
 
     SyncMetadataManager manager(metadata_path, false);
-    const auto identity1 = "testcase3a1";
-    const auto identity2 = "testcase3a3";
+    const auto user_id1 = "testcase3a1";
+    const auto user_id2 = "testcase3a3";
 
     SECTION("properly update as underlying items are added") {
         auto results = manager.all_unmarked_users();
         REQUIRE(results.size() == 0);
         // Add users, one at a time.
-        auto first = manager.get_or_make_user_metadata(identity1);
+        auto first = manager.get_or_make_user_metadata(user_id1);
         REQUIRE(results.size() == 1);
-        REQUIRE(results_contains_user(results, identity1));
-        auto second = manager.get_or_make_user_metadata(identity2);
+        REQUIRE(results_contains_user(results, user_id1));
+        auto second = manager.get_or_make_user_metadata(user_id2);
         REQUIRE(results.size() == 2);
-        REQUIRE(results_contains_user(results, identity2));
+        REQUIRE(results_contains_user(results, user_id2));
     }
 
     SECTION("properly update as underlying items are removed") {
         auto results = manager.all_unmarked_users();
-        auto first = manager.get_or_make_user_metadata(identity1);
-        auto second = manager.get_or_make_user_metadata(identity2);
+        auto first = manager.get_or_make_user_metadata(user_id1);
+        auto second = manager.get_or_make_user_metadata(user_id2);
         REQUIRE(results.size() == 2);
-        REQUIRE(results_contains_user(results, identity1));
-        REQUIRE(results_contains_user(results, identity2));
+        REQUIRE(results_contains_user(results, user_id1));
+        REQUIRE(results_contains_user(results, user_id2));
         // Remove users, one at a time.
         first->remove();
         REQUIRE(results.size() == 1);
-        REQUIRE(!results_contains_user(results, identity1));
+        REQUIRE(!results_contains_user(results, user_id1));
         second->remove();
         REQUIRE(results.size() == 0);
     }
@@ -287,20 +287,20 @@ TEST_CASE("sync_metadata: persistence across metadata manager instances", "[sync
     });
 
     SECTION("works for the basic case") {
-        const auto identity = "testcase4a";
+        const auto user_id = "testcase4a";
         const std::string provider_type = "any-type";
         const std::string sample_token = "this_is_a_user_token";
         SyncMetadataManager first_manager(metadata_path, false);
-        auto first = first_manager.get_or_make_user_metadata(identity);
+        auto first = first_manager.get_or_make_user_metadata(user_id);
         first->set_access_token(sample_token);
-        REQUIRE(first->identity() == identity);
+        REQUIRE(first->user_id() == user_id);
         REQUIRE(first->access_token() == sample_token);
         REQUIRE(first->state() == SyncUser::State::LoggedIn);
         first->set_state(SyncUser::State::LoggedOut);
 
         SyncMetadataManager second_manager(metadata_path, false);
-        auto second = second_manager.get_or_make_user_metadata(identity, false);
-        REQUIRE(second->identity() == identity);
+        auto second = second_manager.get_or_make_user_metadata(user_id, false);
+        REQUIRE(second->user_id() == user_id);
         REQUIRE(second->access_token() == sample_token);
         REQUIRE(second->state() == SyncUser::State::LoggedOut);
     }
@@ -312,7 +312,7 @@ TEST_CASE("sync_metadata: encryption", "[sync][metadata]") {
         util::try_remove_dir_recursive(base_path);
     });
 
-    const auto identity0 = "identity0";
+    const auto user_id0 = "user_id0";
     SECTION("prohibits opening the metadata Realm with different keys") {
         SECTION("different keys") {
             {
@@ -320,9 +320,9 @@ TEST_CASE("sync_metadata: encryption", "[sync][metadata]") {
                 std::vector<char> key0 = make_test_encryption_key(10);
                 SyncMetadataManager manager0(metadata_path, true, key0);
 
-                auto user_metadata0 = manager0.get_or_make_user_metadata(identity0);
+                auto user_metadata0 = manager0.get_or_make_user_metadata(user_id0);
                 REQUIRE(bool(user_metadata0));
-                CHECK(user_metadata0->identity() == identity0);
+                CHECK(user_metadata0->user_id() == user_id0);
                 CHECK(user_metadata0->access_token().empty());
                 CHECK(user_metadata0->is_valid());
             }
@@ -331,14 +331,14 @@ TEST_CASE("sync_metadata: encryption", "[sync][metadata]") {
             std::vector<char> key1 = make_test_encryption_key(11);
             SyncMetadataManager manager1(metadata_path, true, key1);
 
-            auto user_metadata1 = manager1.get_or_make_user_metadata(identity0, false);
+            auto user_metadata1 = manager1.get_or_make_user_metadata(user_id0, false);
             // Expect previous metadata to have been deleted
             CHECK_FALSE(bool(user_metadata1));
 
             // But new metadata can still be created
-            const auto identity1 = "identity1";
-            auto user_metadata2 = manager1.get_or_make_user_metadata(identity1);
-            CHECK(user_metadata2->identity() == identity1);
+            const auto user_id1 = "user_id1";
+            auto user_metadata2 = manager1.get_or_make_user_metadata(user_id1);
+            CHECK(user_metadata2->user_id() == user_id1);
             CHECK(user_metadata2->access_token().empty());
             CHECK(user_metadata2->is_valid());
         }
@@ -347,23 +347,23 @@ TEST_CASE("sync_metadata: encryption", "[sync][metadata]") {
                 // Encrypt metadata realm at path, make metadata
                 SyncMetadataManager manager0(metadata_path, true, make_test_encryption_key(10));
 
-                auto user_metadata0 = manager0.get_or_make_user_metadata(identity0);
+                auto user_metadata0 = manager0.get_or_make_user_metadata(user_id0);
                 REQUIRE(bool(user_metadata0));
-                CHECK(user_metadata0->identity() == identity0);
+                CHECK(user_metadata0->user_id() == user_id0);
                 CHECK(user_metadata0->access_token().empty());
                 CHECK(user_metadata0->is_valid());
             }
             // Metadata realm is closed because only reference to the realm (user_metadata) is now out of scope
             // Open new metadata realm at path with different encryption configuration
             SyncMetadataManager manager1(metadata_path, false);
-            auto user_metadata1 = manager1.get_or_make_user_metadata(identity0, false);
+            auto user_metadata1 = manager1.get_or_make_user_metadata(user_id0, false);
             // Expect previous metadata to have been deleted
             CHECK_FALSE(bool(user_metadata1));
 
             // But new metadata can still be created
-            const auto identity1 = "identity1";
-            auto user_metadata2 = manager1.get_or_make_user_metadata(identity1);
-            CHECK(user_metadata2->identity() == identity1);
+            const auto user_id1 = "user_id1";
+            auto user_metadata2 = manager1.get_or_make_user_metadata(user_id1);
+            CHECK(user_metadata2->user_id() == user_id1);
             CHECK(user_metadata2->access_token().empty());
             CHECK(user_metadata2->is_valid());
         }
@@ -371,18 +371,18 @@ TEST_CASE("sync_metadata: encryption", "[sync][metadata]") {
 
     SECTION("works when enabled") {
         std::vector<char> key = make_test_encryption_key(10);
-        const auto identity = "testcase5a";
+        const auto user_id = "testcase5a";
         SyncMetadataManager manager(metadata_path, true, key);
-        auto user_metadata = manager.get_or_make_user_metadata(identity);
+        auto user_metadata = manager.get_or_make_user_metadata(user_id);
         REQUIRE(bool(user_metadata));
-        CHECK(user_metadata->identity() == identity);
+        CHECK(user_metadata->user_id() == user_id);
         CHECK(user_metadata->access_token().empty());
         CHECK(user_metadata->is_valid());
         // Reopen the metadata file with the same key.
         SyncMetadataManager manager_2(metadata_path, true, key);
-        auto user_metadata_2 = manager_2.get_or_make_user_metadata(identity, false);
+        auto user_metadata_2 = manager_2.get_or_make_user_metadata(user_id, false);
         REQUIRE(bool(user_metadata_2));
-        CHECK(user_metadata_2->identity() == identity);
+        CHECK(user_metadata_2->user_id() == user_id);
         CHECK(user_metadata_2->is_valid());
     }
 
@@ -405,13 +405,13 @@ TEST_CASE("sync_metadata: encryption", "[sync][metadata]") {
         SECTION("automatically generates an encryption key for new files") {
             {
                 SyncMetadataManager manager(metadata_path, true, none);
-                manager.set_current_user_identity(identity0);
+                manager.set_current_user_id(user_id0);
             }
 
             // Should be able to reopen and read data
             {
                 SyncMetadataManager manager(metadata_path, true, none);
-                REQUIRE(manager.get_current_user_identity() == identity0);
+                REQUIRE(manager.get_current_user_id() == user_id0);
             }
 
             // Verify that the file is actually encrypted
@@ -422,11 +422,11 @@ TEST_CASE("sync_metadata: encryption", "[sync][metadata]") {
         SECTION("leaves existing unencrypted files unencrypted") {
             {
                 SyncMetadataManager manager(metadata_path, false, none);
-                manager.set_current_user_identity(identity0);
+                manager.set_current_user_id(user_id0);
             }
             {
                 SyncMetadataManager manager(metadata_path, true, none);
-                REQUIRE(manager.get_current_user_identity() == identity0);
+                REQUIRE(manager.get_current_user_id() == user_id0);
             }
             REQUIRE_NOTHROW(Group(metadata_path));
         }
@@ -434,7 +434,7 @@ TEST_CASE("sync_metadata: encryption", "[sync][metadata]") {
         SECTION("recreates the file if the old encryption key was lost") {
             {
                 SyncMetadataManager manager(metadata_path, true, none);
-                manager.set_current_user_identity(identity0);
+                manager.set_current_user_id(user_id0);
             }
 
             keychain::delete_metadata_realm_encryption_key();
@@ -442,7 +442,7 @@ TEST_CASE("sync_metadata: encryption", "[sync][metadata]") {
             {
                 // File should now be missing the data
                 SyncMetadataManager manager(metadata_path, true, none);
-                REQUIRE(manager.get_current_user_identity() == none);
+                REQUIRE(manager.get_current_user_id() == none);
             }
             // New file should be encrypted
             REQUIRE_EXCEPTION(Group(metadata_path), InvalidDatabase,
@@ -463,7 +463,7 @@ TEST_CASE("sync metadata: can open old metadata realms", "[sync][metadata]") {
     });
 
     const std::string provider_type = "https://realm.example.org";
-    const auto identity = "metadata migration test";
+    const auto user_id = "metadata migration test";
     const std::string sample_token = "metadata migration token";
 
     const auto access_token_1 = encode_fake_jwt("access token 1", 456, 123);
@@ -477,7 +477,7 @@ TEST_CASE("sync metadata: can open old metadata realms", "[sync][metadata]") {
 #if false   // The code to generate the v4 and v5 Realms
         { // Create a metadata Realm with a test user
             SyncMetadataManager manager(metadata_path, false);
-            auto user_metadata = manager.get_or_make_user_metadata(identity, provider_type);
+            auto user_metadata = manager.get_or_make_user_metadata(user_id, provider_type);
             user_metadata->set_access_token(sample_token);
         }
 #elif false // The code to generate the v6 Realm
@@ -536,7 +536,7 @@ TEST_CASE("sync metadata: can open old metadata realms", "[sync][metadata]") {
 #else
         { // Create a metadata Realm with a test user
             SyncMetadataManager manager(metadata_path, false);
-            auto user_metadata = manager.get_or_make_user_metadata(identity);
+            auto user_metadata = manager.get_or_make_user_metadata(user_id);
             user_metadata->set_access_token(sample_token);
         }
 #endif
@@ -568,16 +568,16 @@ TEST_CASE("sync metadata: can open old metadata realms", "[sync][metadata]") {
     SECTION("open schema version 4") {
         File::copy(test_util::get_test_resource_path() + "sync-metadata-v4.realm", metadata_path);
         SyncMetadataManager manager(metadata_path, false);
-        auto user_metadata = manager.get_or_make_user_metadata(identity);
-        REQUIRE(user_metadata->identity() == identity);
+        auto user_metadata = manager.get_or_make_user_metadata(user_id);
+        REQUIRE(user_metadata->user_id() == user_id);
         REQUIRE(user_metadata->access_token() == sample_token);
     }
 
     SECTION("open schema version 5") {
         File::copy(test_util::get_test_resource_path() + "sync-metadata-v5.realm", metadata_path);
         SyncMetadataManager manager(metadata_path, false);
-        auto user_metadata = manager.get_or_make_user_metadata(identity);
-        REQUIRE(user_metadata->identity() == identity);
+        auto user_metadata = manager.get_or_make_user_metadata(user_id);
+        REQUIRE(user_metadata->user_id() == user_id);
         REQUIRE(user_metadata->access_token() == sample_token);
     }
 

--- a/test/object-store/sync/user.cpp
+++ b/test/object-store/sync/user.cpp
@@ -35,15 +35,15 @@ static const std::string base_path = util::make_temp_dir() + "realm_objectstore_
 TEST_CASE("sync_user: SyncManager `get_user()` API", "[sync][user]") {
     TestSyncManager init_sync_manager;
     auto sync_manager = init_sync_manager.app()->backing_store();
-    const std::string identity = "sync_test_identity";
+    const std::string user_id = "sync_test_identity";
     const std::string refresh_token = ENCODE_FAKE_JWT("1234567890-fake-refresh-token");
     const std::string access_token = ENCODE_FAKE_JWT("1234567890-fake-access-token");
 
     SECTION("properly creates a new normal user") {
-        auto user = sync_manager->get_user(identity, refresh_token, access_token, dummy_device_id);
+        auto user = sync_manager->get_user(user_id, refresh_token, access_token, dummy_device_id);
         REQUIRE(user);
         // The expected state for a newly created user:
-        REQUIRE(user->identity() == identity);
+        REQUIRE(user->user_id() == user_id);
         REQUIRE(user->refresh_token() == refresh_token);
         REQUIRE(user->access_token() == access_token);
         REQUIRE(user->state() == SyncUser::State::LoggedIn);
@@ -53,14 +53,14 @@ TEST_CASE("sync_user: SyncManager `get_user()` API", "[sync][user]") {
         const std::string second_refresh_token = ENCODE_FAKE_JWT("0987654321-fake-refresh-token");
         const std::string second_access_token = ENCODE_FAKE_JWT("0987654321-fake-access-token");
 
-        auto first = sync_manager->get_user(identity, refresh_token, access_token, dummy_device_id);
+        auto first = sync_manager->get_user(user_id, refresh_token, access_token, dummy_device_id);
         REQUIRE(first);
-        REQUIRE(first->identity() == identity);
+        REQUIRE(first->user_id() == user_id);
         REQUIRE(first->refresh_token() == refresh_token);
         // Get the user again, but with a different token.
-        auto second = sync_manager->get_user(identity, second_refresh_token, second_access_token, dummy_device_id);
+        auto second = sync_manager->get_user(user_id, second_refresh_token, second_access_token, dummy_device_id);
         REQUIRE(second == first);
-        REQUIRE(second->identity() == identity);
+        REQUIRE(second->user_id() == user_id);
         REQUIRE(second->access_token() == second_access_token);
         REQUIRE(second->refresh_token() == second_refresh_token);
     }
@@ -69,14 +69,14 @@ TEST_CASE("sync_user: SyncManager `get_user()` API", "[sync][user]") {
         const std::string second_refresh_token = ENCODE_FAKE_JWT("0987654321-fake-refresh-token");
         const std::string second_access_token = ENCODE_FAKE_JWT("0987654321-fake-access-token");
 
-        auto first = sync_manager->get_user(identity, refresh_token, access_token, dummy_device_id);
-        REQUIRE(first->identity() == identity);
+        auto first = sync_manager->get_user(user_id, refresh_token, access_token, dummy_device_id);
+        REQUIRE(first->user_id() == user_id);
         first->log_out();
         REQUIRE(first->state() == SyncUser::State::LoggedOut);
         // Get the user again, with a new token.
-        auto second = sync_manager->get_user(identity, second_refresh_token, second_access_token, dummy_device_id);
+        auto second = sync_manager->get_user(user_id, second_refresh_token, second_access_token, dummy_device_id);
         REQUIRE(second == first);
-        REQUIRE(second->identity() == identity);
+        REQUIRE(second->user_id() == user_id);
         REQUIRE(second->refresh_token() == second_refresh_token);
         REQUIRE(second->state() == SyncUser::State::LoggedIn);
     }
@@ -85,13 +85,13 @@ TEST_CASE("sync_user: SyncManager `get_user()` API", "[sync][user]") {
 TEST_CASE("sync_user: update state and tokens", "[sync][user]") {
     TestSyncManager init_sync_manager;
     auto backing_store = init_sync_manager.app()->backing_store();
-    const std::string identity = "sync_test_identity";
+    const std::string user_id = "sync_test_identity";
     const std::string refresh_token = ENCODE_FAKE_JWT("fake-refresh-token-1");
     const std::string access_token = ENCODE_FAKE_JWT("fake-access-token-1");
     const std::string second_refresh_token = ENCODE_FAKE_JWT("fake-refresh-token-4");
     const std::string second_access_token = ENCODE_FAKE_JWT("fake-access-token-4");
 
-    auto user = backing_store->get_user(identity, refresh_token, access_token, dummy_device_id);
+    auto user = backing_store->get_user(user_id, refresh_token, access_token, dummy_device_id);
     REQUIRE(user->is_logged_in());
     REQUIRE(user->refresh_token() == refresh_token);
 
@@ -113,51 +113,51 @@ TEST_CASE("sync_user: update state and tokens", "[sync][user]") {
 TEST_CASE("sync_user: SyncManager get_existing_logged_in_user() API", "[sync][user]") {
     TestSyncManager init_sync_manager(SyncManager::MetadataMode::NoMetadata);
     auto backing_store = init_sync_manager.app()->backing_store();
-    const std::string identity = "sync_test_identity";
+    const std::string user_id = "sync_test_identity";
     const std::string refresh_token = ENCODE_FAKE_JWT("1234567890-fake-refresh-token");
     const std::string access_token = ENCODE_FAKE_JWT("1234567890-fake-access-token");
 
     SECTION("properly returns a null pointer when called for a non-existent user") {
-        std::shared_ptr<SyncUser> user = backing_store->get_existing_logged_in_user(identity);
+        std::shared_ptr<SyncUser> user = backing_store->get_existing_logged_in_user(user_id);
         REQUIRE(!user);
     }
 
     SECTION("can get logged-in user from notification") {
-        auto first = backing_store->get_user(identity, refresh_token, access_token, dummy_device_id);
-        REQUIRE(first->identity() == identity);
+        auto first = backing_store->get_user(user_id, refresh_token, access_token, dummy_device_id);
+        REQUIRE(first->user_id() == user_id);
         REQUIRE(first->state() == SyncUser::State::LoggedIn);
         REQUIRE(first->device_id() == dummy_device_id);
         bool notification_fired = false;
         auto sub_token = first->subscribe([&](const SyncUser& user) {
             auto current_user = backing_store->get_current_user();
-            REQUIRE(current_user->identity() == identity);
-            REQUIRE(current_user->identity() == user.identity());
+            REQUIRE(current_user->user_id() == user_id);
+            REQUIRE(current_user->user_id() == user.user_id());
             notification_fired = true;
         });
 
-        auto second = backing_store->get_user(identity, refresh_token, access_token, dummy_device_id);
+        auto second = backing_store->get_user(user_id, refresh_token, access_token, dummy_device_id);
         second->unsubscribe(sub_token);
         REQUIRE(notification_fired);
     }
 
     SECTION("properly returns an existing logged-in user") {
-        auto first = backing_store->get_user(identity, refresh_token, access_token, dummy_device_id);
-        REQUIRE(first->identity() == identity);
+        auto first = backing_store->get_user(user_id, refresh_token, access_token, dummy_device_id);
+        REQUIRE(first->user_id() == user_id);
         REQUIRE(first->state() == SyncUser::State::LoggedIn);
         REQUIRE(first->device_id() == dummy_device_id);
         // Get that user using the 'existing user' API.
-        auto second = backing_store->get_existing_logged_in_user(identity);
+        auto second = backing_store->get_existing_logged_in_user(user_id);
         REQUIRE(second == first);
         REQUIRE(second->refresh_token() == refresh_token);
     }
 
     SECTION("properly returns a null pointer for a logged-out user") {
-        auto first = backing_store->get_user(identity, refresh_token, access_token, dummy_device_id);
+        auto first = backing_store->get_user(user_id, refresh_token, access_token, dummy_device_id);
         first->log_out();
-        REQUIRE(first->identity() == identity);
+        REQUIRE(first->user_id() == user_id);
         REQUIRE(first->state() == SyncUser::State::LoggedOut);
         // Get that user using the 'existing user' API.
-        auto second = backing_store->get_existing_logged_in_user(identity);
+        auto second = backing_store->get_existing_logged_in_user(user_id);
         REQUIRE(!second);
     }
 }
@@ -165,12 +165,12 @@ TEST_CASE("sync_user: SyncManager get_existing_logged_in_user() API", "[sync][us
 TEST_CASE("sync_user: logout", "[sync][user]") {
     TestSyncManager init_sync_manager(SyncManager::MetadataMode::NoMetadata);
     auto backing_store = init_sync_manager.app()->backing_store();
-    const std::string identity = "sync_test_identity";
+    const std::string user_id = "sync_test_identity";
     const std::string refresh_token = ENCODE_FAKE_JWT("1234567890-fake-refresh-token");
     const std::string access_token = ENCODE_FAKE_JWT("1234567890-fake-access-token");
 
     SECTION("properly changes the state of the user object") {
-        auto user = backing_store->get_user(identity, refresh_token, access_token, dummy_device_id);
+        auto user = backing_store->get_user(user_id, refresh_token, access_token, dummy_device_id);
         REQUIRE(user->state() == SyncUser::State::LoggedIn);
         user->log_out();
         REQUIRE(user->state() == SyncUser::State::LoggedOut);
@@ -185,14 +185,14 @@ TEST_CASE("sync_user: user persistence", "[sync][user]") {
     SyncMetadataManager manager(file_manager.metadata_path(), false);
 
     SECTION("properly persists a user's information upon creation") {
-        const std::string identity = "test_identity_1";
+        const std::string user_id = "test_identity_1";
         const std::string refresh_token = ENCODE_FAKE_JWT("r-token-1");
         const std::string access_token = ENCODE_FAKE_JWT("a-token-1");
         const std::vector<SyncUserIdentity> identities{{"12345", "test_case_provider"}};
-        auto user = backing_store->get_user(identity, refresh_token, access_token, dummy_device_id);
+        auto user = backing_store->get_user(user_id, refresh_token, access_token, dummy_device_id);
         user->update_user_profile(identities, {});
         // Now try to pull the user out of the shadow manager directly.
-        auto metadata = manager.get_or_make_user_metadata(identity, false);
+        auto metadata = manager.get_or_make_user_metadata(user_id, false);
         REQUIRE((bool)metadata);
         REQUIRE(metadata->is_valid());
         REQUIRE(metadata->access_token() == access_token);
@@ -202,15 +202,15 @@ TEST_CASE("sync_user: user persistence", "[sync][user]") {
     }
 
     SECTION("properly removes a user's access/refresh token upon log out") {
-        const std::string identity = "test_identity_1";
+        const std::string user_id = "test_identity_1";
         const std::string refresh_token = ENCODE_FAKE_JWT("r-token-1");
         const std::string access_token = ENCODE_FAKE_JWT("a-token-1");
         const std::vector<SyncUserIdentity> identities{{"12345", "test_case_provider"}};
-        auto user = backing_store->get_user(identity, refresh_token, access_token, dummy_device_id);
+        auto user = backing_store->get_user(user_id, refresh_token, access_token, dummy_device_id);
         user->update_user_profile(identities, {});
         user->log_out();
         // Now try to pull the user out of the shadow manager directly.
-        auto metadata = manager.get_or_make_user_metadata(identity, false);
+        auto metadata = manager.get_or_make_user_metadata(user_id, false);
         REQUIRE((bool)metadata);
         REQUIRE(metadata->is_valid());
         REQUIRE(metadata->access_token() == "");
@@ -222,28 +222,28 @@ TEST_CASE("sync_user: user persistence", "[sync][user]") {
     }
 
     SECTION("properly persists a user's information when the user is updated") {
-        const std::string identity = "test_identity_2";
+        const std::string user_id = "test_identity_2";
         const std::string refresh_token = ENCODE_FAKE_JWT("r_token-2a");
         const std::string access_token = ENCODE_FAKE_JWT("a_token-1a");
         // Create the user and validate it.
-        auto first = backing_store->get_user(identity, refresh_token, access_token, dummy_device_id);
-        auto first_metadata = manager.get_or_make_user_metadata(identity, false);
+        auto first = backing_store->get_user(user_id, refresh_token, access_token, dummy_device_id);
+        auto first_metadata = manager.get_or_make_user_metadata(user_id, false);
         REQUIRE(first_metadata->is_valid());
         REQUIRE(first_metadata->access_token() == access_token);
         const std::string token_2 = ENCODE_FAKE_JWT("token-2b");
         // Update the user.
-        auto second = backing_store->get_user(identity, refresh_token, token_2, dummy_device_id);
-        auto second_metadata = manager.get_or_make_user_metadata(identity, false);
+        auto second = backing_store->get_user(user_id, refresh_token, token_2, dummy_device_id);
+        auto second_metadata = manager.get_or_make_user_metadata(user_id, false);
         REQUIRE(second_metadata->is_valid());
         REQUIRE(second_metadata->access_token() == token_2);
     }
 
     SECTION("properly does not mark a user when the user is logged out and not anon") {
-        const std::string identity = "test_identity_3";
+        const std::string user_id = "test_identity_3";
         const std::string refresh_token = ENCODE_FAKE_JWT("r-token-3");
         const std::string access_token = ENCODE_FAKE_JWT("a-token-3");
         // Create the user and validate it.
-        auto user = backing_store->get_user(identity, refresh_token, access_token, dummy_device_id);
+        auto user = backing_store->get_user(user_id, refresh_token, access_token, dummy_device_id);
         auto marked_users = manager.all_users_marked_for_removal();
         REQUIRE(marked_users.size() == 0);
         // Log out the user.
@@ -253,11 +253,11 @@ TEST_CASE("sync_user: user persistence", "[sync][user]") {
     }
 
     SECTION("properly removes a user when the user is logged out and is anon") {
-        const std::string identity = "test_identity_3";
+        const std::string user_id = "test_identity_3";
         const std::string refresh_token = ENCODE_FAKE_JWT("r-token-3");
         const std::string access_token = ENCODE_FAKE_JWT("a-token-3");
         // Create the user and validate it.
-        auto user = backing_store->get_user(identity, refresh_token, access_token, dummy_device_id);
+        auto user = backing_store->get_user(user_id, refresh_token, access_token, dummy_device_id);
         user->update_user_profile({{"id", app::IdentityProviderAnonymous}}, {});
         auto marked_users = manager.all_users_marked_for_removal();
         REQUIRE(marked_users.size() == 0);
@@ -267,32 +267,32 @@ TEST_CASE("sync_user: user persistence", "[sync][user]") {
     }
 
     SECTION("properly revives a logged-out user when it's requested again") {
-        const std::string identity = "test_identity_3";
+        const std::string user_id = "test_identity_3";
         const std::string refresh_token = ENCODE_FAKE_JWT("r-token-4a");
         const std::string access_token = ENCODE_FAKE_JWT("a-token-4a");
         // Create the user and log it out.
-        auto first = backing_store->get_user(identity, refresh_token, access_token, dummy_device_id);
+        auto first = backing_store->get_user(user_id, refresh_token, access_token, dummy_device_id);
         first->log_out();
         REQUIRE(backing_store->all_users().size() == 1);
         REQUIRE(backing_store->all_users()[0]->state() == SyncUser::State::LoggedOut);
         // Log the user back in.
         const std::string r_token_2 = ENCODE_FAKE_JWT("r-token-4b");
         const std::string a_token_2 = ENCODE_FAKE_JWT("atoken-4b");
-        auto second = backing_store->get_user(identity, r_token_2, a_token_2, dummy_device_id);
+        auto second = backing_store->get_user(user_id, r_token_2, a_token_2, dummy_device_id);
         REQUIRE(backing_store->all_users().size() == 1);
         REQUIRE(backing_store->all_users()[0]->state() == SyncUser::State::LoggedIn);
     }
 
     SECTION("properly deletes a user") {
-        const std::string identity = "test_identity_3";
+        const std::string user_id = "test_identity_3";
         const std::string refresh_token = ENCODE_FAKE_JWT("r-token-3");
         const std::string access_token = ENCODE_FAKE_JWT("a-token-3");
         // Create the user and validate it.
-        auto user = backing_store->get_user(identity, refresh_token, access_token, dummy_device_id);
-        backing_store->set_current_user(identity);
+        auto user = backing_store->get_user(user_id, refresh_token, access_token, dummy_device_id);
+        backing_store->set_current_user(user_id);
         REQUIRE(backing_store->get_current_user() == user);
         REQUIRE(backing_store->all_users().size() == 1);
-        backing_store->delete_user(user->identity());
+        backing_store->delete_user(user->user_id());
         REQUIRE(backing_store->all_users().size() == 0);
         REQUIRE(backing_store->get_current_user() == nullptr);
     }

--- a/test/object-store/util/sync/sync_test_utils.cpp
+++ b/test/object-store/util/sync/sync_test_utils.cpp
@@ -44,7 +44,7 @@ bool results_contains_user(SyncUserMetadataResults& results, const std::string& 
 {
     for (size_t i = 0; i < results.size(); i++) {
         auto this_result = results.get(i);
-        if (this_result.identity() == identity) {
+        if (this_result.user_id() == identity) {
             return true;
         }
     }


### PR DESCRIPTION
I dropped this from #6837 because it was sort of just unnecessary churn, but in the time since I've continued to find it confusing. SyncUser currently has both `identity()` and `identities()` which are two completely unrelated things: the first is the unique id for the user generated by the server, and the second is the set of credentials which have been used to log in the user. To fix this, I renamed `identity()` to `user_id()` and aligned all of the related functions to that name, making it so that the word "identity" is only used for the SyncUserIdentity concept.