### PR TITLE
[bindgen] `commander` dependency upgraded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 ### Compatibility
 * Fileformat: Generates files with format v23. Reads and automatically upgrade from fileformat v5.
 
+-----------
+
+### Internals
+* (bindgen) Upgrading `@commander-js/extra-typings` and adds a missing peer dependency on `commander`.
+
 ----------------------------------------------
 
 # 13.25.0 Release notes

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,13 +8,14 @@
       "name": "@realm/bindgen",
       "version": "0.1.0",
       "dependencies": {
-        "@commander-js/extra-typings": "^10.0.2",
+        "@commander-js/extra-typings": "^11.1.0",
         "@types/node": "^18.15.10",
         "ajv": "^8.11.0",
         "chalk": "^4.1.2",
         "change-case": "^4.1.2",
         "chevrotain": "^10.4.0",
         "clang-format": "^1.8.0",
+        "commander": "^11.1.0",
         "debug": "^4.3.4",
         "typescript-json-schema": "^0.55.0",
         "yaml": "^2.2.2"
@@ -76,11 +77,11 @@
       "integrity": "sha512-hBzuU5+JjB2cqNZyszkDHZgOSrUUT8V3dhgRl8Q9Gp6dAj/H5+KILGjbhDpc3Iy9qmqlm/akuOI2ut9VUtzJxQ=="
     },
     "node_modules/@commander-js/extra-typings": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/@commander-js/extra-typings/-/extra-typings-10.0.3.tgz",
-      "integrity": "sha512-OIw28QV/GlP8k0B5CJTRsl8IyNvd0R8C8rfo54Yz9P388vCNDgdNrFlKxZTGqps+5j6lSw3Ss9JTQwcur1w1oA==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@commander-js/extra-typings/-/extra-typings-11.1.0.tgz",
+      "integrity": "sha512-GuvZ38d23H+7Tz2C9DhzCepivsOsky03s5NI+KCy7ke1FNUvsJ2oO47scQ9YaGGhgjgNW5OYYNSADmbjcSoIhw==",
       "peerDependencies": {
-        "commander": "10.0.x"
+        "commander": "11.1.x"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -1432,12 +1433,11 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/commander": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
-      "peer": true,
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/concat-map": {

--- a/package.json
+++ b/package.json
@@ -16,13 +16,14 @@
     "lint": "eslint bindgen/src"
   },
   "dependencies": {
-    "@commander-js/extra-typings": "^10.0.2",
+    "@commander-js/extra-typings": "^11.1.0",
     "@types/node": "^18.15.10",
     "ajv": "^8.11.0",
     "chalk": "^4.1.2",
     "change-case": "^4.1.2",
     "chevrotain": "^10.4.0",
     "clang-format": "^1.8.0",
+    "commander": "^11.1.0",
     "debug": "^4.3.4",
     "typescript-json-schema": "^0.55.0",
     "yaml": "^2.2.2"


### PR DESCRIPTION
## What, How & Why?

This upgrades the dependency on `@commander-js/extra-typings` and adds a missing peer dependency on `commander`.

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed
* [ ] `bindgen/spec.yml`, if public C++ API changed
