### PR TITLE
Remove SyncUser::binding_context() and related things

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Internals
 * Refactored version resolution for the `build-apple-device.sh` script. ([#7263](https://github.com/realm/realm-core/pull/7263))
+* Remove SyncUser::binding_context() and related things, which were not actually used by any SDKs.
 
 ----------------------------------------------
 

--- a/src/realm/object-store/sync/sync_user.cpp
+++ b/src/realm/object-store/sync/sync_user.cpp
@@ -81,9 +81,6 @@ SyncUserIdentity::SyncUserIdentity(const std::string& id, const std::string& pro
 {
 }
 
-SyncUserContextFactory SyncUser::s_binding_context_factory;
-std::mutex SyncUser::s_binding_context_factory_mutex;
-
 SyncUser::SyncUser(Private, const std::string& refresh_token, const std::string& id, const std::string& access_token,
                    const std::string& device_id, SyncManager* sync_manager)
     : m_state(State::LoggedIn)
@@ -94,12 +91,6 @@ SyncUser::SyncUser(Private, const std::string& refresh_token, const std::string&
     , m_sync_manager(sync_manager)
 {
     REALM_ASSERT(!access_token.empty() && !refresh_token.empty());
-    {
-        std::lock_guard lock(s_binding_context_factory_mutex);
-        if (s_binding_context_factory) {
-            m_binding_context = s_binding_context_factory();
-        }
-    }
 
     m_sync_manager->perform_metadata_update([&](const auto& manager) NO_THREAD_SAFETY_ANALYSIS {
         auto metadata = manager.get_or_make_user_metadata(m_identity);
@@ -128,13 +119,6 @@ SyncUser::SyncUser(Private, const SyncUserMetadata& data, SyncManager* sync_mana
         m_state = State::LoggedOut;
         m_refresh_token = {};
         m_access_token = {};
-    }
-
-    {
-        std::lock_guard lock(s_binding_context_factory_mutex);
-        if (s_binding_context_factory) {
-            m_binding_context = s_binding_context_factory();
-        }
     }
 }
 
@@ -429,12 +413,6 @@ app::MongoClient SyncUser::mongo_client(const std::string& service_name)
     util::CheckedLockGuard lk(m_mutex);
     REALM_ASSERT(m_state == SyncUser::State::LoggedIn);
     return app::MongoClient(shared_from_this(), m_sync_manager->app().lock(), service_name);
-}
-
-void SyncUser::set_binding_context_factory(SyncUserContextFactory factory)
-{
-    std::lock_guard<std::mutex> lock(s_binding_context_factory_mutex);
-    s_binding_context_factory = std::move(factory);
 }
 
 void SyncUser::refresh_custom_data(util::UniqueFunction<void(util::Optional<app::AppError>)> completion_block)

--- a/src/realm/object-store/sync/sync_user.hpp
+++ b/src/realm/object-store/sync/sync_user.hpp
@@ -42,15 +42,6 @@ class SyncManager;
 class SyncSession;
 class SyncUserMetadata;
 
-// A superclass that bindings can inherit from in order to store information
-// upon a `SyncUser` object.
-class SyncUserContext {
-public:
-    virtual ~SyncUserContext() = default;
-};
-
-using SyncUserContextFactory = util::UniqueFunction<std::shared_ptr<SyncUserContext>()>;
-
 // A struct that decodes a given JWT.
 struct RealmJWT {
     // The token being decoded from.
@@ -220,14 +211,6 @@ public:
     // Custom user data embedded in the access token.
     util::Optional<bson::BsonDocument> custom_data() const REQUIRES(!m_tokens_mutex);
 
-    std::shared_ptr<SyncUserContext> binding_context() const
-    {
-        return m_binding_context.load();
-    }
-
-    // Optionally set a context factory. If so, must be set before any sessions are created.
-    static void set_binding_context_factory(SyncUserContextFactory factory);
-
     std::shared_ptr<SyncManager> sync_manager() const REQUIRES(!m_mutex);
 
     /// Retrieves a general-purpose service client for the Realm Cloud service
@@ -288,16 +271,11 @@ protected:
     void detach_from_sync_manager() REQUIRES(!m_mutex);
 
 private:
-    static SyncUserContextFactory s_binding_context_factory;
-    static std::mutex s_binding_context_factory_mutex;
-
     bool do_is_anonymous() const REQUIRES(m_mutex);
 
     std::vector<std::shared_ptr<SyncSession>> revive_sessions() REQUIRES(m_mutex);
 
     State m_state GUARDED_BY(m_mutex);
-
-    util::AtomicSharedPtr<SyncUserContext> m_binding_context;
 
     // UUIDs which used to be used to generate local Realm file paths. Now only
     // used to locate existing files.


### PR DESCRIPTION
Cocoa was the only SDK to use this and it turns out that it hasn't actually been doing anything since token refreshing was moved to object store in 2016, so https://github.com/realm/realm-swift/pull/8470 removes it.