### PR TITLE
Update server version on all entries in the sync history during client reset with recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,7 @@
 * None.
 
 ### Fixed
-* <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Uploading the changesets recovered during an automatic client reset recovery may lead to 'Bad server version' errors and a new client reset. ([#7279](https://github.com/realm/realm-core/issues/7279), since v13.24.1)
  
 ### Breaking changes
 * None.

--- a/test/object-store/sync/flx_sync.cpp
+++ b/test/object-store/sync/flx_sync.cpp
@@ -582,6 +582,7 @@ TEST_CASE("flx: client reset", "[sync][flx][client reset][baas]") {
     config_remote.path += ".remote";
     const std::string str_field_value = "foo";
     const int64_t local_added_int = 100;
+    const int64_t local_added_int2 = 150;
     const int64_t remote_added_int = 200;
     size_t before_reset_count = 0;
     size_t after_reset_count = 0;
@@ -741,6 +742,62 @@ TEST_CASE("flx: client reset", "[sync][flx][client reset][baas]") {
                 REQUIRE(tv.size() == 2);
                 CHECK(tv.get_object(0).get<Int>(int_col) == local_added_int);
                 CHECK(tv.get_object(1).get<Int>(int_col) == remote_added_int);
+            })
+            ->run();
+    }
+
+    SECTION("Recover: offline writes interleaved with subscriptions and empty writes") {
+        config_local.sync_config->client_resync_mode = ClientResyncMode::Recover;
+        auto&& [reset_future, reset_handler] = make_client_reset_handler();
+        config_local.sync_config->notify_after_client_reset = reset_handler;
+        auto test_reset = reset_utils::make_baas_flx_client_reset(config_local, config_remote, harness.session());
+        test_reset
+            ->make_local_changes([&](SharedRealm local_realm) {
+                // The sequence of events bellow generates five changesets:
+                //  1. create sub1 => empty changeset
+                //  2. create local_added_int object
+                //  3. create empty changeset
+                //  4. create sub2 => empty changeset
+                //  5. create local_added_int2 object
+                //
+                // Before sending 'sub2' to the server, an UPLOAD message is sent first.
+                // The upload message contains changeset 2. (local_added_int) with the cursor
+                // of changeset 3. (empty changeset).
+
+                add_subscription_for_new_object(local_realm, str_field_value, local_added_int);
+                // Commit empty changeset.
+                local_realm->begin_transaction();
+                local_realm->commit_transaction();
+                add_subscription_for_new_object(local_realm, str_field_value, local_added_int2);
+            })
+            ->make_remote_changes([&](SharedRealm remote_realm) {
+                add_subscription_for_new_object(remote_realm, str_field_value, remote_added_int);
+                sync::SubscriptionSet::State actual =
+                    remote_realm->get_latest_subscription_set()
+                        .get_state_change_notification(sync::SubscriptionSet::State::Complete)
+                        .get();
+                REQUIRE(actual == sync::SubscriptionSet::State::Complete);
+            })
+            ->on_post_reset([&, client_reset_future = std::move(reset_future)](SharedRealm local_realm) {
+                ClientResyncMode mode = client_reset_future.get();
+                REQUIRE(mode == ClientResyncMode::Recover);
+                auto subs = local_realm->get_latest_subscription_set();
+                subs.get_state_change_notification(sync::SubscriptionSet::State::Complete).get();
+                // make sure that the subscription for "foo" survived the reset
+                size_t count_of_foo = count_queries_with_str(subs, util::format("\"%1\"", str_field_value));
+                REQUIRE(subs.state() == sync::SubscriptionSet::State::Complete);
+                REQUIRE(count_of_foo == 1);
+                local_realm->refresh();
+                auto table = local_realm->read_group().get_table("class_TopLevel");
+                auto str_col = table->get_column_key("queryable_str_field");
+                auto int_col = table->get_column_key("queryable_int_field");
+                auto tv = table->where().equal(str_col, StringData(str_field_value)).find_all();
+                tv.sort(int_col);
+                // the objects we created while offline was recovered, and the remote object was downloaded
+                REQUIRE(tv.size() == 3);
+                CHECK(tv.get_object(0).get<Int>(int_col) == local_added_int);
+                CHECK(tv.get_object(1).get<Int>(int_col) == local_added_int2);
+                CHECK(tv.get_object(2).get<Int>(int_col) == remote_added_int);
             })
             ->run();
     }

--- a/test/object-store/sync/flx_sync.cpp
+++ b/test/object-store/sync/flx_sync.cpp
@@ -785,6 +785,7 @@ TEST_CASE("flx: client reset", "[sync][flx][client reset][baas]") {
                 subs.get_state_change_notification(sync::SubscriptionSet::State::Complete).get();
                 // make sure that the subscription for "foo" survived the reset
                 size_t count_of_foo = count_queries_with_str(subs, util::format("\"%1\"", str_field_value));
+                subs.refresh();
                 REQUIRE(subs.state() == sync::SubscriptionSet::State::Complete);
                 REQUIRE(count_of_foo == 1);
                 local_realm->refresh();


### PR DESCRIPTION
## What, How & Why?
When performing recovery after a client reset, the server version of the recovered changesets is updated with the latest server version. The changesets recovered are *only* the changesets with actual changes, but empty changesets may have been created when a new subscriptions set is committed for example. The server version of such changesets was not updated, leading to `Bad server version` errors during uploads.

The server version is now updated on all entries in the sync history.

Fixes #7279.

## ☑️ ToDos
* [x] 📝 Changelog update
* [X] 🚦 Tests (or not relevant)
* ~~[ ] C-API, if public C++ API changed~~
* ~~[ ] `bindgen/spec.yml`, if public C++ API changed~~
