### PR TITLE
[bindgen] util::Optional is preferred over std::optional

### DIFF
--- a/bindgen/spec.yml
+++ b/bindgen/spec.yml
@@ -1207,7 +1207,7 @@ classes:
       unsubscribe: '(token: AppSubscriptionToken)'
       call_function: '(user: const SharedSyncUser&, name: std::string, args: EJsonArray, service_name: util::Optional<std::string>, cb: AsyncCallback<(result: Nullable<const EJson*>, err: util::Optional<AppError>)>)'
       make_streaming_request: '(user: SharedSyncUser, name: std::string, args: bson::BsonArray, service_name: util::Optional<std::string>) -> Request'
-      update_base_url: '(base_url: std::optional<std::string>, cb: AsyncCallback<(err: util::Optional<AppError>)>&&)'
+      update_base_url: '(base_url: util::Optional<std::string>, cb: AsyncCallback<(err: util::Optional<AppError>)>&&)'
       get_base_url: '() const -> std::string'
 
   WatchStream:


### PR DESCRIPTION
## What, How & Why?

`util::Optional` is preferred over `std::optional` - see the "Template" section in `spec.yml`

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed
* [x] `bindgen/spec.yml`, if public C++ API changed
