### PR TITLE
Split the SyncManger into a BackingStore interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,4 @@ tsconfig.tsbuildinfo
 # Baas remote host artifacts
 baas-work-dir/
 ssh_agent_commands.sh
+baas/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,23 @@
 * None.
  
 ### Breaking changes
-* None.
+* Management of SyncUser state has been moved from SyncManager to a new `app::BackingStore` interface. This allows SDKs to bring their own persistence management which is a step towards enabling sync in web. Core can now be built for app services and without sync enabled which allows access to MongoDB features on restrictive platforms. In practice, SDKs should expect the following changes to adapt to this version:
+  - `app::App::get_app()` now requires a backing store factory, where SDKs can bring their own implementations of a `BackingStore` if they wish.
+  - If the previous behaviour is desired simply use the `RealmBackingStore` like this:
+    ```
+      SyncClientConfig sync_config; // set this as before
+      app::RealmBackingStoreConfig bsc;
+      bsc.base_file_path = my_path; // moved from SyncClientConfig::base_file_path
+      bsc.metadata_mode = my_mode;  // moved from SyncClientConfig::metadata_mode
+      auto factory = [bsc](app::SharedApp app) {
+        return std::make_shared<app::RealmBackingStore>(app, bsc);
+      };
+      auto my_app = app::App::get_app(app::App::CacheMode::Disabled, app_config, SyncClientConfig{}, factory);
+    ```
+  - A version of `App::get_app()` is provided that doesn't take a sync config for cases where only AppServices are required.
+  - `SyncUser::all_sessions()` is removed and replaced by `SyncManager::get_all_sessions_for(std::shared_ptr<SyncUser>)`
+  - `SyncUser::session_for_on_disk_path()` is removed and replaced by `SyncManager::get_existing_session()`
+  - Many methods from `SyncManager` have moved to the `BackingStore` interface which is accessible through `App::backing_store()`
 
 ### Compatibility
 * Fileformat: Generates files with format v23. Reads and automatically upgrade from fileformat v5.

--- a/bindgen/spec.yml
+++ b/bindgen/spec.yml
@@ -78,6 +78,7 @@ templates: # value tells you how many arguments it takes ('*' means any number)
   std::unordered_map: 2
   std::map: 2
   util::UniqueFunction: 1
+  util::FunctionRef: 1
   std::function: 1
   AsyncCallback: 1 # same as UniqueFunction, but guaranteed to be called exactly once.
                    # Recommended to convert to Future/Promise/Task in bound language.
@@ -221,7 +222,7 @@ enums:
       - FUNCTION
       - API_KEY
   MetadataMode:
-    cppName: SyncClientConfig::MetadataMode
+    cppName: app::RealmBackingStoreConfig::MetadataMode
     values:
       - NoEncryption
       - Encryption
@@ -537,6 +538,15 @@ records:
       before_notify: 'Nullable<util::UniqueFunction<(r: SharedRealm)>>'
       schema_did_change: 'Nullable<util::UniqueFunction<(r: SharedRealm)>>' # new schema available as r.schema
 
+  RealmBackingStoreConfig:
+    cppName: app::RealmBackingStoreConfig
+    fields:
+      base_file_path: std::string
+      metadata_mode:
+        type: MetadataMode
+        default: MetadataMode::Encryption
+      custom_encryption_key: util::Optional<EncryptionKey>
+
   SyncClientTimeouts:
     fields:
       connect_timeout:
@@ -557,11 +567,6 @@ records:
 
   SyncClientConfig:
     fields:
-      base_file_path: std::string
-      metadata_mode:
-        type: MetadataMode
-        default: MetadataMode::Encryption
-      custom_encryption_key: util::Optional<EncryptionKey>
       logger_factory: Nullable<LoggerFactory>
       log_level:
         type: LoggerLevel
@@ -651,6 +656,7 @@ opaqueTypes:
   - Schema
   - Group
   - AuditInterface
+  - SyncMetadataManager
 
 classes:
   #SchemaChange: {}
@@ -1170,6 +1176,42 @@ classes:
   AppSubscriptionToken:
     cppName: app::App::Token
 
+  AppMetadata:
+    cppName: SyncAppMetadata
+    properties:
+      deployment_model: std::string
+      location: std::string
+      hostname: std::string
+      ws_hostname: std::string
+
+  BackingStore:
+    cppName: app::BackingStore
+    sharedPtrWrapped: SharedBackingStore
+    methods:
+      get_user: '(user_id: std::string_view, refresh_token: std::string_view, access_token: std::string_view, device_id: std::string_view) -> SharedSyncUser'
+      get_existing_logged_in_user: '(user_id: std::string_view) -> SharedSyncUser'
+      all_users: '() -> std::vector<SharedSyncUser>'
+      get_current_user: '() -> SharedSyncUser'
+      log_out_user: '(user: SyncUser) -> void'
+      set_current_user: '(user_id: std::string_view) -> void'
+      remove_user: '(user_id: std::string_view) -> void'
+      delete_user: '(user_id: std::string_view) -> void'
+      reset_for_testing: '() -> void'
+      initialize: '(parent: std::weak_ptr<App>) -> void'
+      immediately_run_file_actions: '(original_name: std::string_view) -> bool'
+      perform_metadata_update: '(update_function: util::FunctionRef<void(SyncMetadataManager&)>) -> bool'
+      path_for_realm: '(user: SharedSyncUser, custom_file_name: std::optional<std::string>, partition_value: std::optional<std::string>) -> std::string'
+      audit_path_root: '(user: SharedSyncUser, app_id: std::string_view, partition_prefix: std::string_view) -> std::string'
+      recovery_directory_path: '(custom_dir_name: std::optional<std::string>) -> std::string'
+      app_metadata: '() -> std::optional<AppMetadata>'
+
+  RealmBackingStore:
+    cppName: app::RealmBackingStore
+    base: BackingStore
+    sharedPtrWrapped: SharedRealmBackingStore
+    properties:
+      config: const RealmBackingStoreConfig&
+
   App:
     cppName: app::App
     sharedPtrWrapped: SharedApp
@@ -1180,7 +1222,7 @@ classes:
       sync_manager: SharedSyncManager
       subscribers_count: count_t
     staticMethods:
-      get_app: '(mode: AppCacheMode, config: AppConfig, sync_client_config: SyncClientConfig) -> SharedApp'
+      get_app: '(mode: AppCacheMode, config: AppConfig, sync_client_config: SyncClientConfig, store_factory: util::FunctionRef<SharedBackingStore(SharedApp)>) -> SharedApp'
       get_cached_app: '(app_id: const std::string&) -> SharedApp'
       clear_cached_apps: ()
       close_all_sync_sessions: ()

--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -265,7 +265,7 @@ functions:
           if [[ -n "${run_with_encryption}" ]]; then
               export UNITTEST_ENCRYPT_ALL=1
           fi
-          export TSAN_OPTIONS="suppressions=$(pwd)/test/tsan.suppress history_size=4"
+          export TSAN_OPTIONS="suppressions=$(pwd)/test/tsan.suppress history_size=4 second_deadlock_stack=1"
           export UBSAN_OPTIONS="print_stacktrace=1"
 
           cd build

--- a/src/realm/object-store/CMakeLists.txt
+++ b/src/realm/object-store/CMakeLists.txt
@@ -92,41 +92,46 @@ set(HEADERS
 if(REALM_ENABLE_SYNC)
     list(APPEND HEADERS
         sync/app.hpp
+        sync/app_backing_store.hpp
         sync/app_utils.hpp
         sync/app_credentials.hpp
-        sync/generic_network_transport.hpp
         sync/async_open_task.hpp
-        sync/sync_manager.hpp
-        sync/sync_session.hpp
-        sync/sync_user.hpp
         sync/app_service_client.hpp
         sync/auth_request_client.hpp
+        sync/generic_network_transport.hpp
+        sync/impl/sync_client.hpp
+        sync/impl/sync_file.hpp
+        sync/impl/sync_metadata.hpp
+        sync/impl/network_reachability.hpp
         sync/mongo_client.hpp
         sync/mongo_collection.hpp
         sync/mongo_database.hpp
         sync/push_client.hpp
+        sync/realm_backing_store.hpp
         sync/subscribable.hpp
-
-        sync/impl/sync_client.hpp
-        sync/impl/sync_file.hpp
-        sync/impl/sync_metadata.hpp
-        sync/impl/network_reachability.hpp)
+        sync/sync_manager.hpp
+        sync/sync_session.hpp
+        sync/sync_user.hpp
+    )
 
     list(APPEND SOURCES
         sync/app.cpp
         sync/app_utils.cpp
         sync/app_credentials.cpp
-        sync/generic_network_transport.cpp
         sync/async_open_task.cpp
-        sync/sync_manager.cpp
-        sync/sync_session.cpp
-        sync/sync_user.cpp
+        sync/generic_network_transport.cpp
+        sync/impl/sync_file.cpp
+        sync/impl/sync_metadata.cpp
         sync/mongo_client.cpp
         sync/mongo_collection.cpp
         sync/mongo_database.cpp
         sync/push_client.cpp
-        sync/impl/sync_file.cpp
-        sync/impl/sync_metadata.cpp)
+        sync/realm_backing_store.cpp
+        sync/sync_manager.cpp
+        sync/sync_session.cpp
+        sync/sync_user.cpp
+    )
+
     if(APPLE)
         list(APPEND HEADERS
             sync/impl/apple/network_reachability_observer.hpp

--- a/src/realm/object-store/audit.mm
+++ b/src/realm/object-store/audit.mm
@@ -683,7 +683,7 @@ std::shared_ptr<AuditRealmPool> AuditRealmPool::get_pool(std::shared_ptr<SyncUse
                                  }),
                   s_pools.end());
 
-    auto app_id = user->sync_manager()->app().lock()->config().app_id;
+    auto app_id = user->app().lock()->config().app_id;
     auto it = std::find_if(s_pools.begin(), s_pools.end(), [&](auto& pool) {
         return pool.user_identity == user->identity() && pool.partition_prefix == partition_prefix &&
                pool.app_id == app_id;
@@ -707,15 +707,7 @@ AuditRealmPool::AuditRealmPool(Private, std::shared_ptr<SyncUser> user, std::str
     , m_partition_prefix(partition_prefix)
     , m_error_handler(error_handler)
     , m_path_root([&] {
-        auto base_file_path = m_user->sync_manager()->config().base_file_path;
-#ifdef _WIN32 // Move to File?
-        const char separator[] = "\\";
-#else
-        const char separator[] = "/";
-#endif
-        // "$root/realm-audit/$appId/$userId/$partitonPrefix/"
-        return util::format("%2%1realm-audit%1%3%1%4%1%5%1", separator, base_file_path, app_id, m_user->identity(),
-                            partition_prefix);
+        return m_user->app().lock()->backing_store()->audit_path_root(m_user, app_id, partition_prefix);
     }())
     , m_logger(logger)
 {
@@ -845,7 +837,7 @@ void AuditRealmPool::scan_for_realms_to_upload()
         RealmConfig config;
         config.path = db->get_path();
         config.sync_config = std::make_shared<SyncConfig>(m_user, prefixed_partition(partition));
-        wait_for_upload(m_user->sync_manager()->get_session(db, config));
+        wait_for_upload(m_user->app().lock()->sync_manager()->get_session(db, config));
         return;
     }
 
@@ -1012,7 +1004,7 @@ AuditContext::AuditContext(std::shared_ptr<DB> source_db, RealmConfig const& par
     }
 
     if (!m_logger)
-        m_logger = audit_user->sync_manager()->get_logger();
+        m_logger = audit_user->app().lock()->sync_manager()->get_logger();
     if (!m_serializer)
         m_serializer = std::make_shared<AuditObjectSerializer>();
 

--- a/src/realm/object-store/c_api/app.cpp
+++ b/src/realm/object-store/c_api/app.cpp
@@ -245,19 +245,24 @@ RLM_API const char* realm_app_credentials_serialize_as_json(realm_app_credential
     });
 }
 
-RLM_API realm_app_t* realm_app_create(const realm_app_config_t* app_config,
-                                      const realm_sync_client_config_t* sync_client_config)
+RLM_API realm_backing_store_t* realm_backing_store_create(const realm_app_t* app,
+                                                          const realm_backing_store_config_t* config)
 {
     return wrap_err([&] {
-        return new realm_app_t(App::get_app(app::App::CacheMode::Disabled, *app_config, *sync_client_config));
+        return new realm_backing_store_t(std::make_shared<app::RealmBackingStore>(*app, *config));
     });
 }
 
-RLM_API realm_app_t* realm_app_create_cached(const realm_app_config_t* app_config,
-                                             const realm_sync_client_config_t* sync_client_config)
+RLM_API realm_app_t* realm_app_create(realm_app_cache_mode_e mode, const realm_app_config_t* app_config,
+                                      const realm_sync_client_config_t* sync_client_config,
+                                      realm_backing_store_factory_func_t store_factory, realm_userdata_t user_data)
 {
+    auto factory = [&store_factory, &user_data](SharedApp app) {
+        realm_app_t app_t(app);
+        return *store_factory(user_data, &app_t);
+    };
     return wrap_err([&] {
-        return new realm_app_t(App::get_app(app::App::CacheMode::Enabled, *app_config, *sync_client_config));
+        return new realm_app_t(App::get_app(app::App::CacheMode(mode), *app_config, *sync_client_config, factory));
     });
 }
 
@@ -650,9 +655,12 @@ RLM_API char* realm_app_sync_client_get_default_file_path_for_realm(const realm_
                                                                     const char* custom_filename)
 {
     return wrap_err([&]() {
-        util::Optional<std::string> filename =
-            custom_filename ? util::some<std::string>(custom_filename) : util::none;
-        std::string file_path = config->user->sync_manager()->path_for_realm(*config, std::move(filename));
+        std::optional<std::string> filename = custom_filename ? util::some<std::string>(custom_filename) : util::none;
+        std::optional<std::string> partition =
+            config->flx_sync_requested ? none : std::make_optional(config->partition_value);
+
+        std::string file_path =
+            config->user->app().lock()->backing_store()->path_for_realm(config->user, std::move(filename), partition);
         return duplicate_string(file_path);
     });
 }
@@ -741,7 +749,7 @@ RLM_API realm_app_t* realm_user_get_app(const realm_user_t* user) noexcept
 {
     REALM_ASSERT(user);
     try {
-        if (auto shared_app = (*user)->sync_manager()->app().lock()) {
+        if (auto shared_app = (*user)->app().lock()) {
             return new realm_app_t(shared_app);
         }
     }

--- a/src/realm/object-store/c_api/sync.cpp
+++ b/src/realm/object-store/c_api/sync.cpp
@@ -42,12 +42,15 @@ realm_sync_session_connection_state_notification_token::~realm_sync_session_conn
 
 namespace realm::c_api {
 
-static_assert(realm_sync_client_metadata_mode_e(SyncClientConfig::MetadataMode::NoEncryption) ==
-              RLM_SYNC_CLIENT_METADATA_MODE_PLAINTEXT);
-static_assert(realm_sync_client_metadata_mode_e(SyncClientConfig::MetadataMode::Encryption) ==
-              RLM_SYNC_CLIENT_METADATA_MODE_ENCRYPTED);
-static_assert(realm_sync_client_metadata_mode_e(SyncClientConfig::MetadataMode::NoMetadata) ==
-              RLM_SYNC_CLIENT_METADATA_MODE_DISABLED);
+static_assert(realm_backing_store_metadata_mode_e(app::RealmBackingStoreConfig::MetadataMode::NoEncryption) ==
+              RLM_BACKING_STORE_METADATA_MODE_PLAINTEXT);
+static_assert(realm_backing_store_metadata_mode_e(app::RealmBackingStoreConfig::MetadataMode::Encryption) ==
+              RLM_BACKING_STORE_METADATA_MODE_ENCRYPTED);
+static_assert(realm_backing_store_metadata_mode_e(app::RealmBackingStoreConfig::MetadataMode::NoMetadata) ==
+              RLM_BACKING_STORE_METADATA_MODE_DISABLED);
+
+static_assert(realm_app_cache_mode_e(app::App::CacheMode::Enabled) == RLM_APP_CACHE_MODE_ENABLED);
+static_assert(realm_app_cache_mode_e(app::App::CacheMode::Disabled) == RLM_APP_CACHE_MODE_DISABLED);
 
 static_assert(realm_sync_client_reconnect_mode_e(ReconnectMode::normal) == RLM_SYNC_CLIENT_RECONNECT_MODE_NORMAL);
 static_assert(realm_sync_client_reconnect_mode_e(ReconnectMode::testing) == RLM_SYNC_CLIENT_RECONNECT_MODE_TESTING);
@@ -131,27 +134,32 @@ static Query add_ordering_to_realm_query(Query realm_query, const DescriptorOrde
     return realm_query;
 }
 
-RLM_API realm_sync_client_config_t* realm_sync_client_config_new(void) noexcept
+RLM_API realm_backing_store_config_t* realm_backing_store_config_new(void) noexcept
 {
-    return new realm_sync_client_config_t;
+    return new realm_backing_store_config_t;
 }
 
-RLM_API void realm_sync_client_config_set_base_file_path(realm_sync_client_config_t* config,
-                                                         const char* path) noexcept
+RLM_API void realm_backing_store_config_set_base_file_path(realm_backing_store_config_t* config,
+                                                           const char* path) noexcept
 {
     config->base_file_path = path;
 }
 
-RLM_API void realm_sync_client_config_set_metadata_mode(realm_sync_client_config_t* config,
-                                                        realm_sync_client_metadata_mode_e mode) noexcept
+RLM_API void realm_backing_store_config_set_metadata_mode(realm_backing_store_config_t* config,
+                                                          realm_backing_store_metadata_mode_e mode) noexcept
 {
-    config->metadata_mode = SyncClientConfig::MetadataMode(mode);
+    config->metadata_mode = app::RealmBackingStoreConfig::MetadataMode(mode);
 }
 
-RLM_API void realm_sync_client_config_set_metadata_encryption_key(realm_sync_client_config_t* config,
-                                                                  const uint8_t key[64]) noexcept
+RLM_API void realm_backing_store_config_set_metadata_encryption_key(realm_backing_store_config_t* config,
+                                                                    const uint8_t key[64]) noexcept
 {
     config->custom_encryption_key = std::vector<char>(key, key + 64);
+}
+
+RLM_API realm_sync_client_config_t* realm_sync_client_config_new(void) noexcept
+{
+    return new realm_sync_client_config_t;
 }
 
 RLM_API void realm_sync_client_config_set_reconnect_mode(realm_sync_client_config_t* config,
@@ -763,7 +771,7 @@ RLM_API bool realm_sync_immediately_run_file_actions(realm_app_t* realm_app, con
                                                      bool* did_run) noexcept
 {
     return wrap_err([&]() {
-        *did_run = (*realm_app)->sync_manager()->immediately_run_file_actions(sync_path);
+        *did_run = (*realm_app)->backing_store()->immediately_run_file_actions(sync_path);
         return true;
     });
 }

--- a/src/realm/object-store/c_api/types.hpp
+++ b/src/realm/object-store/c_api/types.hpp
@@ -620,6 +620,30 @@ struct realm_sync_client_config : realm::c_api::WrapC, realm::SyncClientConfig {
     using SyncClientConfig::SyncClientConfig;
 };
 
+struct realm_backing_store_config : realm::c_api::WrapC, realm::app::RealmBackingStoreConfig {
+    using RealmBackingStoreConfig::RealmBackingStoreConfig;
+};
+
+struct realm_backing_store : realm::c_api::WrapC, std::shared_ptr<realm::app::RealmBackingStore> {
+    realm_backing_store(std::shared_ptr<realm::app::RealmBackingStore> store)
+        : std::shared_ptr<realm::app::RealmBackingStore>{std::move(store)}
+    {
+    }
+
+    realm_backing_store* clone() const override
+    {
+        return new realm_backing_store{*this};
+    }
+
+    bool equals(const WrapC& other) const noexcept final
+    {
+        if (auto ptr = dynamic_cast<const realm_backing_store*>(&other)) {
+            return get() == ptr->get();
+        }
+        return false;
+    }
+};
+
 struct realm_sync_config : realm::c_api::WrapC, realm::SyncConfig {
     using SyncConfig::SyncConfig;
     realm_sync_config(const SyncConfig& c)

--- a/src/realm/object-store/impl/realm_coordinator.cpp
+++ b/src/realm/object-store/impl/realm_coordinator.cpp
@@ -436,7 +436,9 @@ bool RealmCoordinator::open_db()
         // If we previously opened this Realm, we may have a lingering sync
         // session which outlived its RealmCoordinator. If that happens we
         // want to reuse it instead of creating a new DB.
-        m_sync_session = m_config.sync_config->user->sync_manager()->get_existing_session(m_config.path);
+        if (auto app = m_config.sync_config->user->app().lock()) {
+            m_sync_session = app->sync_manager()->get_existing_session(m_config.path);
+        }
         if (m_sync_session) {
             m_db = SyncSession::Internal::get_db(*m_sync_session);
             init_external_helpers();
@@ -538,8 +540,15 @@ void RealmCoordinator::init_external_helpers()
 #if REALM_ENABLE_SYNC
     // We may have reused an existing sync session that outlived its original
     // RealmCoordinator. If not, we need to create a new one now.
-    if (m_config.sync_config && !m_sync_session)
-        m_sync_session = m_config.sync_config->user->sync_manager()->get_session(m_db, m_config);
+    if (m_config.sync_config && !m_sync_session) {
+        if (auto app = m_config.sync_config->user->app().lock()) {
+            m_sync_session = app->sync_manager()->get_session(m_db, m_config);
+        }
+        else {
+            throw LogicError(ErrorCodes::ClientAppDeallocated,
+                             "Cannot start a sync session for a user which has outlived its backing App.");
+        }
+    }
 #endif
 
     if (!m_notifier && !m_config.immutable() && m_config.automatic_change_notifications) {

--- a/src/realm/object-store/sync/app_backing_store.hpp
+++ b/src/realm/object-store/sync/app_backing_store.hpp
@@ -1,0 +1,131 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2023 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#ifndef REALM_OS_APP_BACKING_STORE_HPP
+#define REALM_OS_APP_BACKING_STORE_HPP
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <realm/object-store/sync/sync_user.hpp>
+#include <realm/util/function_ref.hpp>
+
+namespace realm {
+
+class SyncAppMetadata;
+class SyncMetadataManager;
+class SyncUser;
+
+namespace app {
+
+class App;
+
+class BackingStore {
+public:
+    BackingStore(std::weak_ptr<app::App> parent)
+        : m_parent_app(parent)
+    {
+    }
+    // Get a sync user for a given identity, or create one if none exists yet, and set its token.
+    // If a logged-out user exists, it will marked as logged back in.
+    virtual std::shared_ptr<SyncUser> get_user(std::string_view user_id, std::string_view refresh_token,
+                                               std::string_view access_token, std::string_view device_id) = 0;
+
+    // Get an existing user for a given identifier, if one exists and is logged in.
+    virtual std::shared_ptr<SyncUser> get_existing_logged_in_user(std::string_view user_id) const = 0;
+
+    // Get all the users that are logged in and not errored out.
+    virtual std::vector<std::shared_ptr<SyncUser>> all_users() = 0;
+
+    // Gets the currently active user.
+    virtual std::shared_ptr<SyncUser> get_current_user() const = 0;
+
+    // Log out a given user
+    virtual void log_out_user(const SyncUser& user) = 0;
+
+    // Sets the currently active user.
+    virtual void set_current_user(std::string_view user_id) = 0;
+
+    // Removes a user
+    virtual void remove_user(std::string_view user_id) = 0;
+
+    // Permanently deletes a user.
+    virtual void delete_user(std::string_view user_id) = 0;
+
+    // Destroy all users persisted state and mark oustanding User instances as Removed
+    // clean up persisted state.
+    virtual void reset_for_testing() = 0;
+
+    // FIXME: this is an implementation detail leak and doesn't belong in this API
+    // FIXME: consider abstracting it to something called `on_manual_client_reset()`
+    // Immediately run file actions for a single Realm at a given original path.
+    // Returns whether or not a file action was successfully executed for the specified Realm.
+    // Preconditions: all references to the Realm at the given path must have already been invalidated.
+    // The metadata and file management subsystems must also have already been configured.
+    virtual bool immediately_run_file_actions(std::string_view original_name) = 0;
+
+    // If the metadata manager is configured, perform an update. Returns `true` if the code was run.
+    virtual bool perform_metadata_update(util::FunctionRef<void(SyncMetadataManager&)> update_function) const = 0;
+
+    // Get the default path for a Realm for the given SyncUser.
+    // The default value is `<rootDir>/<appId>/<userId>/<partitionValue>.realm`.
+    // If the file cannot be created at this location, for example due to path length restrictions,
+    // this function may pass back `<rootDir>/<hashedFileName>.realm`
+    // The `user` is required.
+    // If partition_value is empty, FLX sync is requested
+    // otherwise this is for a PBS Realm and the string
+    // is a BSON formatted value.
+    virtual std::string path_for_realm(std::shared_ptr<SyncUser> user,
+                                       std::optional<std::string> custom_file_name = std::nullopt,
+                                       std::optional<std::string> partition_value = std::nullopt) const = 0;
+
+    // Get the base path where audit Realms will be stored. This path may need to be created.
+    virtual std::string audit_path_root(std::shared_ptr<SyncUser> user, std::string_view app_id,
+                                        std::string_view partition_prefix) const = 0;
+
+    // Get the path of the recovery directory for backed-up or recovered Realms.
+    virtual std::string
+    recovery_directory_path(std::optional<std::string> const& custom_dir_name = std::nullopt) const = 0;
+
+    // Get the app metadata for the active app.
+    virtual std::optional<SyncAppMetadata> app_metadata() const = 0;
+
+protected:
+    // these methods allow only derived backing stores to construct SyncUsers
+    // because SyncUser has a private constructor but BackingStore is a friend class
+    std::shared_ptr<SyncUser> make_user(std::string_view refresh_token, std::string_view id,
+                                        std::string_view access_token, std::string_view device_id,
+                                        std::shared_ptr<app::App> app) const
+    {
+        return std::make_shared<SyncUser>(SyncUser::Private{}, refresh_token, id, access_token, device_id,
+                                          std::move(app));
+    }
+    std::shared_ptr<SyncUser> make_user(const SyncUserMetadata& data, std::shared_ptr<app::App> app) const
+    {
+        return std::make_shared<SyncUser>(SyncUser::Private{}, data, std::move(app));
+    }
+
+    std::weak_ptr<app::App> m_parent_app;
+};
+
+} // namespace app
+} // namespace realm
+
+#endif // REALM_OS_APP_BACKING_STORE_HPP

--- a/src/realm/object-store/sync/impl/sync_metadata.cpp
+++ b/src/realm/object-store/sync/impl/sync_metadata.cpp
@@ -304,7 +304,7 @@ SyncFileActionMetadataResults SyncMetadataManager::all_pending_actions() const
     return SyncFileActionMetadataResults(Results(realm, table), m_file_action_schema);
 }
 
-void SyncMetadataManager::set_current_user_identity(const std::string& identity)
+void SyncMetadataManager::set_current_user_identity(std::string_view identity)
 {
     auto realm = get_realm();
 
@@ -324,7 +324,7 @@ void SyncMetadataManager::set_current_user_identity(const std::string& identity)
     realm->commit_transaction();
 }
 
-util::Optional<SyncUserMetadata> SyncMetadataManager::get_or_make_user_metadata(const std::string& identity,
+util::Optional<SyncUserMetadata> SyncMetadataManager::get_or_make_user_metadata(std::string_view identity,
                                                                                 bool make_if_absent) const
 {
     auto realm = get_realm();
@@ -358,9 +358,9 @@ util::Optional<SyncUserMetadata> SyncMetadataManager::get_or_make_user_metadata(
 
         obj = table->create_object();
 
-        currentUserIdentityObj.set<String>(c_sync_current_user_identity, identity);
+        currentUserIdentityObj.set<String>(c_sync_current_user_identity, StringData(identity));
 
-        obj->set(schema.identity_col, identity);
+        obj->set(schema.identity_col, StringData(identity));
         obj->set(schema.state_col, (int64_t)SyncUser::State::LoggedIn);
         realm->commit_transaction();
         return SyncUserMetadata(schema, std::move(realm), *obj);
@@ -629,14 +629,14 @@ SyncUserProfile SyncUserMetadata::profile() const
     return SyncUserProfile(static_cast<bson::BsonDocument>(bson::parse(std::string_view(result))));
 }
 
-void SyncUserMetadata::set_refresh_token(const std::string& refresh_token)
+void SyncUserMetadata::set_refresh_token(std::string_view refresh_token)
 {
     if (m_invalid)
         return;
 
     REALM_ASSERT_DEBUG(m_realm);
     m_realm->begin_transaction();
-    m_obj.set<String>(m_schema.refresh_token_col, refresh_token);
+    m_obj.set<String>(m_schema.refresh_token_col, StringData(refresh_token));
     m_realm->commit_transaction();
 }
 
@@ -651,8 +651,8 @@ void SyncUserMetadata::set_state(SyncUser::State state)
     m_realm->commit_transaction();
 }
 
-void SyncUserMetadata::set_state_and_tokens(SyncUser::State state, const std::string& access_token,
-                                            const std::string& refresh_token)
+void SyncUserMetadata::set_state_and_tokens(SyncUser::State state, std::string_view access_token,
+                                            std::string_view refresh_token)
 {
     if (m_invalid)
         return;
@@ -660,8 +660,8 @@ void SyncUserMetadata::set_state_and_tokens(SyncUser::State state, const std::st
     REALM_ASSERT_DEBUG(m_realm);
     m_realm->begin_transaction();
     m_obj.set(m_schema.state_col, static_cast<int64_t>(state));
-    m_obj.set(m_schema.access_token_col, access_token);
-    m_obj.set(m_schema.refresh_token_col, refresh_token);
+    m_obj.set(m_schema.access_token_col, StringData(access_token));
+    m_obj.set(m_schema.refresh_token_col, StringData(refresh_token));
     m_realm->commit_transaction();
 }
 
@@ -688,25 +688,25 @@ void SyncUserMetadata::set_identities(std::vector<SyncUserIdentity> identities)
     m_realm->commit_transaction();
 }
 
-void SyncUserMetadata::set_access_token(const std::string& user_token)
+void SyncUserMetadata::set_access_token(std::string_view user_token)
 {
     if (m_invalid)
         return;
 
     REALM_ASSERT_DEBUG(m_realm);
     m_realm->begin_transaction();
-    m_obj.set(m_schema.access_token_col, user_token);
+    m_obj.set(m_schema.access_token_col, StringData(user_token));
     m_realm->commit_transaction();
 }
 
-void SyncUserMetadata::set_device_id(const std::string& device_id)
+void SyncUserMetadata::set_device_id(std::string_view device_id)
 {
     if (m_invalid)
         return;
 
     REALM_ASSERT_DEBUG(m_realm);
     m_realm->begin_transaction();
-    m_obj.set(m_schema.device_id_col, device_id);
+    m_obj.set(m_schema.device_id_col, StringData(device_id));
     m_realm->commit_transaction();
 }
 
@@ -744,7 +744,7 @@ std::vector<std::string> SyncUserMetadata::realm_file_paths() const
     return std::vector<std::string>(paths.begin(), paths.end());
 }
 
-void SyncUserMetadata::add_realm_file_path(const std::string& path)
+void SyncUserMetadata::add_realm_file_path(std::string_view path)
 {
     if (m_invalid)
         return;
@@ -752,7 +752,7 @@ void SyncUserMetadata::add_realm_file_path(const std::string& path)
     REALM_ASSERT_DEBUG(m_realm);
     m_realm->begin_transaction();
     Set<StringData> paths = m_obj.get_set<StringData>(m_schema.realm_file_paths_col);
-    paths.insert(path);
+    paths.insert(StringData(path));
     m_realm->commit_transaction();
 }
 

--- a/src/realm/object-store/sync/impl/sync_metadata.hpp
+++ b/src/realm/object-store/sync/impl/sync_metadata.hpp
@@ -84,23 +84,22 @@ public:
     std::vector<realm::SyncUserIdentity> identities() const;
     void set_identities(std::vector<SyncUserIdentity>);
 
-    void set_state_and_tokens(SyncUser::State state, const std::string& access_token,
-                              const std::string& refresh_token);
+    void set_state_and_tokens(SyncUser::State state, std::string_view access_token, std::string_view refresh_token);
 
     std::string refresh_token() const;
-    void set_refresh_token(const std::string& token);
+    void set_refresh_token(std::string_view token);
 
     std::string access_token() const;
-    void set_access_token(const std::string& token);
+    void set_access_token(std::string_view token);
 
     std::string device_id() const;
-    void set_device_id(const std::string&);
+    void set_device_id(std::string_view);
 
     SyncUserProfile profile() const;
     void set_user_profile(const SyncUserProfile&);
 
     std::vector<std::string> realm_file_paths() const;
-    void add_realm_file_path(const std::string& path);
+    void add_realm_file_path(std::string_view path);
 
     void set_state(SyncUser::State);
 
@@ -220,7 +219,7 @@ public:
 
     // Retrieve or create user metadata.
     // Note: if `make_is_absent` is true and the user has been marked for deletion, it will be unmarked.
-    util::Optional<SyncUserMetadata> get_or_make_user_metadata(const std::string& identity,
+    util::Optional<SyncUserMetadata> get_or_make_user_metadata(std::string_view identity,
                                                                bool make_if_absent = true) const;
 
     // Retrieve file action metadata.
@@ -231,7 +230,7 @@ public:
                                    SyncFileActionMetadata::Action action, StringData new_name = {}) const;
 
     util::Optional<std::string> get_current_user_identity() const;
-    void set_current_user_identity(const std::string& identity);
+    void set_current_user_identity(std::string_view identity);
 
     util::Optional<SyncAppMetadata> get_app_metadata();
     /// Set or update the cached app server metadata. The metadata will not be updated if it has already been

--- a/src/realm/object-store/sync/realm_backing_store.cpp
+++ b/src/realm/object-store/sync/realm_backing_store.cpp
@@ -1,0 +1,452 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2023 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#include <realm/object-store/sync/realm_backing_store.hpp>
+
+#include <realm/object-store/sync/app_backing_store.hpp>
+#include <realm/object-store/sync/impl/sync_file.hpp>
+#include <realm/object-store/sync/impl/sync_metadata.hpp>
+#include <realm/object-store/sync/sync_user.hpp>
+
+using namespace realm;
+using namespace realm::app;
+
+RealmBackingStore::RealmBackingStore(std::weak_ptr<app::App> parent, RealmBackingStoreConfig config)
+    : app::BackingStore(parent)
+    , m_config(config)
+{
+    initialize();
+}
+
+RealmBackingStore::~RealmBackingStore()
+{
+    util::CheckedLockGuard lk(m_user_mutex);
+    for (auto& user : m_users) {
+        user->detach_from_backing_store();
+    }
+}
+
+void RealmBackingStore::reset_for_testing()
+{
+    {
+        util::CheckedLockGuard lock(m_file_system_mutex);
+        m_metadata_manager = nullptr;
+    }
+
+    {
+        // Destroy all the users.
+        util::CheckedLockGuard lock(m_user_mutex);
+        for (auto& user : m_users) {
+            user->detach_from_backing_store();
+        }
+        m_users.clear();
+        m_current_user = nullptr;
+    }
+    // FIXME: clearing disk state might be happening too soon?
+    {
+        util::CheckedLockGuard lock(m_file_system_mutex);
+        if (m_file_manager)
+            util::try_remove_dir_recursive(m_file_manager->base_path());
+        m_file_manager = nullptr;
+    }
+}
+
+void RealmBackingStore::initialize()
+{
+    std::vector<std::shared_ptr<SyncUser>> users_to_add;
+    {
+        util::CheckedLockGuard lock(m_file_system_mutex);
+        // The RealmBackingStore is not designed to be used
+        // across multiple App instances.
+        REALM_ASSERT_RELEASE(!m_file_manager);
+        // Set up the file manager.
+        m_file_manager =
+            std::make_unique<SyncFileManager>(m_config.base_file_path, m_parent_app.lock()->config().app_id);
+
+        // Set up the metadata manager, and perform initial loading/purging work.
+        if (m_metadata_manager || m_config.metadata_mode == app::RealmBackingStoreConfig::MetadataMode::NoMetadata) {
+            return;
+        }
+
+        bool encrypt = m_config.metadata_mode == app::RealmBackingStoreConfig::MetadataMode::Encryption;
+        m_metadata_manager = std::make_unique<SyncMetadataManager>(m_file_manager->metadata_path(), encrypt,
+                                                                   m_config.custom_encryption_key);
+
+        REALM_ASSERT(m_metadata_manager);
+
+        // Perform our "on next startup" actions such as deleting Realm files
+        // which we couldn't delete immediately due to them being in use
+        std::vector<SyncFileActionMetadata> completed_actions;
+        SyncFileActionMetadataResults file_actions = m_metadata_manager->all_pending_actions();
+        for (size_t i = 0; i < file_actions.size(); i++) {
+            auto file_action = file_actions.get(i);
+            if (run_file_action(file_action)) {
+                completed_actions.emplace_back(std::move(file_action));
+            }
+        }
+        for (auto& action : completed_actions) {
+            action.remove();
+        }
+
+        // Load persisted users into the users map.
+        SyncUserMetadataResults users = m_metadata_manager->all_unmarked_users();
+        for (size_t i = 0; i < users.size(); i++) {
+            auto user_data = users.get(i);
+            auto refresh_token = user_data.refresh_token();
+            auto access_token = user_data.access_token();
+            if (!refresh_token.empty() && !access_token.empty()) {
+                users_to_add.push_back(BackingStore::make_user(user_data, m_parent_app.lock()));
+            }
+        }
+
+        // Delete any users marked for death.
+        std::vector<SyncUserMetadata> dead_users;
+        SyncUserMetadataResults users_to_remove = m_metadata_manager->all_users_marked_for_removal();
+        dead_users.reserve(users_to_remove.size());
+        for (size_t i = 0; i < users_to_remove.size(); i++) {
+            auto user = users_to_remove.get(i);
+            // FIXME: delete user data in a different way? (This deletes a logged-out user's data as soon as the
+            // app launches again, which might not be how some apps want to treat their data.)
+            try {
+                m_file_manager->remove_user_realms(user.identity(), user.realm_file_paths());
+                dead_users.emplace_back(std::move(user));
+            }
+            catch (FileAccessError const&) {
+                continue;
+            }
+        }
+        for (auto& user : dead_users) {
+            user.remove();
+        }
+    }
+    {
+        util::CheckedLockGuard lock(m_user_mutex);
+        m_users.insert(m_users.end(), users_to_add.begin(), users_to_add.end());
+    }
+}
+
+bool RealmBackingStore::immediately_run_file_actions(std::string_view realm_path)
+{
+    util::CheckedLockGuard lock(m_file_system_mutex);
+    if (!m_metadata_manager) {
+        return false;
+    }
+    if (auto metadata = m_metadata_manager->get_file_action_metadata(realm_path)) {
+        if (run_file_action(*metadata)) {
+            metadata->remove();
+            return true;
+        }
+    }
+    return false;
+}
+
+// Perform a file action. Returns whether or not the file action can be removed.
+bool RealmBackingStore::run_file_action(SyncFileActionMetadata& md)
+{
+    switch (md.action()) {
+        case SyncFileActionMetadata::Action::DeleteRealm:
+            // Delete all the files for the given Realm.
+            return m_file_manager->remove_realm(md.original_name());
+        case SyncFileActionMetadata::Action::BackUpThenDeleteRealm:
+            // Copy the primary Realm file to the recovery dir, and then delete the Realm.
+            auto new_name = md.new_name();
+            auto original_name = md.original_name();
+            if (!util::File::exists(original_name)) {
+                // The Realm file doesn't exist anymore.
+                return true;
+            }
+            if (new_name && !util::File::exists(*new_name) &&
+                m_file_manager->copy_realm_file(original_name, *new_name)) {
+                // We successfully copied the Realm file to the recovery directory.
+                bool did_remove = m_file_manager->remove_realm(original_name);
+                // if the copy succeeded but not the delete, then running BackupThenDelete
+                // a second time would fail, so change this action to just delete the original file.
+                if (did_remove) {
+                    return true;
+                }
+                md.set_action(SyncFileActionMetadata::Action::DeleteRealm);
+                return false;
+            }
+            return false;
+    }
+    return false;
+}
+
+bool RealmBackingStore::perform_metadata_update(util::FunctionRef<void(SyncMetadataManager&)> update_function) const
+{
+    util::CheckedLockGuard lock(m_file_system_mutex);
+    if (!m_metadata_manager) {
+        return false;
+    }
+    update_function(*m_metadata_manager);
+    return true;
+}
+
+std::shared_ptr<SyncUser> RealmBackingStore::get_user(std::string_view user_id, std::string_view refresh_token,
+                                                      std::string_view access_token, std::string_view device_id)
+{
+    std::shared_ptr<SyncUser> user;
+    {
+        util::CheckedLockGuard lock(m_user_mutex);
+        auto it = std::find_if(m_users.begin(), m_users.end(), [&](const auto& user) {
+            return user->identity() == user_id && user->state() != SyncUser::State::Removed;
+        });
+        if (it == m_users.end()) {
+            // No existing user.
+            auto new_user =
+                BackingStore::make_user(refresh_token, user_id, access_token, device_id, m_parent_app.lock());
+            m_users.emplace(m_users.begin(), new_user);
+            {
+                util::CheckedLockGuard lock(m_file_system_mutex);
+                // m_current_user is normally set very indirectly via the metadata manger
+                if (!m_metadata_manager)
+                    m_current_user = new_user;
+            }
+            return new_user;
+        }
+
+        // LoggedOut => LoggedIn
+        user = *it;
+        REALM_ASSERT(user->state() != SyncUser::State::Removed);
+    }
+    user->log_in(access_token, refresh_token);
+    return user;
+}
+
+std::vector<std::shared_ptr<SyncUser>> RealmBackingStore::all_users()
+{
+    util::CheckedLockGuard lock(m_user_mutex);
+    m_users.erase(std::remove_if(m_users.begin(), m_users.end(),
+                                 [](auto& user) {
+                                     bool should_remove = (user->state() == SyncUser::State::Removed);
+                                     if (should_remove) {
+                                         user->detach_from_backing_store();
+                                     }
+                                     return should_remove;
+                                 }),
+                  m_users.end());
+    return m_users;
+}
+
+std::shared_ptr<SyncUser> RealmBackingStore::get_user_for_identity(std::string_view identity) const noexcept
+{
+    auto is_active_user = [identity](auto& el) {
+        return el->identity() == identity;
+    };
+    auto it = std::find_if(m_users.begin(), m_users.end(), is_active_user);
+    return it == m_users.end() ? nullptr : *it;
+}
+
+std::shared_ptr<SyncUser> RealmBackingStore::get_current_user() const
+{
+    util::CheckedLockGuard lock(m_user_mutex);
+
+    if (m_current_user)
+        return m_current_user;
+    util::CheckedLockGuard fs_lock(m_file_system_mutex);
+    if (!m_metadata_manager)
+        return nullptr;
+
+    auto cur_user_ident = m_metadata_manager->get_current_user_identity();
+    return cur_user_ident ? get_user_for_identity(*cur_user_ident) : nullptr;
+}
+
+void RealmBackingStore::log_out_user(const SyncUser& user)
+{
+    util::CheckedLockGuard lock(m_user_mutex);
+
+    // Move this user to the end of the vector
+    auto user_pos = std::partition(m_users.begin(), m_users.end(), [&](auto& u) {
+        return u.get() != &user;
+    });
+
+    auto active_user = std::find_if(m_users.begin(), user_pos, [](auto& u) {
+        return u->state() == SyncUser::State::LoggedIn;
+    });
+
+    util::CheckedLockGuard fs_lock(m_file_system_mutex);
+    bool was_active = m_current_user.get() == &user ||
+                      (m_metadata_manager && m_metadata_manager->get_current_user_identity() == user.identity());
+    if (!was_active)
+        return;
+
+    // Set the current active user to the next logged in user, or null if none
+    if (active_user != user_pos) {
+        m_current_user = *active_user;
+        if (m_metadata_manager)
+            m_metadata_manager->set_current_user_identity((*active_user)->identity());
+    }
+    else {
+        m_current_user = nullptr;
+        if (m_metadata_manager)
+            m_metadata_manager->set_current_user_identity("");
+    }
+}
+
+void RealmBackingStore::set_current_user(std::string_view user_id)
+{
+    util::CheckedLockGuard lock(m_user_mutex);
+
+    m_current_user = get_user_for_identity(user_id);
+    util::CheckedLockGuard fs_lock(m_file_system_mutex);
+    if (m_metadata_manager)
+        m_metadata_manager->set_current_user_identity(user_id);
+}
+
+void RealmBackingStore::remove_user(std::string_view user_id)
+{
+    util::CheckedLockGuard lock(m_user_mutex);
+    if (auto user = get_user_for_identity(user_id))
+        user->invalidate();
+}
+
+void RealmBackingStore::delete_user(std::string_view user_id)
+{
+    util::CheckedLockGuard lock(m_user_mutex);
+    // Avoid iterating over m_users twice by not calling `get_user_for_identity`.
+    auto it = std::find_if(m_users.begin(), m_users.end(), [&user_id](auto& user) {
+        return user->identity() == user_id;
+    });
+    auto user = it == m_users.end() ? nullptr : *it;
+
+    if (!user)
+        return;
+
+    // Deletion should happen immediately, not when we do the cleanup
+    // task on next launch.
+    m_users.erase(it);
+    user->detach_from_backing_store();
+
+    if (m_current_user && m_current_user->identity() == user->identity())
+        m_current_user = nullptr;
+
+    util::CheckedLockGuard fs_lock(m_file_system_mutex);
+    if (!m_metadata_manager)
+        return;
+
+    auto users = m_metadata_manager->all_unmarked_users();
+    for (size_t i = 0; i < users.size(); i++) {
+        auto metadata = users.get(i);
+        if (user->identity() == metadata.identity()) {
+            m_file_manager->remove_user_realms(metadata.identity(), metadata.realm_file_paths());
+            metadata.remove();
+            break;
+        }
+    }
+}
+
+std::shared_ptr<SyncUser> RealmBackingStore::get_existing_logged_in_user(std::string_view user_id) const
+{
+    util::CheckedLockGuard lock(m_user_mutex);
+    auto user = get_user_for_identity(user_id);
+    return user && user->state() == SyncUser::State::LoggedIn ? user : nullptr;
+}
+
+struct UnsupportedBsonPartition : public std::logic_error {
+    UnsupportedBsonPartition(std::string msg)
+        : std::logic_error(msg)
+    {
+    }
+};
+
+static std::string string_from_partition(std::string_view partition)
+{
+    bson::Bson partition_value = bson::parse(partition);
+    switch (partition_value.type()) {
+        case bson::Bson::Type::Int32:
+            return util::format("i_%1", static_cast<int32_t>(partition_value));
+        case bson::Bson::Type::Int64:
+            return util::format("l_%1", static_cast<int64_t>(partition_value));
+        case bson::Bson::Type::String:
+            return util::format("s_%1", static_cast<std::string>(partition_value));
+        case bson::Bson::Type::ObjectId:
+            return util::format("o_%1", static_cast<ObjectId>(partition_value).to_string());
+        case bson::Bson::Type::Uuid:
+            return util::format("u_%1", static_cast<UUID>(partition_value).to_string());
+        case bson::Bson::Type::Null:
+            return "null";
+        default:
+            throw UnsupportedBsonPartition(util::format("Unsupported partition key value: '%1'. Only int, string "
+                                                        "UUID and ObjectId types are currently supported.",
+                                                        partition_value.to_string()));
+    }
+}
+
+std::string RealmBackingStore::path_for_realm(std::shared_ptr<SyncUser> user,
+                                              std::optional<std::string> custom_file_name,
+                                              std::optional<std::string> partition_value) const
+{
+    REALM_ASSERT(user);
+    std::string path;
+    {
+        util::CheckedLockGuard lock(m_file_system_mutex);
+        REALM_ASSERT(m_file_manager);
+
+        // Attempt to make a nicer filename which will ease debugging when
+        // locating files in the filesystem.
+        auto file_name = [&]() -> std::string {
+            if (custom_file_name) {
+                return *custom_file_name;
+            }
+            if (!partition_value) {
+                return "flx_sync_default";
+            }
+            return string_from_partition(*partition_value);
+        }();
+        path = m_file_manager->realm_file_path(user->identity(), user->legacy_identities(), file_name,
+                                               partition_value.value_or(""));
+    }
+    // Report the use of a Realm for this user, so the metadata can track it for clean up.
+    perform_metadata_update([&](const auto& manager) {
+        auto metadata = manager.get_or_make_user_metadata(user->identity());
+        metadata->add_realm_file_path(path);
+    });
+    return path;
+}
+
+std::string RealmBackingStore::audit_path_root(std::shared_ptr<SyncUser> user, std::string_view app_id,
+                                               std::string_view partition_prefix) const
+{
+    REALM_ASSERT(user);
+
+#ifdef _WIN32 // Move to File?
+    const char separator[] = "\\";
+#else
+    const char separator[] = "/";
+#endif
+
+    // "$root/realm-audit/$appId/$userId/$partitonPrefix/"
+    return util::format("%2%1realm-audit%1%3%1%4%1%5%1", separator, m_config.base_file_path, app_id, user->identity(),
+                        partition_prefix);
+}
+
+std::string RealmBackingStore::recovery_directory_path(util::Optional<std::string> const& custom_dir_name) const
+{
+    util::CheckedLockGuard lock(m_file_system_mutex);
+    REALM_ASSERT(m_file_manager);
+    return m_file_manager->recovery_directory_path(custom_dir_name);
+}
+
+std::optional<SyncAppMetadata> RealmBackingStore::app_metadata() const
+{
+    util::CheckedLockGuard lock(m_file_system_mutex);
+    if (!m_metadata_manager) {
+        return util::none;
+    }
+    return m_metadata_manager->get_app_metadata();
+}

--- a/src/realm/object-store/sync/realm_backing_store.hpp
+++ b/src/realm/object-store/sync/realm_backing_store.hpp
@@ -1,0 +1,109 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2023 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#ifndef REALM_OS_BACKING_STORE_HPP
+#define REALM_OS_BACKING_STORE_HPP
+
+#include <realm/object-store/sync/app_backing_store.hpp>
+
+#include <realm/util/checked_mutex.hpp>
+#include <memory>
+
+namespace realm {
+class SyncUser;
+class SyncFileManager;
+class SyncMetadataManager;
+class SyncFileActionMetadata;
+class SyncAppMetadata;
+} // namespace realm
+
+namespace realm::app {
+class App;
+
+struct RealmBackingStoreConfig {
+    enum class MetadataMode {
+        NoEncryption, // Enable metadata, but disable encryption.
+        Encryption,   // Enable metadata, and use encryption (automatic if possible).
+        NoMetadata,   // Disable metadata.
+    };
+
+    std::string base_file_path;
+    MetadataMode metadata_mode = MetadataMode::Encryption;
+    std::optional<std::vector<char>> custom_encryption_key;
+};
+
+struct RealmBackingStore final : public app::BackingStore {
+
+    RealmBackingStore(std::weak_ptr<app::App> parent, RealmBackingStoreConfig config);
+    virtual ~RealmBackingStore();
+    std::shared_ptr<SyncUser> get_user(std::string_view user_id, std::string_view refresh_token,
+                                       std::string_view access_token, std::string_view device_id) override
+        REQUIRES(!m_user_mutex, !m_file_system_mutex);
+    std::shared_ptr<SyncUser> get_existing_logged_in_user(std::string_view user_id) const override
+        REQUIRES(!m_user_mutex);
+    std::vector<std::shared_ptr<SyncUser>> all_users() override REQUIRES(!m_user_mutex);
+    std::shared_ptr<SyncUser> get_current_user() const override REQUIRES(!m_user_mutex, !m_file_system_mutex);
+    void log_out_user(const SyncUser& user) override REQUIRES(!m_user_mutex, !m_file_system_mutex);
+    void set_current_user(std::string_view user_id) override REQUIRES(!m_user_mutex, !m_file_system_mutex);
+    void remove_user(std::string_view user_id) override REQUIRES(!m_user_mutex, !m_file_system_mutex);
+    void delete_user(std::string_view user_id) override REQUIRES(!m_user_mutex, !m_file_system_mutex);
+    void reset_for_testing() override REQUIRES(!m_user_mutex, !m_file_system_mutex);
+    bool immediately_run_file_actions(std::string_view realm_path) override REQUIRES(!m_file_system_mutex);
+    bool perform_metadata_update(util::FunctionRef<void(SyncMetadataManager&)> update_function) const override
+        REQUIRES(!m_file_system_mutex);
+
+    std::string path_for_realm(std::shared_ptr<SyncUser> user, std::optional<std::string> custom_file_name = none,
+                               std::optional<std::string> partition_value = none) const override
+        REQUIRES(!m_file_system_mutex);
+
+    std::string audit_path_root(std::shared_ptr<SyncUser> user, std::string_view app_id,
+                                std::string_view partition_prefix) const override;
+
+    std::string recovery_directory_path(std::optional<std::string> const& custom_dir_name = none) const override
+        REQUIRES(!m_file_system_mutex);
+    std::optional<SyncAppMetadata> app_metadata() const override REQUIRES(!m_file_system_mutex);
+
+    // Access to the config that was used to create this instance.
+    const RealmBackingStoreConfig& config() const
+    {
+        return m_config;
+    }
+
+private:
+    std::shared_ptr<SyncUser> get_user_for_identity(std::string_view identity) const noexcept REQUIRES(m_user_mutex);
+    bool run_file_action(SyncFileActionMetadata&) REQUIRES(m_file_system_mutex);
+    void initialize() REQUIRES(!m_file_system_mutex, !m_user_mutex);
+
+    const RealmBackingStoreConfig m_config;
+
+    // Protects m_users
+    mutable util::CheckedMutex m_user_mutex;
+
+    // A vector of all SyncUser objects.
+    std::vector<std::shared_ptr<SyncUser>> m_users GUARDED_BY(m_user_mutex);
+    std::shared_ptr<SyncUser> m_current_user GUARDED_BY(m_user_mutex);
+
+    // Protects m_file_manager and m_metadata_manager
+    mutable util::CheckedMutex m_file_system_mutex;
+    std::unique_ptr<SyncFileManager> m_file_manager GUARDED_BY(m_file_system_mutex);
+    std::unique_ptr<SyncMetadataManager> m_metadata_manager GUARDED_BY(m_file_system_mutex);
+};
+
+} // namespace realm::app
+
+#endif // REALM_OS_BACKING_STORE_HPP

--- a/src/realm/object-store/sync/subscribable.hpp
+++ b/src/realm/object-store/sync/subscribable.hpp
@@ -21,6 +21,7 @@
 
 #include <atomic>
 #include <cstdint>
+#include <functional>
 #include <mutex>
 #include <unordered_map>
 

--- a/src/realm/object-store/sync/sync_manager.cpp
+++ b/src/realm/object-store/sync/sync_manager.cpp
@@ -19,8 +19,6 @@
 #include <realm/object-store/sync/sync_manager.hpp>
 
 #include <realm/object-store/sync/impl/sync_client.hpp>
-#include <realm/object-store/sync/impl/sync_file.hpp>
-#include <realm/object-store/sync/impl/sync_metadata.hpp>
 #include <realm/object-store/sync/sync_session.hpp>
 #include <realm/object-store/sync/sync_user.hpp>
 #include <realm/object-store/sync/app.hpp>
@@ -43,167 +41,30 @@ SyncClientTimeouts::SyncClientTimeouts()
 {
 }
 
-SyncManager::SyncManager() = default;
-
-void SyncManager::configure(std::shared_ptr<app::App> app, std::optional<std::string> sync_route,
-                            const SyncClientConfig& config)
+SyncManager::SyncManager(std::shared_ptr<app::App> app, const SyncClientConfig& config)
 {
-    std::vector<std::shared_ptr<SyncUser>> users_to_add;
-    {
-        // Locking the mutex here ensures that it is released before locking m_user_mutex
-        util::CheckedLockGuard lock(m_mutex);
-        m_app = app;
-        m_sync_route = sync_route;
-        m_config = std::move(config);
-        if (m_sync_client)
-            return;
+    REALM_ASSERT(app);
+    m_app = app;
+    // Start with an empty sync route in the sync manager. It will ensure the
+    // location has been updated at least once when the first sync session is
+    // started by requesting a new access token.
+    m_sync_route.reset();
+    m_config = std::move(config);
+    if (m_sync_client)
+        return;
 
-        // create a new logger - if the logger_factory is updated later, a new
-        // logger will be created at that time.
-        do_make_logger();
-
-        {
-            util::CheckedLockGuard lock(m_file_system_mutex);
-
-            // Set up the file manager.
-            if (m_file_manager) {
-                // Changing the base path for tests requires calling reset_for_testing()
-                // first, and otherwise isn't supported
-                REALM_ASSERT(m_file_manager->base_path() == m_config.base_file_path);
-            }
-            else {
-                m_file_manager = std::make_unique<SyncFileManager>(m_config.base_file_path, app->config().app_id);
-            }
-
-            // Set up the metadata manager, and perform initial loading/purging work.
-            if (m_metadata_manager || m_config.metadata_mode == MetadataMode::NoMetadata) {
-                return;
-            }
-
-            bool encrypt = m_config.metadata_mode == MetadataMode::Encryption;
-            m_metadata_manager = std::make_unique<SyncMetadataManager>(m_file_manager->metadata_path(), encrypt,
-                                                                       m_config.custom_encryption_key);
-
-            REALM_ASSERT(m_metadata_manager);
-
-            // Perform our "on next startup" actions such as deleting Realm files
-            // which we couldn't delete immediately due to them being in use
-            std::vector<SyncFileActionMetadata> completed_actions;
-            SyncFileActionMetadataResults file_actions = m_metadata_manager->all_pending_actions();
-            for (size_t i = 0; i < file_actions.size(); i++) {
-                auto file_action = file_actions.get(i);
-                if (run_file_action(file_action)) {
-                    completed_actions.emplace_back(std::move(file_action));
-                }
-            }
-            for (auto& action : completed_actions) {
-                action.remove();
-            }
-
-            // Load persisted users into the users map.
-            SyncUserMetadataResults users = m_metadata_manager->all_unmarked_users();
-            for (size_t i = 0; i < users.size(); i++) {
-                auto user_data = users.get(i);
-                auto refresh_token = user_data.refresh_token();
-                auto access_token = user_data.access_token();
-                if (!refresh_token.empty() && !access_token.empty()) {
-                    users_to_add.push_back(std::make_shared<SyncUser>(SyncUser::Private(), user_data, this));
-                }
-            }
-
-            // Delete any users marked for death.
-            std::vector<SyncUserMetadata> dead_users;
-            SyncUserMetadataResults users_to_remove = m_metadata_manager->all_users_marked_for_removal();
-            dead_users.reserve(users_to_remove.size());
-            for (size_t i = 0; i < users_to_remove.size(); i++) {
-                auto user = users_to_remove.get(i);
-                // FIXME: delete user data in a different way? (This deletes a logged-out user's data as soon as the
-                // app launches again, which might not be how some apps want to treat their data.)
-                try {
-                    m_file_manager->remove_user_realms(user.identity(), user.realm_file_paths());
-                    dead_users.emplace_back(std::move(user));
-                }
-                catch (FileAccessError const&) {
-                    continue;
-                }
-            }
-            for (auto& user : dead_users) {
-                user.remove();
-            }
-        }
-    }
-    {
-        util::CheckedLockGuard lock(m_user_mutex);
-        m_users.insert(m_users.end(), users_to_add.begin(), users_to_add.end());
-    }
-}
-
-bool SyncManager::immediately_run_file_actions(const std::string& realm_path)
-{
-    util::CheckedLockGuard lock(m_file_system_mutex);
-    if (!m_metadata_manager) {
-        return false;
-    }
-    if (auto metadata = m_metadata_manager->get_file_action_metadata(realm_path)) {
-        if (run_file_action(*metadata)) {
-            metadata->remove();
-            return true;
-        }
-    }
-    return false;
-}
-
-// Perform a file action. Returns whether or not the file action can be removed.
-bool SyncManager::run_file_action(SyncFileActionMetadata& md)
-{
-    switch (md.action()) {
-        case SyncFileActionMetadata::Action::DeleteRealm:
-            // Delete all the files for the given Realm.
-            return m_file_manager->remove_realm(md.original_name());
-        case SyncFileActionMetadata::Action::BackUpThenDeleteRealm:
-            // Copy the primary Realm file to the recovery dir, and then delete the Realm.
-            auto new_name = md.new_name();
-            auto original_name = md.original_name();
-            if (!util::File::exists(original_name)) {
-                // The Realm file doesn't exist anymore.
-                return true;
-            }
-            if (new_name && !util::File::exists(*new_name) &&
-                m_file_manager->copy_realm_file(original_name, *new_name)) {
-                // We successfully copied the Realm file to the recovery directory.
-                bool did_remove = m_file_manager->remove_realm(original_name);
-                // if the copy succeeded but not the delete, then running BackupThenDelete
-                // a second time would fail, so change this action to just delete the original file.
-                if (did_remove) {
-                    return true;
-                }
-                md.set_action(SyncFileActionMetadata::Action::DeleteRealm);
-                return false;
-            }
-            return false;
-    }
-    return false;
+    // create a new logger - if the logger_factory is updated later, a new
+    // logger will be created at that time.
+    do_make_logger();
 }
 
 void SyncManager::reset_for_testing()
 {
     {
-        util::CheckedLockGuard lock(m_file_system_mutex);
-        m_metadata_manager = nullptr;
-    }
-
-    {
-        // Destroy all the users.
-        util::CheckedLockGuard lock(m_user_mutex);
-        for (auto& user : m_users) {
-            user->detach_from_sync_manager();
-        }
-        m_users.clear();
-        m_current_user = nullptr;
-    }
-
-    {
         util::CheckedLockGuard lock(m_mutex);
+        if (auto app = m_app.lock()) {
+            app->backing_store()->reset_for_testing();
+        }
         // Stop the client. This will abort any uploads that inactive sessions are waiting for.
         if (m_sync_client)
             m_sync_client->stop();
@@ -251,13 +112,6 @@ void SyncManager::reset_for_testing()
         m_config = {};
         m_logger_ptr.reset();
         m_sync_route.reset();
-    }
-
-    {
-        util::CheckedLockGuard lock(m_file_system_mutex);
-        if (m_file_manager)
-            util::try_remove_dir_recursive(m_file_manager->base_path());
-        m_file_manager = nullptr;
     }
 }
 
@@ -326,169 +180,6 @@ util::Logger::Level SyncManager::log_level() const noexcept
     return m_config.log_level;
 }
 
-bool SyncManager::perform_metadata_update(util::FunctionRef<void(SyncMetadataManager&)> update_function) const
-{
-    util::CheckedLockGuard lock(m_file_system_mutex);
-    if (!m_metadata_manager) {
-        return false;
-    }
-    update_function(*m_metadata_manager);
-    return true;
-}
-
-std::shared_ptr<SyncUser> SyncManager::get_user(const std::string& user_id, const std::string& refresh_token,
-                                                const std::string& access_token, const std::string& device_id)
-{
-    std::shared_ptr<SyncUser> user;
-    {
-        util::CheckedLockGuard lock(m_user_mutex);
-        auto it = std::find_if(m_users.begin(), m_users.end(), [&](const auto& user) {
-            return user->identity() == user_id && user->state() != SyncUser::State::Removed;
-        });
-        if (it == m_users.end()) {
-            // No existing user.
-            auto new_user = std::make_shared<SyncUser>(SyncUser::Private(), refresh_token, user_id, access_token,
-                                                       device_id, this);
-            m_users.emplace(m_users.begin(), new_user);
-            {
-                util::CheckedLockGuard lock(m_file_system_mutex);
-                // m_current_user is normally set very indirectly via the metadata manger
-                if (!m_metadata_manager)
-                    m_current_user = new_user;
-            }
-            return new_user;
-        }
-
-        // LoggedOut => LoggedIn
-        user = *it;
-        REALM_ASSERT(user->state() != SyncUser::State::Removed);
-    }
-    user->log_in(access_token, refresh_token);
-    return user;
-}
-
-std::vector<std::shared_ptr<SyncUser>> SyncManager::all_users()
-{
-    util::CheckedLockGuard lock(m_user_mutex);
-    m_users.erase(std::remove_if(m_users.begin(), m_users.end(),
-                                 [](auto& user) {
-                                     bool should_remove = (user->state() == SyncUser::State::Removed);
-                                     if (should_remove) {
-                                         user->detach_from_sync_manager();
-                                     }
-                                     return should_remove;
-                                 }),
-                  m_users.end());
-    return m_users;
-}
-
-std::shared_ptr<SyncUser> SyncManager::get_user_for_identity(std::string const& identity) const noexcept
-{
-    auto is_active_user = [identity](auto& el) {
-        return el->identity() == identity;
-    };
-    auto it = std::find_if(m_users.begin(), m_users.end(), is_active_user);
-    return it == m_users.end() ? nullptr : *it;
-}
-
-std::shared_ptr<SyncUser> SyncManager::get_current_user() const
-{
-    util::CheckedLockGuard lock(m_user_mutex);
-
-    if (m_current_user)
-        return m_current_user;
-    util::CheckedLockGuard fs_lock(m_file_system_mutex);
-    if (!m_metadata_manager)
-        return nullptr;
-
-    auto cur_user_ident = m_metadata_manager->get_current_user_identity();
-    return cur_user_ident ? get_user_for_identity(*cur_user_ident) : nullptr;
-}
-
-void SyncManager::log_out_user(const SyncUser& user)
-{
-    util::CheckedLockGuard lock(m_user_mutex);
-
-    // Move this user to the end of the vector
-    auto user_pos = std::partition(m_users.begin(), m_users.end(), [&](auto& u) {
-        return u.get() != &user;
-    });
-
-    auto active_user = std::find_if(m_users.begin(), user_pos, [](auto& u) {
-        return u->state() == SyncUser::State::LoggedIn;
-    });
-
-    util::CheckedLockGuard fs_lock(m_file_system_mutex);
-    bool was_active = m_current_user.get() == &user ||
-                      (m_metadata_manager && m_metadata_manager->get_current_user_identity() == user.identity());
-    if (!was_active)
-        return;
-
-    // Set the current active user to the next logged in user, or null if none
-    if (active_user != user_pos) {
-        m_current_user = *active_user;
-        if (m_metadata_manager)
-            m_metadata_manager->set_current_user_identity((*active_user)->identity());
-    }
-    else {
-        m_current_user = nullptr;
-        if (m_metadata_manager)
-            m_metadata_manager->set_current_user_identity("");
-    }
-}
-
-void SyncManager::set_current_user(const std::string& user_id)
-{
-    util::CheckedLockGuard lock(m_user_mutex);
-
-    m_current_user = get_user_for_identity(user_id);
-    util::CheckedLockGuard fs_lock(m_file_system_mutex);
-    if (m_metadata_manager)
-        m_metadata_manager->set_current_user_identity(user_id);
-}
-
-void SyncManager::remove_user(const std::string& user_id)
-{
-    util::CheckedLockGuard lock(m_user_mutex);
-    if (auto user = get_user_for_identity(user_id))
-        user->invalidate();
-}
-
-void SyncManager::delete_user(const std::string& user_id)
-{
-    util::CheckedLockGuard lock(m_user_mutex);
-    // Avoid iterating over m_users twice by not calling `get_user_for_identity`.
-    auto it = std::find_if(m_users.begin(), m_users.end(), [&user_id](auto& user) {
-        return user->identity() == user_id;
-    });
-    auto user = it == m_users.end() ? nullptr : *it;
-
-    if (!user)
-        return;
-
-    // Deletion should happen immediately, not when we do the cleanup
-    // task on next launch.
-    m_users.erase(it);
-    user->detach_from_sync_manager();
-
-    if (m_current_user && m_current_user->identity() == user->identity())
-        m_current_user = nullptr;
-
-    util::CheckedLockGuard fs_lock(m_file_system_mutex);
-    if (!m_metadata_manager)
-        return;
-
-    auto users = m_metadata_manager->all_unmarked_users();
-    for (size_t i = 0; i < users.size(); i++) {
-        auto metadata = users.get(i);
-        if (user->identity() == metadata.identity()) {
-            m_file_manager->remove_user_realms(metadata.identity(), metadata.realm_file_paths());
-            metadata.remove();
-            break;
-        }
-    }
-}
-
 SyncManager::~SyncManager() NO_THREAD_SAFETY_ANALYSIS
 {
     // Grab the current sessions under a lock so we can shut them down. We have to
@@ -505,94 +196,11 @@ SyncManager::~SyncManager() NO_THREAD_SAFETY_ANALYSIS
     }
 
     {
-        util::CheckedLockGuard lk(m_user_mutex);
-        for (auto& user : m_users) {
-            user->detach_from_sync_manager();
-        }
-    }
-
-    {
         util::CheckedLockGuard lk(m_mutex);
         // Stop the client. This will abort any uploads that inactive sessions are waiting for.
         if (m_sync_client)
             m_sync_client->stop();
     }
-}
-
-std::shared_ptr<SyncUser> SyncManager::get_existing_logged_in_user(const std::string& user_id) const
-{
-    util::CheckedLockGuard lock(m_user_mutex);
-    auto user = get_user_for_identity(user_id);
-    return user && user->state() == SyncUser::State::LoggedIn ? user : nullptr;
-}
-
-struct UnsupportedBsonPartition : public std::logic_error {
-    UnsupportedBsonPartition(std::string msg)
-        : std::logic_error(msg)
-    {
-    }
-};
-
-static std::string string_from_partition(const std::string& partition)
-{
-    bson::Bson partition_value = bson::parse(partition);
-    switch (partition_value.type()) {
-        case bson::Bson::Type::Int32:
-            return util::format("i_%1", static_cast<int32_t>(partition_value));
-        case bson::Bson::Type::Int64:
-            return util::format("l_%1", static_cast<int64_t>(partition_value));
-        case bson::Bson::Type::String:
-            return util::format("s_%1", static_cast<std::string>(partition_value));
-        case bson::Bson::Type::ObjectId:
-            return util::format("o_%1", static_cast<ObjectId>(partition_value).to_string());
-        case bson::Bson::Type::Uuid:
-            return util::format("u_%1", static_cast<UUID>(partition_value).to_string());
-        case bson::Bson::Type::Null:
-            return "null";
-        default:
-            throw UnsupportedBsonPartition(util::format("Unsupported partition key value: '%1'. Only int, string "
-                                                        "UUID and ObjectId types are currently supported.",
-                                                        partition_value.to_string()));
-    }
-}
-
-std::string SyncManager::path_for_realm(const SyncConfig& config, util::Optional<std::string> custom_file_name) const
-{
-    auto user = config.user;
-    REALM_ASSERT(user);
-    std::string path;
-    {
-        util::CheckedLockGuard lock(m_file_system_mutex);
-        REALM_ASSERT(m_file_manager);
-
-        // Attempt to make a nicer filename which will ease debugging when
-        // locating files in the filesystem.
-        auto file_name = [&]() -> std::string {
-            if (custom_file_name) {
-                return *custom_file_name;
-            }
-            if (config.flx_sync_requested) {
-                REALM_ASSERT_DEBUG(config.partition_value.empty());
-                return "flx_sync_default";
-            }
-            return string_from_partition(config.partition_value);
-        }();
-        path = m_file_manager->realm_file_path(user->identity(), user->legacy_identities(), file_name,
-                                               config.partition_value);
-    }
-    // Report the use of a Realm for this user, so the metadata can track it for clean up.
-    perform_metadata_update([&](const auto& manager) {
-        auto metadata = manager.get_or_make_user_metadata(user->identity());
-        metadata->add_realm_file_path(path);
-    });
-    return path;
-}
-
-std::string SyncManager::recovery_directory_path(util::Optional<std::string> const& custom_dir_name) const
-{
-    util::CheckedLockGuard lock(m_file_system_mutex);
-    REALM_ASSERT(m_file_manager);
-    return m_file_manager->recovery_directory_path(custom_dir_name);
 }
 
 std::vector<std::shared_ptr<SyncSession>> SyncManager::get_all_sessions() const
@@ -602,6 +210,19 @@ std::vector<std::shared_ptr<SyncSession>> SyncManager::get_all_sessions() const
     for (auto& [_, session] : m_sessions) {
         if (auto external_reference = session->existing_external_reference())
             sessions.push_back(std::move(external_reference));
+    }
+    return sessions;
+}
+
+std::vector<std::shared_ptr<SyncSession>> SyncManager::get_all_sessions_for(const SyncUser& user) const
+{
+    util::CheckedLockGuard lock(m_session_mutex);
+    std::vector<std::shared_ptr<SyncSession>> sessions;
+    for (auto& [_, session] : m_sessions) {
+        if (session->user().get() == &user) {
+            if (auto external_reference = session->existing_external_reference())
+                sessions.push_back(std::move(external_reference));
+        }
     }
     return sessions;
 }
@@ -644,7 +265,6 @@ std::shared_ptr<SyncSession> SyncManager::get_session(std::shared_ptr<DB> db, co
 
     util::CheckedUniqueLock lock(m_session_mutex);
     if (auto session = get_existing_session_locked(path)) {
-        config.sync_config->user->register_session(session);
         return session->external_reference();
     }
 
@@ -653,15 +273,7 @@ std::shared_ptr<SyncSession> SyncManager::get_session(std::shared_ptr<DB> db, co
 
     // Create the external reference immediately to ensure that the session will become
     // inactive if an exception is thrown in the following code.
-    auto external_reference = shared_session->external_reference();
-    // unlocking m_session_mutex here prevents a deadlock for synchronous network
-    // transports such as the unit test suite, in the case where the log in request is
-    // denied by the server: Active -> WaitingForAccessToken -> handle_refresh(401
-    // error) -> user.log_out() -> unregister_session (locks m_session_mutex again)
-    lock.unlock();
-    config.sync_config->user->register_session(std::move(shared_session));
-
-    return external_reference;
+    return shared_session->external_reference();
 }
 
 bool SyncManager::has_existing_sessions()
@@ -747,15 +359,6 @@ SyncClient& SyncManager::get_sync_client() const
 std::unique_ptr<SyncClient> SyncManager::create_sync_client() const
 {
     return std::make_unique<SyncClient>(m_logger_ptr, m_config, weak_from_this());
-}
-
-util::Optional<SyncAppMetadata> SyncManager::app_metadata() const
-{
-    util::CheckedLockGuard lock(m_file_system_mutex);
-    if (!m_metadata_manager) {
-        return util::none;
-    }
-    return m_metadata_manager->get_app_metadata();
 }
 
 void SyncManager::close_all_sessions()

--- a/src/realm/object-store/sync/sync_manager.hpp
+++ b/src/realm/object-store/sync/sync_manager.hpp
@@ -20,6 +20,7 @@
 #define REALM_OS_SYNC_MANAGER_HPP
 
 #include <realm/object-store/shared_realm.hpp>
+#include <realm/object-store/sync/realm_backing_store.hpp>
 
 #include <realm/util/checked_mutex.hpp>
 #include <realm/util/logger.hpp>
@@ -41,10 +42,6 @@ class DB;
 struct SyncConfig;
 class SyncSession;
 class SyncUser;
-class SyncFileManager;
-class SyncMetadataManager;
-class SyncFileActionMetadata;
-class SyncAppMetadata;
 
 namespace _impl {
 struct SyncClient;
@@ -65,16 +62,6 @@ struct SyncClientTimeouts {
 };
 
 struct SyncClientConfig {
-    enum class MetadataMode {
-        NoEncryption, // Enable metadata, but disable encryption.
-        Encryption,   // Enable metadata, and use encryption (automatic if possible).
-        NoMetadata,   // Disable metadata.
-    };
-
-    std::string base_file_path;
-    MetadataMode metadata_mode = MetadataMode::Encryption;
-    util::Optional<std::vector<char>> custom_encryption_key;
-
     using LoggerFactory = std::function<std::shared_ptr<util::Logger>(util::Logger::Level)>;
     LoggerFactory logger_factory;
     util::Logger::Level log_level = util::Logger::Level::info;
@@ -111,13 +98,7 @@ class SyncManager : public std::enable_shared_from_this<SyncManager> {
     friend class ::TestAppSession;
 
 public:
-    using MetadataMode = SyncClientConfig::MetadataMode;
-
-    // Immediately run file actions for a single Realm at a given original path.
-    // Returns whether or not a file action was successfully executed for the specified Realm.
-    // Preconditions: all references to the Realm at the given path must have already been invalidated.
-    // The metadata and file management subsystems must also have already been configured.
-    bool immediately_run_file_actions(const std::string& original_name) REQUIRES(!m_file_system_mutex);
+    using MetadataMode = app::RealmBackingStoreConfig::MetadataMode;
 
     // Enables/disables using a single connection for all sync sessions for each host/port/user rather
     // than one per session.
@@ -157,6 +138,8 @@ public:
     util::Logger::Level log_level() const noexcept REQUIRES(!m_mutex);
 
     std::vector<std::shared_ptr<SyncSession>> get_all_sessions() const REQUIRES(!m_session_mutex);
+    std::vector<std::shared_ptr<SyncSession>> get_all_sessions_for(const SyncUser& user) const
+        REQUIRES(!m_session_mutex);
     std::shared_ptr<SyncSession> get_session(std::shared_ptr<DB> db, const RealmConfig& config)
         REQUIRES(!m_mutex, !m_session_mutex);
     std::shared_ptr<SyncSession> get_existing_session(const std::string& path) const REQUIRES(!m_session_mutex);
@@ -174,55 +157,10 @@ public:
     // makes it possible to guarantee that all sessions have, in fact, been closed.
     void wait_for_sessions_to_terminate() REQUIRES(!m_mutex);
 
-    // If the metadata manager is configured, perform an update. Returns `true` if the code was run.
-    bool perform_metadata_update(util::FunctionRef<void(SyncMetadataManager&)> update_function) const
-        REQUIRES(!m_file_system_mutex);
-
-    // Get a sync user for a given identity, or create one if none exists yet, and set its token.
-    // If a logged-out user exists, it will marked as logged back in.
-    std::shared_ptr<SyncUser> get_user(const std::string& user_id, const std::string& refresh_token,
-                                       const std::string& access_token, const std::string& device_id)
-        REQUIRES(!m_user_mutex, !m_file_system_mutex);
-
-    // Get an existing user for a given identifier, if one exists and is logged in.
-    std::shared_ptr<SyncUser> get_existing_logged_in_user(const std::string& user_id) const REQUIRES(!m_user_mutex);
-
-    // Get all the users that are logged in and not errored out.
-    std::vector<std::shared_ptr<SyncUser>> all_users() REQUIRES(!m_user_mutex);
-
-    // Gets the currently active user.
-    std::shared_ptr<SyncUser> get_current_user() const REQUIRES(!m_user_mutex, !m_file_system_mutex);
-
-    // Log out a given user
-    void log_out_user(const SyncUser& user) REQUIRES(!m_user_mutex, !m_file_system_mutex);
-
-    // Sets the currently active user.
-    void set_current_user(const std::string& user_id) REQUIRES(!m_user_mutex, !m_file_system_mutex);
-
-    // Removes a user
-    void remove_user(const std::string& user_id) REQUIRES(!m_user_mutex, !m_file_system_mutex);
-
-    // Permanently deletes a user.
-    void delete_user(const std::string& user_id) REQUIRES(!m_user_mutex, !m_file_system_mutex);
-
-    // Get the default path for a Realm for the given configuration.
-    // The default value is `<rootDir>/<appId>/<userId>/<partitionValue>.realm`.
-    // If the file cannot be created at this location, for example due to path length restrictions,
-    // this function may pass back `<rootDir>/<hashedFileName>.realm`
-    std::string path_for_realm(const SyncConfig& config, util::Optional<std::string> custom_file_name = none) const
-        REQUIRES(!m_file_system_mutex);
-
-    // Get the path of the recovery directory for backed-up or recovered Realms.
-    std::string recovery_directory_path(util::Optional<std::string> const& custom_dir_name = none) const
-        REQUIRES(!m_file_system_mutex);
-
     // Reset the singleton state for testing purposes. DO NOT CALL OUTSIDE OF TESTING CODE.
     // Precondition: any synced Realms or `SyncSession`s must be closed or rendered inactive prior to
     // calling this method.
-    void reset_for_testing() REQUIRES(!m_mutex, !m_file_system_mutex, !m_user_mutex, !m_session_mutex);
-
-    // Get the app metadata for the active app.
-    util::Optional<SyncAppMetadata> app_metadata() const REQUIRES(!m_file_system_mutex);
+    void reset_for_testing() REQUIRES(!m_mutex, !m_session_mutex);
 
     // Immediately closes any open sync sessions for this sync manager
     void close_all_sessions() REQUIRES(!m_mutex, !m_session_mutex);
@@ -261,7 +199,7 @@ public:
     // Return the cached logger
     const std::shared_ptr<util::Logger>& get_logger() const REQUIRES(!m_mutex);
 
-    SyncManager();
+    SyncManager(std::shared_ptr<app::App> app, const SyncClientConfig& config);
     SyncManager(const SyncManager&) = delete;
     SyncManager& operator=(const SyncManager&) = delete;
 
@@ -281,10 +219,6 @@ protected:
 private:
     friend class app::App;
 
-    void configure(std::shared_ptr<app::App> app, std::optional<std::string> sync_route,
-                   const SyncClientConfig& config)
-        REQUIRES(!m_mutex, !m_file_system_mutex, !m_user_mutex, !m_session_mutex);
-
     // Stop tracking the session for the given path if it is inactive.
     // No-op if the session is either still active or in the active sessions list
     // due to someone holding a strong reference to it.
@@ -295,33 +229,17 @@ private:
 
     std::shared_ptr<SyncSession> get_existing_session_locked(const std::string& path) const REQUIRES(m_session_mutex);
 
-    std::shared_ptr<SyncUser> get_user_for_identity(std::string const& identity) const noexcept
-        REQUIRES(m_user_mutex);
-
     mutable util::CheckedMutex m_mutex;
 
-    bool run_file_action(SyncFileActionMetadata&) REQUIRES(m_file_system_mutex);
     void init_metadata(SyncClientConfig config, const std::string& app_id);
 
     // internally create a new logger - used by configure() and set_logger_factory()
     void do_make_logger() REQUIRES(m_mutex);
 
-    // Protects m_users
-    mutable util::CheckedMutex m_user_mutex;
-
-    // A vector of all SyncUser objects.
-    std::vector<std::shared_ptr<SyncUser>> m_users GUARDED_BY(m_user_mutex);
-    std::shared_ptr<SyncUser> m_current_user GUARDED_BY(m_user_mutex);
-
     mutable std::unique_ptr<_impl::SyncClient> m_sync_client GUARDED_BY(m_mutex);
 
     SyncClientConfig m_config GUARDED_BY(m_mutex);
     mutable std::shared_ptr<util::Logger> m_logger_ptr GUARDED_BY(m_mutex);
-
-    // Protects m_file_manager and m_metadata_manager
-    mutable util::CheckedMutex m_file_system_mutex;
-    std::unique_ptr<SyncFileManager> m_file_manager GUARDED_BY(m_file_system_mutex);
-    std::unique_ptr<SyncMetadataManager> m_metadata_manager GUARDED_BY(m_file_system_mutex);
 
     // Protects m_sessions
     mutable util::CheckedMutex m_session_mutex;

--- a/src/realm/object-store/sync/sync_session.cpp
+++ b/src/realm/object-store/sync/sync_session.cpp
@@ -441,6 +441,7 @@ void SyncSession::detach_from_sync_manager()
 
 void SyncSession::update_error_and_mark_file_for_deletion(SyncError& error, ShouldBackup should_backup)
 {
+    auto backing_store = user()->app().lock()->backing_store();
     util::CheckedLockGuard config_lock(m_config_mutex);
     // Add a SyncFileActionMetadata marking the Realm as needing to be deleted.
     std::string recovery_path;
@@ -448,16 +449,16 @@ void SyncSession::update_error_and_mark_file_for_deletion(SyncError& error, Shou
     error.user_info[SyncError::c_original_file_path_key] = original_path;
     if (should_backup == ShouldBackup::yes) {
         recovery_path = util::reserve_unique_file_name(
-            m_sync_manager->recovery_directory_path(m_config.sync_config->recovery_directory),
+            backing_store->recovery_directory_path(m_config.sync_config->recovery_directory),
             util::create_timestamped_template("recovered_realm"));
         error.user_info[SyncError::c_recovery_file_path_key] = recovery_path;
     }
     using Action = SyncFileActionMetadata::Action;
     auto action = should_backup == ShouldBackup::yes ? Action::BackUpThenDeleteRealm : Action::DeleteRealm;
-    m_sync_manager->perform_metadata_update([action, original_path = std::move(original_path),
-                                             recovery_path = std::move(recovery_path),
-                                             partition_value = m_config.sync_config->partition_value,
-                                             identity = m_config.sync_config->user->identity()](const auto& manager) {
+    backing_store->perform_metadata_update([action, original_path = std::move(original_path),
+                                            recovery_path = std::move(recovery_path),
+                                            partition_value = m_config.sync_config->partition_value,
+                                            identity = m_config.sync_config->user->identity()](const auto& manager) {
         manager.make_file_action_metadata(original_path, partition_value, identity, action, recovery_path);
     });
 }

--- a/src/realm/object-store/sync/sync_user.hpp
+++ b/src/realm/object-store/sync/sync_user.hpp
@@ -19,10 +19,10 @@
 #ifndef REALM_OS_SYNC_USER_HPP
 #define REALM_OS_SYNC_USER_HPP
 
-#include <realm/object-store/util/atomic_shared_ptr.hpp>
-#include <realm/util/bson/bson.hpp>
 #include <realm/object-store/sync/subscribable.hpp>
+#include <realm/object-store/util/atomic_shared_ptr.hpp>
 
+#include <realm/util/bson/bson.hpp>
 #include <realm/util/checked_mutex.hpp>
 #include <realm/util/optional.hpp>
 #include <realm/table.hpp>
@@ -35,7 +35,9 @@
 
 namespace realm {
 namespace app {
+class App;
 struct AppError;
+class BackingStore;
 class MongoClient;
 } // namespace app
 class SyncManager;
@@ -54,6 +56,8 @@ struct RealmJWT {
     // Custom user data embedded in the encoded token.
     util::Optional<bson::BsonDocument> user_data;
 
+    explicit RealmJWT(std::string_view token);
+    explicit RealmJWT(StringData token);
     explicit RealmJWT(const std::string& token);
     RealmJWT() = default;
 
@@ -162,7 +166,7 @@ struct SyncUserIdentity {
 // A `SyncUser` represents a single user account. Each user manages the sessions that
 // are associated with it.
 class SyncUser : public std::enable_shared_from_this<SyncUser>, public Subscribable<SyncUser> {
-    friend class SyncSession;
+    friend class app::BackingStore; // only this is expected to construct a SyncUser
     struct Private {};
 
 public:
@@ -171,15 +175,6 @@ public:
         LoggedIn,
         Removed,
     };
-
-    // Return a list of all sessions belonging to this user.
-    std::vector<std::shared_ptr<SyncSession>> all_sessions() REQUIRES(!m_mutex);
-
-    // Return a session for a given on disk path.
-    // In most cases, bindings shouldn't expose this to consumers, since the on-disk
-    // path for a synced Realm is an opaque implementation detail. This API is retained
-    // for testing purposes, and for bindings for consumers that are servers or tools.
-    std::shared_ptr<SyncSession> session_for_on_disk_path(const std::string& path) REQUIRES(!m_mutex);
 
     // Log the user out and mark it as such. This will also close its associated Sessions.
     void log_out() REQUIRES(!m_mutex, !m_tokens_mutex);
@@ -211,26 +206,28 @@ public:
     // Custom user data embedded in the access token.
     util::Optional<bson::BsonDocument> custom_data() const REQUIRES(!m_tokens_mutex);
 
-    std::shared_ptr<SyncManager> sync_manager() const REQUIRES(!m_mutex);
+    // Get the app instance that this user belongs to.
+    // This may not lock() if this SyncUser has become detached.
+    std::weak_ptr<app::App> app() const REQUIRES(!m_mutex);
 
     /// Retrieves a general-purpose service client for the Realm Cloud service
     /// @param service_name The name of the cluster
     app::MongoClient mongo_client(const std::string& service_name) REQUIRES(!m_mutex);
 
     // ------------------------------------------------------------------------
-    // All of the following are called by `SyncManager` and are public only for
+    // All of the following are called by `RealmBackingStore` and are public only for
     // testing purposes. SDKs should not call these directly in non-test code
     // or expose them in the public API.
 
-    explicit SyncUser(Private, const std::string& refresh_token, const std::string& id,
-                      const std::string& access_token, const std::string& device_id, SyncManager* sync_manager);
-    explicit SyncUser(Private, const SyncUserMetadata& data, SyncManager* sync_manager);
+    // Don't use this directly; use the `BackingStore` APIs. Public for use with `make_shared`.
+    SyncUser(Private, std::string_view refresh_token, std::string_view id, std::string_view access_token,
+             std::string_view device_id, std::shared_ptr<app::App> app);
+    SyncUser(Private, const SyncUserMetadata& data, std::shared_ptr<app::App> app);
     SyncUser(const SyncUser&) = delete;
     SyncUser& operator=(const SyncUser&) = delete;
 
     // Atomically set the user to be logged in and update both tokens.
-    void log_in(const std::string& access_token, const std::string& refresh_token)
-        REQUIRES(!m_mutex, !m_tokens_mutex);
+    void log_in(std::string_view access_token, std::string_view refresh_token) REQUIRES(!m_mutex, !m_tokens_mutex);
 
     // Atomically set the user to be removed and remove tokens.
     void invalidate() REQUIRES(!m_mutex, !m_tokens_mutex);
@@ -241,12 +238,6 @@ public:
 
     // Update the user's profile and identities.
     void update_user_profile(std::vector<SyncUserIdentity> identities, SyncUserProfile profile) REQUIRES(!m_mutex);
-
-    // Register a session to this user.
-    // A registered session will be bound at the earliest opportunity: either
-    // immediately, or upon the user becoming Active.
-    // Note that this is called by the SyncManager, and should not be directly called.
-    void register_session(std::shared_ptr<SyncSession>) REQUIRES(!m_mutex);
 
     /// Refreshes the custom data for this user
     /// If `update_location` is true, the location metadata will be queried before the request
@@ -266,14 +257,11 @@ public:
         m_seconds_to_adjust_time_for_testing.store(seconds);
     }
 
-protected:
-    friend class SyncManager;
-    void detach_from_sync_manager() REQUIRES(!m_mutex);
+    // FIXME: Not for public use.
+    void detach_from_backing_store() REQUIRES(!m_mutex);
 
 private:
     bool do_is_anonymous() const REQUIRES(m_mutex);
-
-    std::vector<std::shared_ptr<SyncSession>> revive_sessions() REQUIRES(m_mutex);
 
     State m_state GUARDED_BY(m_mutex);
 
@@ -285,13 +273,6 @@ private:
 
     // Set by the server. The unique ID of the user account on the Realm Application.
     const std::string m_identity;
-
-    // Sessions are owned by the SyncManager, but the user keeps a map of weak references
-    // to them.
-    std::unordered_map<std::string, std::weak_ptr<SyncSession>> m_sessions;
-
-    // Waiting sessions are those that should be asked to connect once this user is logged in.
-    std::unordered_map<std::string, std::weak_ptr<SyncSession>> m_waiting_sessions;
 
     mutable util::CheckedMutex m_tokens_mutex;
 
@@ -308,7 +289,7 @@ private:
 
     const std::string m_device_id;
 
-    SyncManager* m_sync_manager;
+    std::weak_ptr<app::App> m_app;
 
     std::atomic<int> m_seconds_to_adjust_time_for_testing = 0;
 };

--- a/test/object-store/CMakeLists.txt
+++ b/test/object-store/CMakeLists.txt
@@ -46,6 +46,7 @@ if(REALM_ENABLE_AUTH_TESTS)
     list(APPEND SOURCES util/sync/baas_admin_api.cpp)
 endif()
 
+
 if(REALM_ENABLE_SYNC)
     list(APPEND HEADERS
         util/sync/baas_admin_api.hpp
@@ -57,6 +58,7 @@ if(REALM_ENABLE_SYNC)
     list(APPEND SOURCES
         bson.cpp
         sync/app.cpp
+        sync/app_backing_store.cpp
         sync/client_reset.cpp
         sync/file.cpp
         sync/flx_migration.cpp

--- a/test/object-store/audit.cpp
+++ b/test/object-store/audit.cpp
@@ -78,7 +78,7 @@ util::Optional<std::string> to_optional_string(StringData sd)
 std::vector<AuditEvent> get_audit_events(TestSyncManager& manager, bool parse_events = true)
 {
     // Wait for all sessions to be fully uploaded and then tear them down
-    auto sync_manager = manager.app()->sync_manager();
+    auto sync_manager = manager.sync_manager();
     REALM_ASSERT(sync_manager);
     auto sessions = sync_manager->get_all_sessions();
     for (auto& session : sessions) {
@@ -1676,7 +1676,7 @@ TEST_CASE("audit integration tests", "[sync][pbs][audit][baas]") {
     auto app_create_config = default_app_config();
     app_create_config.schema = schema;
     app_create_config.dev_mode_enabled = false;
-    TestAppSession session = create_app(app_create_config);
+    TestAppSession session(TestAppSession::Config{create_app(app_create_config)});
 
     SyncTestFile config(session.app()->current_user(), bson::Bson("default"));
     config.schema = schema;
@@ -1734,7 +1734,7 @@ TEST_CASE("audit integration tests", "[sync][pbs][audit][baas]") {
         // Create an app which does not include AuditEvent in the schema so that
         // things will break if audit tries to use it
         app_create_config.schema = no_audit_event_schema;
-        TestAppSession session_2 = create_app(app_create_config);
+        TestAppSession session_2(TestAppSession::Config{create_app(app_create_config)});
         SyncTestFile config(session_2.app()->current_user(), bson::Bson("default"));
         config.schema = no_audit_event_schema;
         config.audit_config = std::make_shared<AuditConfig>();
@@ -1775,7 +1775,7 @@ TEST_CASE("audit integration tests", "[sync][pbs][audit][baas]") {
         auto audit_user = session.app()->current_user();
         config.audit_config->audit_user = audit_user;
         auto realm = Realm::get_shared_realm(config);
-        session.app()->sync_manager()->remove_user(audit_user->identity());
+        session.app()->backing_store()->remove_user(audit_user->identity());
 
         auto audit = realm->audit_context();
         auto scope = audit->begin_scope("scope");
@@ -1793,7 +1793,7 @@ TEST_CASE("audit integration tests", "[sync][pbs][audit][baas]") {
 
     SECTION("AuditEvent missing from server schema") {
         app_create_config.schema = no_audit_event_schema;
-        TestAppSession session_2 = create_app(app_create_config);
+        TestAppSession session_2(TestAppSession::Config{create_app(app_create_config)});
         SyncTestFile config(session_2.app()->current_user(), bson::Bson("default"));
         config.schema = no_audit_event_schema;
         config.audit_config = std::make_shared<AuditConfig>();

--- a/test/object-store/benchmarks/CMakeLists.txt
+++ b/test/object-store/benchmarks/CMakeLists.txt
@@ -23,6 +23,7 @@ if(REALM_ENABLE_SYNC)
     )
     list(APPEND SOURCES
         ../util/sync/sync_test_utils.cpp
+        ../util/unit_test_transport.cpp
         client_reset.cpp
     )
 endif()

--- a/test/object-store/sync/app_backing_store.cpp
+++ b/test/object-store/sync/app_backing_store.cpp
@@ -1,0 +1,332 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2024 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#include "util/sync/baas_admin_api.hpp"
+#include "util/sync/sync_test_utils.hpp"
+#include "util/unit_test_transport.hpp"
+#include <util/sync/flx_sync_harness.hpp>
+
+#include <realm/object-store/impl/object_accessor_impl.hpp>
+#include <realm/object-store/sync/app_backing_store.hpp>
+
+#include <catch2/catch_all.hpp>
+
+using namespace realm;
+using namespace realm::app;
+using namespace std::string_literals;
+
+struct TestBackingStore final : public app::BackingStore {
+
+    TestBackingStore(std::weak_ptr<app::App> parent)
+        : app::BackingStore(parent)
+        , m_file_path_root(util::make_temp_dir())
+    {
+    }
+    virtual ~TestBackingStore()
+    {
+        if (util::File::exists(m_file_path_root)) {
+            util::try_remove_dir_recursive(m_file_path_root);
+        }
+    }
+    std::shared_ptr<SyncUser> get_user(std::string_view user_id, std::string_view refresh_token,
+                                       std::string_view access_token, std::string_view device_id) override
+        REQUIRES(!m_user_mutex)
+    {
+        std::shared_ptr<SyncUser> user;
+        {
+            util::CheckedLockGuard guard(m_user_mutex);
+            auto it = std::find_if(m_users.begin(), m_users.end(), [&](const auto& user) {
+                return user->identity() == user_id && user->state() != SyncUser::State::Removed;
+            });
+            if (it == m_users.end()) {
+                // No existing user.
+                auto new_user = app::BackingStore::make_user(refresh_token, user_id, access_token, device_id,
+                                                             m_parent_app.lock());
+                m_users.emplace(m_users.begin(), new_user);
+                m_current_user = new_user;
+                return new_user;
+            }
+            user = *it;
+        }
+        user->log_in(access_token, refresh_token);
+        return user;
+    }
+    std::shared_ptr<SyncUser> get_existing_logged_in_user(std::string_view user_id) const override
+        REQUIRES(!m_user_mutex)
+    {
+        util::CheckedLockGuard lock(m_user_mutex);
+        auto matcher = [user_id](auto& el) {
+            return el->identity() == user_id && el->state() == SyncUser::State::LoggedIn;
+        };
+        auto it = std::find_if(m_users.begin(), m_users.end(), matcher);
+        return it == m_users.end() ? nullptr : *it;
+    }
+    std::vector<std::shared_ptr<SyncUser>> all_users() override REQUIRES(!m_user_mutex)
+    {
+        util::CheckedLockGuard lock(m_user_mutex);
+        m_users.erase(std::remove_if(m_users.begin(), m_users.end(),
+                                     [](auto& user) {
+                                         bool should_remove = (user->state() == SyncUser::State::Removed);
+                                         if (should_remove) {
+                                             user->detach_from_backing_store();
+                                         }
+                                         return should_remove;
+                                     }),
+                      m_users.end());
+        return m_users;
+    }
+    std::shared_ptr<SyncUser> get_current_user() const override REQUIRES(!m_user_mutex)
+    {
+        util::CheckedLockGuard lock(m_user_mutex);
+        if (m_current_user)
+            return m_current_user;
+        return nullptr;
+    }
+    void log_out_user(const SyncUser& user) override REQUIRES(!m_user_mutex)
+    {
+        util::CheckedLockGuard lock(m_user_mutex);
+        // Move this user to the end of the vector
+        auto user_pos = std::partition(m_users.begin(), m_users.end(), [&](auto& u) {
+            return u.get() != &user;
+        });
+        auto active_user = std::find_if(m_users.begin(), user_pos, [](auto& u) {
+            return u->state() == SyncUser::State::LoggedIn;
+        });
+        if (active_user != user_pos) {
+            m_current_user = *active_user;
+        }
+        else {
+            m_current_user = nullptr;
+        }
+    }
+    void set_current_user(std::string_view user_id) override REQUIRES(!m_user_mutex)
+    {
+        util::CheckedLockGuard lock(m_user_mutex);
+        m_current_user = get_user_for_identity(user_id);
+    }
+    void remove_user(std::string_view user_id) override REQUIRES(!m_user_mutex)
+    {
+        util::CheckedLockGuard lock(m_user_mutex);
+        if (auto user = get_user_for_identity(user_id))
+            user->invalidate();
+    }
+    void delete_user(std::string_view user_id) override REQUIRES(!m_user_mutex)
+    {
+        util::CheckedLockGuard lock(m_user_mutex);
+        auto it = std::find_if(m_users.begin(), m_users.end(), [&user_id](auto& user) {
+            return user->identity() == user_id;
+        });
+        auto user = it == m_users.end() ? nullptr : *it;
+
+        if (!user)
+            return;
+
+        // Deletion should happen immediately, not when we do the cleanup
+        // task on next launch.
+        m_users.erase(it);
+        user->detach_from_backing_store();
+
+        if (m_current_user && m_current_user->identity() == user->identity())
+            m_current_user = nullptr;
+    }
+    void reset_for_testing() override REQUIRES(!m_user_mutex)
+    {
+        // Destroy all the users.
+        util::CheckedLockGuard lock(m_user_mutex);
+        for (auto& user : m_users) {
+            user->detach_from_backing_store();
+        }
+        m_users.clear();
+        m_current_user = nullptr;
+    }
+    bool immediately_run_file_actions(std::string_view) override
+    {
+        // no-op
+        return false;
+    }
+    bool perform_metadata_update(util::FunctionRef<void(SyncMetadataManager&)>) const override
+    {
+        return false;
+    }
+    std::string path_for_realm(std::shared_ptr<SyncUser> user, std::optional<std::string> custom_file_name = none,
+                               std::optional<std::string> partition_value = none) const override
+    {
+        REALM_ASSERT(user);
+        auto file_name = [&]() -> std::string {
+            if (custom_file_name) {
+                return *custom_file_name;
+            }
+            if (!partition_value) {
+                return "flx_sync_default";
+            }
+            return *partition_value;
+        }();
+
+        auto ident = user->identity();
+        auto app_id = user->app().lock()->config().app_id;
+        return util::format("%1/%2/%3/%4", m_file_path_root, app_id, ident, file_name);
+    }
+    std::string audit_path_root(std::shared_ptr<SyncUser> user, std::string_view app_id,
+                                std::string_view partition_prefix) const override
+    {
+        auto ident = user->identity();
+        return util::format("%1/%2/realm-audit/%3/%4", m_file_path_root, app_id, ident, partition_prefix);
+    }
+
+    std::string recovery_directory_path(std::optional<std::string> const& = none) const override
+    {
+        REALM_UNREACHABLE();
+    }
+    std::optional<SyncAppMetadata> app_metadata() const override
+    {
+        return util::none;
+    }
+
+private:
+    std::shared_ptr<SyncUser> get_user_for_identity(std::string_view identity) const noexcept REQUIRES(m_user_mutex)
+    {
+        auto is_active_user = [identity](auto& el) {
+            return el->identity() == identity;
+        };
+        auto it = std::find_if(m_users.begin(), m_users.end(), is_active_user);
+        return it == m_users.end() ? nullptr : *it;
+    }
+
+    // Protects m_users
+    mutable util::CheckedMutex m_user_mutex;
+    // A vector of all SyncUser objects.
+    std::vector<std::shared_ptr<SyncUser>> m_users GUARDED_BY(m_user_mutex);
+    std::shared_ptr<SyncUser> m_current_user GUARDED_BY(m_user_mutex);
+    const std::string m_file_path_root;
+};
+
+TEST_CASE("app: custom backing store without sync", "[app][backing store]") {
+    App::Config config;
+    set_app_config_defaults(config, instance_of<UnitTestTransport>);
+    std::shared_ptr<TestBackingStore> test_store;
+    size_t stores_created = 0;
+    auto factory = [&test_store, &stores_created](SharedApp app) {
+        test_store = std::make_shared<TestBackingStore>(app);
+        ++stores_created;
+        return test_store;
+    };
+    SyncClientConfig sc_config;
+    auto app = App::get_app(app::App::CacheMode::Enabled, config, sc_config, factory);
+    REQUIRE(test_store);
+    constexpr bool reuse_anon = false;
+    auto creds = app::AppCredentials::anonymous(reuse_anon);
+    CHECK(test_store->all_users().size() == 0);
+    CHECK(test_store->get_current_user() == nullptr);
+    std::shared_ptr<SyncUser> user1, user2, user3;
+    app->log_in_with_credentials(creds,
+                                 [&user1](const std::shared_ptr<SyncUser>& user, util::Optional<AppError> err) {
+                                     user1 = user;
+                                     REQUIRE(!err);
+                                 });
+    app->log_in_with_credentials(creds,
+                                 [&user2](const std::shared_ptr<SyncUser>& user, util::Optional<AppError> err) {
+                                     user2 = user;
+                                     REQUIRE(!err);
+                                 });
+    app->log_in_with_credentials(creds,
+                                 [&user3](const std::shared_ptr<SyncUser>& user, util::Optional<AppError> err) {
+                                     user3 = user;
+                                     REQUIRE(!err);
+                                 });
+    CHECK(user3 == test_store->get_current_user());
+    CHECK(user1 == test_store->get_existing_logged_in_user(user1->identity()));
+    REQUIRE(test_store->all_users().size() == 3);
+    CHECK(test_store->all_users()[0] == user3);
+    CHECK(test_store->all_users()[1] == user2);
+    CHECK(test_store->all_users()[2] == user1);
+    app->log_out(user3, [](util::Optional<AppError> err) {
+        REALM_ASSERT(!err);
+    });
+    CHECK(test_store->get_current_user() != user3);
+    app->remove_user(user2, [](util::Optional<AppError> err) {
+        REALM_ASSERT(!err);
+    });
+    CHECK(test_store->get_current_user() == user1);
+    CHECK(test_store->all_users().size() == 1);
+
+    app->delete_user(user1, [](util::Optional<AppError> err) {
+        REALM_ASSERT(!err);
+    });
+    CHECK(test_store->get_current_user() == nullptr);
+    CHECK(test_store->all_users().size() == 0);
+    App::clear_cached_apps();
+    REQUIRE(stores_created == 1);
+}
+
+#if REALM_ENABLE_AUTH_TESTS
+
+TEST_CASE("app: custom backing store with sync", "[app][sync][backing store][baas][flx]") {
+    FLXSyncTestHarness::Config harness_config("flx_custom_backing_store",
+                                              FLXSyncTestHarness::default_server_schema());
+    harness_config.factory = [](SharedApp app) {
+        return std::make_shared<TestBackingStore>(app);
+    };
+    FLXSyncTestHarness harness(std::move(harness_config));
+
+    auto foo_obj_id = ObjectId::gen();
+    auto bar_obj_id = ObjectId::gen();
+    harness.load_initial_data([&](SharedRealm realm) {
+        CppContext c(realm);
+        Object::create(c, realm, "TopLevel",
+                       std::any(AnyDict{{"_id", foo_obj_id},
+                                        {"queryable_str_field", "foo"s},
+                                        {"queryable_int_field", static_cast<int64_t>(5)},
+                                        {"non_queryable_field", "non queryable 1"s}}));
+        Object::create(c, realm, "TopLevel",
+                       std::any(AnyDict{{"_id", bar_obj_id},
+                                        {"queryable_str_field", "bar"s},
+                                        {"queryable_int_field", static_cast<int64_t>(10)},
+                                        {"non_queryable_field", "non queryable 2"s}}));
+    });
+
+    harness.do_with_new_realm([&](SharedRealm realm) {
+        {
+            auto empty_subs = realm->get_latest_subscription_set();
+            CHECK(empty_subs.size() == 0);
+            CHECK(empty_subs.version() == 0);
+            empty_subs.get_state_change_notification(sync::SubscriptionSet::State::Complete).get();
+        }
+
+        auto table = realm->read_group().get_table("class_TopLevel");
+        auto col_key = table->get_column_key("queryable_str_field");
+        Query query_foo(table);
+        query_foo.equal(col_key, "foo");
+        {
+            auto new_subs = realm->get_latest_subscription_set().make_mutable_copy();
+            new_subs.insert_or_assign(query_foo);
+            auto subs = new_subs.commit();
+            subs.get_state_change_notification(sync::SubscriptionSet::State::Complete).get();
+        }
+
+        {
+            wait_for_advance(*realm);
+            Results results(realm, table);
+            CHECK(results.size() == 1);
+            auto obj = results.get<Obj>(0);
+            CHECK(obj.is_valid());
+            CHECK(obj.get<ObjectId>("_id") == foo_obj_id);
+        }
+    });
+}
+
+#endif // REALM_ENABLE_AUTH_TESTS

--- a/test/object-store/sync/client_reset.cpp
+++ b/test/object-store/sync/client_reset.cpp
@@ -326,7 +326,7 @@ TEST_CASE("sync: client reset", "[sync][pbs][client reset][baas]") {
             recovery_path = recovery_path_it->second;
             REQUIRE(util::File::exists(orig_path));
             REQUIRE(!util::File::exists(recovery_path));
-            bool did_reset_files = test_app_session.app()->sync_manager()->immediately_run_file_actions(orig_path);
+            bool did_reset_files = test_app_session.app()->backing_store()->immediately_run_file_actions(orig_path);
             REQUIRE(did_reset_files);
             REQUIRE(!util::File::exists(orig_path));
             REQUIRE(util::File::exists(recovery_path));
@@ -1926,6 +1926,8 @@ TEST_CASE("sync: Client reset during async open", "[sync][pbs][client reset][baa
         }
     });
     auto realm = realm_pf.future.get();
+    REQUIRE(realm);
+    realm->sync_session()->shutdown_and_wait();
     before_callback_called.future.get();
     after_callback_called.future.get();
 }

--- a/test/object-store/sync/session/connection_change_notifications.cpp
+++ b/test/object-store/sync/session/connection_change_notifications.cpp
@@ -53,8 +53,8 @@ TEST_CASE("sync: Connection state changes", "[sync][session][connection change]"
     config.base_path = base_path;
     TestSyncManager init_sync_manager(config);
     auto app = init_sync_manager.app();
-    auto user = app->sync_manager()->get_user("user", ENCODE_FAKE_JWT("not_a_real_token"),
-                                              ENCODE_FAKE_JWT("also_not_a_real_token"), dummy_device_id);
+    auto user = app->backing_store()->get_user("user", ENCODE_FAKE_JWT("not_a_real_token"),
+                                               ENCODE_FAKE_JWT("also_not_a_real_token"), dummy_device_id);
 
     SECTION("register connection change listener") {
         auto session = sync_session(

--- a/test/object-store/sync/session/wait_for_completion.cpp
+++ b/test/object-store/sync/session/wait_for_completion.cpp
@@ -39,13 +39,13 @@ TEST_CASE("SyncSession: wait_for_download_completion() API", "[sync][pbs][sessio
     config.metadata_mode = SyncManager::MetadataMode::NoMetadata;
     TestSyncManager init_sync_manager(config, {false});
     auto& server = init_sync_manager.sync_server();
-    auto sync_manager = init_sync_manager.app()->sync_manager();
+    auto backing_store = init_sync_manager.app()->backing_store();
     std::atomic<bool> handler_called(false);
 
     SECTION("works properly when called after the session is bound") {
         server.start();
-        auto user = sync_manager->get_user("user-async-wait-download-1", ENCODE_FAKE_JWT("not_a_real_token"),
-                                           ENCODE_FAKE_JWT("not_a_real_token"), dummy_device_id);
+        auto user = backing_store->get_user("user-async-wait-download-1", ENCODE_FAKE_JWT("not_a_real_token"),
+                                            ENCODE_FAKE_JWT("not_a_real_token"), dummy_device_id);
         auto session = sync_session(user, "/async-wait-download-1", [](auto, auto) {});
         EventLoop::main().run_until([&] {
             return sessions_are_active(*session);
@@ -62,8 +62,8 @@ TEST_CASE("SyncSession: wait_for_download_completion() API", "[sync][pbs][sessio
     SECTION("works properly when called on a logged-out session") {
         server.start();
         const auto user_id = "user-async-wait-download-3";
-        auto user = sync_manager->get_user(user_id, ENCODE_FAKE_JWT("not_a_real_token"),
-                                           ENCODE_FAKE_JWT("not_a_real_token"), dummy_device_id);
+        auto user = backing_store->get_user(user_id, ENCODE_FAKE_JWT("not_a_real_token"),
+                                            ENCODE_FAKE_JWT("not_a_real_token"), dummy_device_id);
         auto session = sync_session(user, "/user-async-wait-download-3", [](auto, auto) {});
         EventLoop::main().run_until([&] {
             return sessions_are_active(*session);
@@ -80,8 +80,8 @@ TEST_CASE("SyncSession: wait_for_download_completion() API", "[sync][pbs][sessio
         spin_runloop();
         REQUIRE(handler_called == false);
         // Log the user back in
-        user = sync_manager->get_user(user_id, ENCODE_FAKE_JWT("not_a_real_token"),
-                                      ENCODE_FAKE_JWT("not_a_real_token"), dummy_device_id);
+        user = backing_store->get_user(user_id, ENCODE_FAKE_JWT("not_a_real_token"),
+                                       ENCODE_FAKE_JWT("not_a_real_token"), dummy_device_id);
         EventLoop::main().run_until([&] {
             return sessions_are_active(*session);
         });
@@ -92,8 +92,8 @@ TEST_CASE("SyncSession: wait_for_download_completion() API", "[sync][pbs][sessio
     }
 
     SECTION("aborts properly when queued and the session errors out") {
-        auto user = sync_manager->get_user("user-async-wait-download-4", ENCODE_FAKE_JWT("not_a_real_token"),
-                                           ENCODE_FAKE_JWT("not_a_real_token"), dummy_device_id);
+        auto user = backing_store->get_user("user-async-wait-download-4", ENCODE_FAKE_JWT("not_a_real_token"),
+                                            ENCODE_FAKE_JWT("not_a_real_token"), dummy_device_id);
         std::atomic<int> error_count(0);
         std::shared_ptr<SyncSession> session = sync_session(user, "/async-wait-download-4", [&](auto, auto) {
             ++error_count;
@@ -129,13 +129,13 @@ TEST_CASE("SyncSession: wait_for_upload_completion() API", "[sync][pbs][session]
     SyncServer::Config server_config = {false};
     TestSyncManager init_sync_manager(config, server_config);
     auto& server = init_sync_manager.sync_server();
-    auto sync_manager = init_sync_manager.app()->sync_manager();
+    auto backing_store = init_sync_manager.app()->backing_store();
     std::atomic<bool> handler_called(false);
 
     SECTION("works properly when called after the session is bound") {
         server.start();
-        auto user = sync_manager->get_user("user-async-wait-upload-1", ENCODE_FAKE_JWT("not_a_real_token"),
-                                           ENCODE_FAKE_JWT("not_a_real_token"), dummy_device_id);
+        auto user = backing_store->get_user("user-async-wait-upload-1", ENCODE_FAKE_JWT("not_a_real_token"),
+                                            ENCODE_FAKE_JWT("not_a_real_token"), dummy_device_id);
         auto session = sync_session(user, "/async-wait-upload-1", [](auto, auto) {});
         EventLoop::main().run_until([&] {
             return sessions_are_active(*session);
@@ -152,8 +152,8 @@ TEST_CASE("SyncSession: wait_for_upload_completion() API", "[sync][pbs][session]
     SECTION("works properly when called on a logged-out session") {
         server.start();
         const auto user_id = "user-async-wait-upload-3";
-        auto user = sync_manager->get_user(user_id, ENCODE_FAKE_JWT("not_a_real_token"),
-                                           ENCODE_FAKE_JWT("not_a_real_token"), dummy_device_id);
+        auto user = backing_store->get_user(user_id, ENCODE_FAKE_JWT("not_a_real_token"),
+                                            ENCODE_FAKE_JWT("not_a_real_token"), dummy_device_id);
         auto session = sync_session(user, "/user-async-wait-upload-3", [](auto, auto) {});
         EventLoop::main().run_until([&] {
             return sessions_are_active(*session);
@@ -170,8 +170,8 @@ TEST_CASE("SyncSession: wait_for_upload_completion() API", "[sync][pbs][session]
         spin_runloop();
         REQUIRE(handler_called == false);
         // Log the user back in
-        user = sync_manager->get_user(user_id, ENCODE_FAKE_JWT("not_a_real_token"),
-                                      ENCODE_FAKE_JWT("not_a_real_token"), dummy_device_id);
+        user = backing_store->get_user(user_id, ENCODE_FAKE_JWT("not_a_real_token"),
+                                       ENCODE_FAKE_JWT("not_a_real_token"), dummy_device_id);
         EventLoop::main().run_until([&] {
             return sessions_are_active(*session);
         });

--- a/test/object-store/sync/sync_manager.cpp
+++ b/test/object-store/sync/sync_manager.cpp
@@ -55,53 +55,56 @@ bool validate_user_in_vector(std::vector<std::shared_ptr<SyncUser>> vector, cons
 
 TEST_CASE("sync_manager: basic properties and APIs", "[sync][sync manager]") {
     TestSyncManager init_sync_manager;
-    auto app = init_sync_manager.app();
 
     SECTION("should not crash on 'reconnect()'") {
-        app->sync_manager()->reconnect();
+        init_sync_manager.sync_manager()->reconnect();
     }
 }
 
-TEST_CASE("sync_manager: `path_for_realm` API", "[sync][sync manager]") {
+TEST_CASE("RealmBackingStore: `path_for_realm` API", "[sync][backing store]") {
     const std::string raw_url = "realms://realm.example.org/a/b/~/123456/xyz";
 
     SECTION("should work properly without metadata") {
         TestSyncManager tsm(SyncManager::MetadataMode::NoMetadata);
-        auto sync_manager = tsm.app()->sync_manager();
+        auto backing_store = tsm.app()->backing_store();
         const std::string identity = random_string(10);
         auto base_path = fs::path{tsm.base_file_path()}.make_preferred() / "mongodb-realm" / "app_id" / identity;
         const auto expected = base_path / "realms%3A%2F%2Frealm.example.org%2Fa%2Fb%2F%7E%2F123456%2Fxyz.realm";
-        auto user = tsm.app()->sync_manager()->get_user(identity, ENCODE_FAKE_JWT("dummy_token"),
-                                                        ENCODE_FAKE_JWT("not_a_real_token"), dummy_device_id);
+        auto user = backing_store->get_user(identity, ENCODE_FAKE_JWT("dummy_token"),
+                                            ENCODE_FAKE_JWT("not_a_real_token"), dummy_device_id);
         REQUIRE(user->identity() == identity);
         SyncConfig config(user, bson::Bson{});
-        REQUIRE(tsm.app()->sync_manager()->path_for_realm(config, raw_url) == expected);
+        std::optional<std::string> partition =
+            config.flx_sync_requested ? none : std::make_optional(config.partition_value);
+        REQUIRE(backing_store->path_for_realm(config.user, raw_url, partition) == expected);
         // This API should also generate the directory if it doesn't already exist.
         REQUIRE_DIR_PATH_EXISTS(base_path);
     }
 
     SECTION("should work properly with metadata") {
         TestSyncManager tsm(SyncManager::MetadataMode::NoEncryption);
-        auto sync_manager = tsm.app()->sync_manager();
+        auto backing_store = tsm.app()->backing_store();
         const std::string identity = random_string(10);
         auto base_path = fs::path{tsm.base_file_path()}.make_preferred() / "mongodb-realm" / "app_id" / identity;
         const auto expected = base_path / "realms%3A%2F%2Frealm.example.org%2Fa%2Fb%2F%7E%2F123456%2Fxyz.realm";
-        auto user = tsm.app()->sync_manager()->get_user(identity, ENCODE_FAKE_JWT("dummy_token"),
-                                                        ENCODE_FAKE_JWT("not_a_real_token"), dummy_device_id);
+        auto user = backing_store->get_user(identity, ENCODE_FAKE_JWT("dummy_token"),
+                                            ENCODE_FAKE_JWT("not_a_real_token"), dummy_device_id);
         REQUIRE(user->identity() == identity);
         SyncConfig config(user, bson::Bson{});
-        REQUIRE(tsm.app()->sync_manager()->path_for_realm(config, raw_url) == expected);
+        std::optional<std::string> partition =
+            config.flx_sync_requested ? none : std::make_optional(config.partition_value);
+        REQUIRE(backing_store->path_for_realm(config.user, raw_url, partition) == expected);
         // This API should also generate the directory if it doesn't already exist.
         REQUIRE_DIR_PATH_EXISTS(base_path);
     }
 
     SECTION("should produce the expected path for all partition key types") {
         TestSyncManager tsm(SyncManager::MetadataMode::NoMetadata);
-        auto sync_manager = tsm.app()->sync_manager();
+        auto backing_store = tsm.app()->backing_store();
         const std::string identity = random_string(10);
         auto base_path = fs::path{tsm.base_file_path()}.make_preferred() / "mongodb-realm" / "app_id" / identity;
-        auto user = tsm.app()->sync_manager()->get_user(identity, ENCODE_FAKE_JWT("dummy_token"),
-                                                        ENCODE_FAKE_JWT("not_a_real_token"), dummy_device_id);
+        auto user = backing_store->get_user(identity, ENCODE_FAKE_JWT("dummy_token"),
+                                            ENCODE_FAKE_JWT("not_a_real_token"), dummy_device_id);
 
         // Directory should not be created until we get the path
         REQUIRE_DIR_PATH_DOES_NOT_EXIST(base_path);
@@ -109,7 +112,9 @@ TEST_CASE("sync_manager: `path_for_realm` API", "[sync][sync manager]") {
         SECTION("string") {
             const bson::Bson partition("string-partition-value&^#");
             SyncConfig config(user, partition);
-            REQUIRE(sync_manager->path_for_realm(config) == base_path / "s_string-partition-value%26%5E%23.realm");
+
+            REQUIRE(backing_store->path_for_realm(user, none, config.partition_value) ==
+                    base_path / "s_string-partition-value%26%5E%23.realm");
         }
 
         SECTION("string which exceeds the file system path length limit") {
@@ -121,7 +126,7 @@ TEST_CASE("sync_manager: `path_for_realm` API", "[sync][sync manager]") {
             // Note: does not include `identity` as that's in the hashed part
             auto base_path = fs::path{tsm.base_file_path()}.make_preferred() / "mongodb-realm" / "app_id";
             const std::string expected_suffix = ".realm";
-            std::string actual = sync_manager->path_for_realm(config);
+            std::string actual = backing_store->path_for_realm(user, none, config.partition_value);
             size_t expected_length = base_path.string().length() + 1 + 64 + expected_suffix.length();
             REQUIRE(actual.length() == expected_length);
             REQUIRE(StringData(actual).begins_with(base_path.string()));
@@ -131,66 +136,63 @@ TEST_CASE("sync_manager: `path_for_realm` API", "[sync][sync manager]") {
         SECTION("int32") {
             const bson::Bson partition(int32_t(-25));
             SyncConfig config(user, partition);
-            REQUIRE(sync_manager->path_for_realm(config) == base_path / "i_-25.realm");
+            REQUIRE(backing_store->path_for_realm(user, none, config.partition_value) == base_path / "i_-25.realm");
         }
 
         SECTION("int64") {
             const bson::Bson partition(int64_t(1.15e18)); // > 32 bits
             SyncConfig config(user, partition);
-            REQUIRE(sync_manager->path_for_realm(config) == base_path / "l_1150000000000000000.realm");
+            REQUIRE(backing_store->path_for_realm(user, none, config.partition_value) ==
+                    base_path / "l_1150000000000000000.realm");
         }
 
         SECTION("UUID") {
             const bson::Bson partition(UUID("3b241101-e2bb-4255-8caf-4136c566a961"));
             SyncConfig config(user, partition);
-            REQUIRE(sync_manager->path_for_realm(config) ==
+            REQUIRE(backing_store->path_for_realm(user, none, config.partition_value) ==
                     base_path / "u_3b241101-e2bb-4255-8caf-4136c566a961.realm");
         }
 
         SECTION("ObjectId") {
             const bson::Bson partition(ObjectId("0123456789abcdefffffffff"));
             SyncConfig config(user, partition);
-            REQUIRE(sync_manager->path_for_realm(config) == base_path / "o_0123456789abcdefffffffff.realm");
+            REQUIRE(backing_store->path_for_realm(user, none, config.partition_value) ==
+                    base_path / "o_0123456789abcdefffffffff.realm");
         }
 
         SECTION("Null") {
             const bson::Bson partition;
             REQUIRE(partition.type() == bson::Bson::Type::Null);
             SyncConfig config(user, partition);
-            REQUIRE(sync_manager->path_for_realm(config) == base_path / "null.realm");
+            REQUIRE(backing_store->path_for_realm(user, none, config.partition_value) == base_path / "null.realm");
         }
 
         SECTION("Flexible sync") {
-            SyncConfig config(user, SyncConfig::FLXSyncEnabled{});
-            REQUIRE(sync_manager->path_for_realm(config) == base_path / "flx_sync_default.realm");
+            REQUIRE(backing_store->path_for_realm(user) == base_path / "flx_sync_default.realm");
         }
 
         SECTION("Custom filename for Flexible Sync") {
-            SyncConfig config(user, SyncConfig::FLXSyncEnabled{});
-            REQUIRE(sync_manager->path_for_realm(config, util::make_optional<std::string>("custom")) ==
+            REQUIRE(backing_store->path_for_realm(user, util::make_optional<std::string>("custom")) ==
                     base_path / "custom.realm");
         }
 
         SECTION("Custom filename with type will still append .realm") {
-            SyncConfig config(user, SyncConfig::FLXSyncEnabled{});
-            REQUIRE(sync_manager->path_for_realm(config, util::make_optional<std::string>("custom.foo")) ==
+            REQUIRE(backing_store->path_for_realm(user, util::make_optional<std::string>("custom.foo")) ==
                     base_path / "custom.foo.realm");
         }
 
         SECTION("Custom filename for Flexible Sync including .realm") {
-            SyncConfig config(user, SyncConfig::FLXSyncEnabled{});
-            REQUIRE(sync_manager->path_for_realm(config, util::make_optional<std::string>("custom.realm")) ==
+            REQUIRE(backing_store->path_for_realm(user, util::make_optional<std::string>("custom.realm")) ==
                     base_path / "custom.realm");
         }
 
         SECTION("Custom filename for Flexible Sync with an existing path") {
-            SyncConfig config(user, SyncConfig::FLXSyncEnabled{});
-            std::string path = sync_manager->path_for_realm(config, util::make_optional<std::string>("custom.realm"));
+            std::string path = backing_store->path_for_realm(user, util::make_optional<std::string>("custom.realm"));
             realm::test_util::TestPathGuard guard(path);
             realm::util::File existing_realm_file(path, File::mode_Write);
             existing_realm_file.write(std::string("test"));
             existing_realm_file.sync();
-            REQUIRE(sync_manager->path_for_realm(config, util::make_optional<std::string>("custom.realm")) ==
+            REQUIRE(backing_store->path_for_realm(user, util::make_optional<std::string>("custom.realm")) ==
                     base_path / "custom.realm");
         }
 
@@ -199,9 +201,9 @@ TEST_CASE("sync_manager: `path_for_realm` API", "[sync][sync manager]") {
     }
 }
 
-TEST_CASE("sync_manager: user state management", "[sync][sync manager]") {
+TEST_CASE("RealmBackingStore: user state management", "[sync][backing store]") {
     TestSyncManager init_sync_manager(SyncManager::MetadataMode::NoEncryption);
-    auto sync_manager = init_sync_manager.app()->sync_manager();
+    auto backing_store = init_sync_manager.app()->backing_store();
 
     const std::string r_token_1 = ENCODE_FAKE_JWT("foo_token");
     const std::string r_token_2 = ENCODE_FAKE_JWT("bar_token");
@@ -216,20 +218,20 @@ TEST_CASE("sync_manager: user state management", "[sync][sync manager]") {
     const std::string identity_3 = "user-baz";
 
     SECTION("should get all users that are created during run time") {
-        sync_manager->get_user(identity_1, r_token_1, a_token_1, dummy_device_id);
-        sync_manager->get_user(identity_2, r_token_2, a_token_2, dummy_device_id);
-        auto users = sync_manager->all_users();
+        backing_store->get_user(identity_1, r_token_1, a_token_1, dummy_device_id);
+        backing_store->get_user(identity_2, r_token_2, a_token_2, dummy_device_id);
+        auto users = backing_store->all_users();
         REQUIRE(users.size() == 2);
         CHECK(validate_user_in_vector(users, identity_1, r_token_1, a_token_1, dummy_device_id));
         CHECK(validate_user_in_vector(users, identity_2, r_token_2, a_token_2, dummy_device_id));
     }
 
     SECTION("should be able to distinguish users based solely on user ID") {
-        sync_manager->get_user(identity_1, r_token_1, a_token_1, dummy_device_id);
-        sync_manager->get_user(identity_2, r_token_1, a_token_1, dummy_device_id);
-        sync_manager->get_user(identity_3, r_token_1, a_token_1, dummy_device_id);
-        sync_manager->get_user(identity_1, r_token_1, a_token_1, dummy_device_id); // existing
-        auto users = sync_manager->all_users();
+        backing_store->get_user(identity_1, r_token_1, a_token_1, dummy_device_id);
+        backing_store->get_user(identity_2, r_token_1, a_token_1, dummy_device_id);
+        backing_store->get_user(identity_3, r_token_1, a_token_1, dummy_device_id);
+        backing_store->get_user(identity_1, r_token_1, a_token_1, dummy_device_id); // existing
+        auto users = backing_store->all_users();
         REQUIRE(users.size() == 3);
         CHECK(validate_user_in_vector(users, identity_1, r_token_1, a_token_1, dummy_device_id));
         CHECK(validate_user_in_vector(users, identity_2, r_token_1, a_token_1, dummy_device_id));
@@ -240,10 +242,10 @@ TEST_CASE("sync_manager: user state management", "[sync][sync manager]") {
         auto r_token_3a = ENCODE_FAKE_JWT("qwerty");
         auto a_token_3a = ENCODE_FAKE_JWT("ytrewq");
 
-        auto u1 = sync_manager->get_user(identity_1, r_token_1, a_token_1, dummy_device_id);
-        auto u2 = sync_manager->get_user(identity_2, r_token_2, a_token_2, dummy_device_id);
-        auto u3 = sync_manager->get_user(identity_3, r_token_3, a_token_3, dummy_device_id);
-        auto users = sync_manager->all_users();
+        auto u1 = backing_store->get_user(identity_1, r_token_1, a_token_1, dummy_device_id);
+        auto u2 = backing_store->get_user(identity_2, r_token_2, a_token_2, dummy_device_id);
+        auto u3 = backing_store->get_user(identity_3, r_token_3, a_token_3, dummy_device_id);
+        auto users = backing_store->all_users();
         REQUIRE(users.size() == 3);
         CHECK(validate_user_in_vector(users, identity_1, r_token_1, a_token_1, dummy_device_id));
         CHECK(validate_user_in_vector(users, identity_2, r_token_2, a_token_2, dummy_device_id));
@@ -251,38 +253,38 @@ TEST_CASE("sync_manager: user state management", "[sync][sync manager]") {
         // Log out users 1 and 3
         u1->log_out();
         u3->log_out();
-        users = sync_manager->all_users();
+        users = backing_store->all_users();
         REQUIRE(users.size() == 3);
         CHECK(validate_user_in_vector(users, identity_2, r_token_2, a_token_2, dummy_device_id));
         // Log user 3 back in
-        u3 = sync_manager->get_user(identity_3, r_token_3a, a_token_3a, dummy_device_id);
-        users = sync_manager->all_users();
+        u3 = backing_store->get_user(identity_3, r_token_3a, a_token_3a, dummy_device_id);
+        users = backing_store->all_users();
         REQUIRE(users.size() == 3);
         CHECK(validate_user_in_vector(users, identity_2, r_token_2, a_token_2, dummy_device_id));
         CHECK(validate_user_in_vector(users, identity_3, r_token_3a, a_token_3a, dummy_device_id));
         // Log user 2 out
         u2->log_out();
-        users = sync_manager->all_users();
+        users = backing_store->all_users();
         REQUIRE(users.size() == 3);
         CHECK(validate_user_in_vector(users, identity_3, r_token_3a, a_token_3a, dummy_device_id));
     }
 
     SECTION("should return current user that was created during run time") {
-        auto u_null = sync_manager->get_current_user();
+        auto u_null = backing_store->get_current_user();
         REQUIRE(u_null == nullptr);
 
-        auto u1 = sync_manager->get_user(identity_1, r_token_1, a_token_1, dummy_device_id);
-        auto u_current = sync_manager->get_current_user();
+        auto u1 = backing_store->get_user(identity_1, r_token_1, a_token_1, dummy_device_id);
+        auto u_current = backing_store->get_current_user();
         REQUIRE(u_current == u1);
 
-        auto u2 = sync_manager->get_user(identity_2, r_token_2, a_token_2, dummy_device_id);
+        auto u2 = backing_store->get_user(identity_2, r_token_2, a_token_2, dummy_device_id);
         // The current user has switched to return the most recently used: "u2"
-        u_current = sync_manager->get_current_user();
+        u_current = backing_store->get_current_user();
         REQUIRE(u_current == u2);
     }
 }
 
-TEST_CASE("sync_manager: persistent user state management", "[sync][sync manager]") {
+TEST_CASE("RealmBackingStore: persistent user state management", "[sync][backing store]") {
     TestSyncManager::Config config;
     auto app_id = config.app_config.app_id = "app_id-" + random_string(10);
     config.metadata_mode = SyncManager::MetadataMode::NoEncryption;
@@ -324,7 +326,7 @@ TEST_CASE("sync_manager: persistent user state management", "[sync][sync manager
         SECTION("they should be added to the active users list when metadata is enabled") {
             config.metadata_mode = SyncManager::MetadataMode::NoEncryption;
             TestSyncManager tsm(config);
-            auto users = tsm.app()->sync_manager()->all_users();
+            auto users = tsm.app()->all_users();
             REQUIRE(users.size() == 3);
             REQUIRE(validate_user_in_vector(users, identity_1, r_token_1, a_token_1, dummy_device_id));
             REQUIRE(validate_user_in_vector(users, identity_2, r_token_2, a_token_2, dummy_device_id));
@@ -334,7 +336,7 @@ TEST_CASE("sync_manager: persistent user state management", "[sync][sync manager
         SECTION("they should not be added to the active users list when metadata is disabled") {
             config.metadata_mode = SyncManager::MetadataMode::NoMetadata;
             TestSyncManager tsm(config);
-            auto users = tsm.app()->sync_manager()->all_users();
+            auto users = tsm.app()->all_users();
             REQUIRE(users.size() == 0);
         }
     }
@@ -394,12 +396,12 @@ TEST_CASE("sync_manager: persistent user state management", "[sync][sync manager
 
         std::vector<std::string> paths;
         {
-            auto sync_manager = tsm.app()->sync_manager();
+            auto backing_store = tsm.app()->backing_store();
 
             // Pre-populate the user directories.
-            auto user1 = sync_manager->get_user(u1->identity(), r_token_1, a_token_1, dummy_device_id);
-            auto user2 = sync_manager->get_user(u2->identity(), r_token_2, a_token_2, dummy_device_id);
-            auto user3 = sync_manager->get_user(u3->identity(), r_token_3, a_token_3, dummy_device_id);
+            auto user1 = backing_store->get_user(u1->identity(), r_token_1, a_token_1, dummy_device_id);
+            auto user2 = backing_store->get_user(u2->identity(), r_token_2, a_token_2, dummy_device_id);
+            auto user3 = backing_store->get_user(u3->identity(), r_token_3, a_token_3, dummy_device_id);
             for (auto& dir : dirs_to_create) {
                 try_make_dir(dir);
             }
@@ -409,15 +411,19 @@ TEST_CASE("sync_manager: persistent user state management", "[sync][sync manager
                 }
             }
 
-            paths = {sync_manager->path_for_realm(SyncConfig{user1, bson::Bson("123456789")}),
-                     sync_manager->path_for_realm(SyncConfig{user1, bson::Bson("foo")}),
-                     sync_manager->path_for_realm(SyncConfig{user2, bson::Bson("partition")}, {"123456789"}),
-                     sync_manager->path_for_realm(SyncConfig{user3, bson::Bson("foo")}),
-                     sync_manager->path_for_realm(SyncConfig{user3, bson::Bson("bar")}),
-                     sync_manager->path_for_realm(SyncConfig{user3, bson::Bson("baz")})};
+            auto path_for_config = [&](SyncConfig config, std::optional<std::string> custom_name = std::nullopt) {
+                return backing_store->path_for_realm(config.user, custom_name, config.partition_value);
+            };
+
+            paths = {path_for_config(SyncConfig{user1, bson::Bson("123456789")}),
+                     path_for_config(SyncConfig{user1, bson::Bson("foo")}),
+                     path_for_config(SyncConfig{user2, bson::Bson("partition")}, {"123456789"}),
+                     path_for_config(SyncConfig{user3, bson::Bson("foo")}),
+                     path_for_config(SyncConfig{user3, bson::Bson("bar")}),
+                     path_for_config(SyncConfig{user3, bson::Bson("baz")})};
 
             for (auto& test : paths_under_test) {
-                std::string actual = sync_manager->path_for_realm(SyncConfig{user1, test.partition});
+                std::string actual = path_for_config(SyncConfig{user1, test.partition});
                 REQUIRE(actual == test.expected_path);
                 paths.push_back(actual);
             }
@@ -425,8 +431,8 @@ TEST_CASE("sync_manager: persistent user state management", "[sync][sync manager
             for (auto& path : paths) {
                 create_dummy_realm(path);
             }
-            sync_manager->remove_user(u1->identity());
-            sync_manager->remove_user(u2->identity());
+            backing_store->remove_user(u1->identity());
+            backing_store->remove_user(u2->identity());
         }
         for (auto& path : paths) {
             REQUIRE_REALM_EXISTS(path);
@@ -435,7 +441,7 @@ TEST_CASE("sync_manager: persistent user state management", "[sync][sync manager
         config.should_teardown_test_directory = false;
         SECTION("they should be cleaned up if metadata is enabled") {
             TestSyncManager tsm(config);
-            auto users = tsm.app()->sync_manager()->all_users();
+            auto users = tsm.app()->all_users();
             REQUIRE(users.size() == 1);
             REQUIRE(validate_user_in_vector(users, identity_3, r_token_3, a_token_3, dummy_device_id));
             REQUIRE_REALM_DOES_NOT_EXIST(paths[0]);
@@ -453,7 +459,7 @@ TEST_CASE("sync_manager: persistent user state management", "[sync][sync manager
             config.should_teardown_test_directory = true;
             config.metadata_mode = SyncManager::MetadataMode::NoMetadata;
             TestSyncManager tsm(config);
-            auto users = tsm.app()->sync_manager()->all_users();
+            auto users = tsm.app()->all_users();
             for (auto& path : paths) {
                 REQUIRE_REALM_EXISTS(path);
             }
@@ -501,7 +507,7 @@ TEST_CASE("sync_manager: file actions", "[sync][sync manager]") {
         TestSyncManager tsm(config);
         manager.make_file_action_metadata(realm_path_1, realm_url, "user1", Action::DeleteRealm);
 
-        REQUIRE_FALSE(tsm.app()->sync_manager()->immediately_run_file_actions(realm_path_1));
+        REQUIRE_FALSE(tsm.app()->backing_store()->immediately_run_file_actions(realm_path_1));
     }
 #endif
 
@@ -637,7 +643,7 @@ TEST_CASE("sync_manager: file actions", "[sync][sync manager]") {
                                               recovery_1);
             REQUIRE(manager.all_pending_actions().size() == 1);
             // Force the recovery. (In a real application, the user would have closed the files by now.)
-            REQUIRE(tsm.app()->sync_manager()->immediately_run_file_actions(realm_path_4));
+            REQUIRE(tsm.app()->backing_store()->immediately_run_file_actions(realm_path_4));
             // There should be recovery files.
             REQUIRE_REALM_DOES_NOT_EXIST(realm_path_4);
             CHECK(File::exists(recovery_1));
@@ -693,7 +699,7 @@ TEST_CASE("sync_manager: file actions", "[sync][sync manager]") {
             CHECK(File::exists(recovery_3));   // the copy was successful
             CHECK(File::exists(realm_path_3)); // the delete failed
             // try again with proper permissions
-            REQUIRE(tsm.app()->sync_manager()->immediately_run_file_actions(realm_path_3));
+            REQUIRE(tsm.app()->backing_store()->immediately_run_file_actions(realm_path_3));
             REQUIRE(manager.all_pending_actions().size() == 0);
             // Realms should all be deleted.
             REQUIRE_REALM_DOES_NOT_EXIST(realm_path_1);
@@ -731,13 +737,13 @@ TEST_CASE("sync_manager: set_session_multiplexing", "[sync][sync manager]") {
     tsm_config.start_sync_client = false;
     TestSyncManager tsm(std::move(tsm_config));
     bool sync_multiplexing_allowed = GENERATE(true, false);
-    auto sync_manager = tsm.app()->sync_manager();
-    sync_manager->set_session_multiplexing(sync_multiplexing_allowed);
+    auto backing_store = tsm.app()->backing_store();
+    tsm.sync_manager()->set_session_multiplexing(sync_multiplexing_allowed);
 
-    auto user_1 = sync_manager->get_user("user-name-1", ENCODE_FAKE_JWT("not_a_real_token"),
-                                         ENCODE_FAKE_JWT("samesies"), dummy_device_id);
-    auto user_2 = sync_manager->get_user("user-name-2", ENCODE_FAKE_JWT("not_a_real_token"),
-                                         ENCODE_FAKE_JWT("samesies"), dummy_device_id);
+    auto user_1 = backing_store->get_user("user-name-1", ENCODE_FAKE_JWT("not_a_real_token"),
+                                          ENCODE_FAKE_JWT("samesies"), dummy_device_id);
+    auto user_2 = backing_store->get_user("user-name-2", ENCODE_FAKE_JWT("not_a_real_token"),
+                                          ENCODE_FAKE_JWT("samesies"), dummy_device_id);
 
     SyncTestFile file_1(user_1, "partition1", util::none);
     SyncTestFile file_2(user_1, "partition2", util::none);
@@ -764,7 +770,7 @@ TEST_CASE("sync_manager: set_session_multiplexing", "[sync][sync manager]") {
 
 TEST_CASE("sync_manager: has_existing_sessions", "[sync][sync manager][active sessions]") {
     TestSyncManager init_sync_manager({}, {false});
-    auto sync_manager = init_sync_manager.app()->sync_manager();
+    auto sync_manager = init_sync_manager.sync_manager();
 
     SECTION("no active sessions") {
         REQUIRE(!sync_manager->has_existing_sessions());
@@ -780,8 +786,8 @@ TEST_CASE("sync_manager: has_existing_sessions", "[sync][sync manager][active se
 
     std::atomic<bool> error_handler_invoked(false);
     Realm::Config config;
-    auto user = sync_manager->get_user("user-name", ENCODE_FAKE_JWT("not_a_real_token"), ENCODE_FAKE_JWT("samesies"),
-                                       dummy_device_id);
+    auto user = init_sync_manager.app()->backing_store()->get_user("user-name", ENCODE_FAKE_JWT("not_a_real_token"),
+                                                                   ENCODE_FAKE_JWT("samesies"), dummy_device_id);
     auto create_session = [&](SyncSessionStopPolicy stop_policy) {
         std::shared_ptr<SyncSession> session = sync_session(
             user, "/test-dying-state",

--- a/test/object-store/sync/user.cpp
+++ b/test/object-store/sync/user.cpp
@@ -21,7 +21,6 @@
 #include <util/sync/sync_test_utils.hpp>
 
 #include <realm/object-store/sync/app_credentials.hpp>
-#include <realm/object-store/sync/sync_manager.hpp>
 #include <realm/object-store/sync/sync_user.hpp>
 
 #include <realm/util/file.hpp>
@@ -34,15 +33,15 @@ using File = realm::util::File;
 static const std::string base_path = util::make_temp_dir() + "realm_objectstore_sync_user/";
 static const std::string dummy_device_id = "123400000000000000000000";
 
-TEST_CASE("sync_user: SyncManager `get_user()` API", "[sync][user]") {
+TEST_CASE("sync_user: BackingStore `get_user()` API", "[sync][user]") {
     TestSyncManager init_sync_manager;
-    auto sync_manager = init_sync_manager.app()->sync_manager();
+    auto store = init_sync_manager.app()->backing_store();
     const std::string identity = "sync_test_identity";
     const std::string refresh_token = ENCODE_FAKE_JWT("1234567890-fake-refresh-token");
     const std::string access_token = ENCODE_FAKE_JWT("1234567890-fake-access-token");
 
     SECTION("properly creates a new normal user") {
-        auto user = sync_manager->get_user(identity, refresh_token, access_token, dummy_device_id);
+        auto user = store->get_user(identity, refresh_token, access_token, dummy_device_id);
         REQUIRE(user);
         // The expected state for a newly created user:
         REQUIRE(user->identity() == identity);
@@ -55,12 +54,12 @@ TEST_CASE("sync_user: SyncManager `get_user()` API", "[sync][user]") {
         const std::string second_refresh_token = ENCODE_FAKE_JWT("0987654321-fake-refresh-token");
         const std::string second_access_token = ENCODE_FAKE_JWT("0987654321-fake-access-token");
 
-        auto first = sync_manager->get_user(identity, refresh_token, access_token, dummy_device_id);
+        auto first = store->get_user(identity, refresh_token, access_token, dummy_device_id);
         REQUIRE(first);
         REQUIRE(first->identity() == identity);
         REQUIRE(first->refresh_token() == refresh_token);
         // Get the user again, but with a different token.
-        auto second = sync_manager->get_user(identity, second_refresh_token, second_access_token, dummy_device_id);
+        auto second = store->get_user(identity, second_refresh_token, second_access_token, dummy_device_id);
         REQUIRE(second == first);
         REQUIRE(second->identity() == identity);
         REQUIRE(second->access_token() == second_access_token);
@@ -71,12 +70,12 @@ TEST_CASE("sync_user: SyncManager `get_user()` API", "[sync][user]") {
         const std::string second_refresh_token = ENCODE_FAKE_JWT("0987654321-fake-refresh-token");
         const std::string second_access_token = ENCODE_FAKE_JWT("0987654321-fake-access-token");
 
-        auto first = sync_manager->get_user(identity, refresh_token, access_token, dummy_device_id);
+        auto first = store->get_user(identity, refresh_token, access_token, dummy_device_id);
         REQUIRE(first->identity() == identity);
         first->log_out();
         REQUIRE(first->state() == SyncUser::State::LoggedOut);
         // Get the user again, with a new token.
-        auto second = sync_manager->get_user(identity, second_refresh_token, second_access_token, dummy_device_id);
+        auto second = store->get_user(identity, second_refresh_token, second_access_token, dummy_device_id);
         REQUIRE(second == first);
         REQUIRE(second->identity() == identity);
         REQUIRE(second->refresh_token() == second_refresh_token);
@@ -86,14 +85,14 @@ TEST_CASE("sync_user: SyncManager `get_user()` API", "[sync][user]") {
 
 TEST_CASE("sync_user: update state and tokens", "[sync][user]") {
     TestSyncManager init_sync_manager;
-    auto sync_manager = init_sync_manager.app()->sync_manager();
+    auto backing_store = init_sync_manager.app()->backing_store();
     const std::string identity = "sync_test_identity";
     const std::string refresh_token = ENCODE_FAKE_JWT("fake-refresh-token-1");
     const std::string access_token = ENCODE_FAKE_JWT("fake-access-token-1");
     const std::string second_refresh_token = ENCODE_FAKE_JWT("fake-refresh-token-4");
     const std::string second_access_token = ENCODE_FAKE_JWT("fake-access-token-4");
 
-    auto user = sync_manager->get_user(identity, refresh_token, access_token, dummy_device_id);
+    auto user = backing_store->get_user(identity, refresh_token, access_token, dummy_device_id);
     REQUIRE(user->is_logged_in());
     REQUIRE(user->refresh_token() == refresh_token);
 
@@ -114,65 +113,65 @@ TEST_CASE("sync_user: update state and tokens", "[sync][user]") {
 
 TEST_CASE("sync_user: SyncManager get_existing_logged_in_user() API", "[sync][user]") {
     TestSyncManager init_sync_manager(SyncManager::MetadataMode::NoMetadata);
-    auto sync_manager = init_sync_manager.app()->sync_manager();
+    auto backing_store = init_sync_manager.app()->backing_store();
     const std::string identity = "sync_test_identity";
     const std::string refresh_token = ENCODE_FAKE_JWT("1234567890-fake-refresh-token");
     const std::string access_token = ENCODE_FAKE_JWT("1234567890-fake-access-token");
 
     SECTION("properly returns a null pointer when called for a non-existent user") {
-        std::shared_ptr<SyncUser> user = sync_manager->get_existing_logged_in_user(identity);
+        std::shared_ptr<SyncUser> user = backing_store->get_existing_logged_in_user(identity);
         REQUIRE(!user);
     }
 
     SECTION("can get logged-in user from notification") {
-        auto first = sync_manager->get_user(identity, refresh_token, access_token, dummy_device_id);
+        auto first = backing_store->get_user(identity, refresh_token, access_token, dummy_device_id);
         REQUIRE(first->identity() == identity);
         REQUIRE(first->state() == SyncUser::State::LoggedIn);
         REQUIRE(first->device_id() == dummy_device_id);
         bool notification_fired = false;
         auto sub_token = first->subscribe([&](const SyncUser& user) {
-            auto current_user = sync_manager->get_current_user();
+            auto current_user = backing_store->get_current_user();
             REQUIRE(current_user->identity() == identity);
             REQUIRE(current_user->identity() == user.identity());
             notification_fired = true;
         });
 
-        auto second = sync_manager->get_user(identity, refresh_token, access_token, dummy_device_id);
+        auto second = backing_store->get_user(identity, refresh_token, access_token, dummy_device_id);
         second->unsubscribe(sub_token);
         REQUIRE(notification_fired);
     }
 
     SECTION("properly returns an existing logged-in user") {
-        auto first = sync_manager->get_user(identity, refresh_token, access_token, dummy_device_id);
+        auto first = backing_store->get_user(identity, refresh_token, access_token, dummy_device_id);
         REQUIRE(first->identity() == identity);
         REQUIRE(first->state() == SyncUser::State::LoggedIn);
         REQUIRE(first->device_id() == dummy_device_id);
         // Get that user using the 'existing user' API.
-        auto second = sync_manager->get_existing_logged_in_user(identity);
+        auto second = backing_store->get_existing_logged_in_user(identity);
         REQUIRE(second == first);
         REQUIRE(second->refresh_token() == refresh_token);
     }
 
     SECTION("properly returns a null pointer for a logged-out user") {
-        auto first = sync_manager->get_user(identity, refresh_token, access_token, dummy_device_id);
+        auto first = backing_store->get_user(identity, refresh_token, access_token, dummy_device_id);
         first->log_out();
         REQUIRE(first->identity() == identity);
         REQUIRE(first->state() == SyncUser::State::LoggedOut);
         // Get that user using the 'existing user' API.
-        auto second = sync_manager->get_existing_logged_in_user(identity);
+        auto second = backing_store->get_existing_logged_in_user(identity);
         REQUIRE(!second);
     }
 }
 
 TEST_CASE("sync_user: logout", "[sync][user]") {
     TestSyncManager init_sync_manager(SyncManager::MetadataMode::NoMetadata);
-    auto sync_manager = init_sync_manager.app()->sync_manager();
+    auto backing_store = init_sync_manager.app()->backing_store();
     const std::string identity = "sync_test_identity";
     const std::string refresh_token = ENCODE_FAKE_JWT("1234567890-fake-refresh-token");
     const std::string access_token = ENCODE_FAKE_JWT("1234567890-fake-access-token");
 
     SECTION("properly changes the state of the user object") {
-        auto user = sync_manager->get_user(identity, refresh_token, access_token, dummy_device_id);
+        auto user = backing_store->get_user(identity, refresh_token, access_token, dummy_device_id);
         REQUIRE(user->state() == SyncUser::State::LoggedIn);
         user->log_out();
         REQUIRE(user->state() == SyncUser::State::LoggedOut);
@@ -181,7 +180,7 @@ TEST_CASE("sync_user: logout", "[sync][user]") {
 
 TEST_CASE("sync_user: user persistence", "[sync][user]") {
     TestSyncManager tsm(SyncManager::MetadataMode::NoEncryption);
-    auto sync_manager = tsm.app()->sync_manager();
+    auto backing_store = tsm.app()->backing_store();
     auto file_manager = SyncFileManager(tsm.base_file_path(), tsm.app()->config().app_id);
     // Open the metadata separately, so we can investigate it ourselves.
     SyncMetadataManager manager(file_manager.metadata_path(), false);
@@ -191,7 +190,7 @@ TEST_CASE("sync_user: user persistence", "[sync][user]") {
         const std::string refresh_token = ENCODE_FAKE_JWT("r-token-1");
         const std::string access_token = ENCODE_FAKE_JWT("a-token-1");
         const std::vector<SyncUserIdentity> identities{{"12345", "test_case_provider"}};
-        auto user = sync_manager->get_user(identity, refresh_token, access_token, dummy_device_id);
+        auto user = backing_store->get_user(identity, refresh_token, access_token, dummy_device_id);
         user->update_user_profile(identities, {});
         // Now try to pull the user out of the shadow manager directly.
         auto metadata = manager.get_or_make_user_metadata(identity, false);
@@ -208,7 +207,7 @@ TEST_CASE("sync_user: user persistence", "[sync][user]") {
         const std::string refresh_token = ENCODE_FAKE_JWT("r-token-1");
         const std::string access_token = ENCODE_FAKE_JWT("a-token-1");
         const std::vector<SyncUserIdentity> identities{{"12345", "test_case_provider"}};
-        auto user = sync_manager->get_user(identity, refresh_token, access_token, dummy_device_id);
+        auto user = backing_store->get_user(identity, refresh_token, access_token, dummy_device_id);
         user->update_user_profile(identities, {});
         user->log_out();
         // Now try to pull the user out of the shadow manager directly.
@@ -228,13 +227,13 @@ TEST_CASE("sync_user: user persistence", "[sync][user]") {
         const std::string refresh_token = ENCODE_FAKE_JWT("r_token-2a");
         const std::string access_token = ENCODE_FAKE_JWT("a_token-1a");
         // Create the user and validate it.
-        auto first = sync_manager->get_user(identity, refresh_token, access_token, dummy_device_id);
+        auto first = backing_store->get_user(identity, refresh_token, access_token, dummy_device_id);
         auto first_metadata = manager.get_or_make_user_metadata(identity, false);
         REQUIRE(first_metadata->is_valid());
         REQUIRE(first_metadata->access_token() == access_token);
         const std::string token_2 = ENCODE_FAKE_JWT("token-2b");
         // Update the user.
-        auto second = sync_manager->get_user(identity, refresh_token, token_2, dummy_device_id);
+        auto second = backing_store->get_user(identity, refresh_token, token_2, dummy_device_id);
         auto second_metadata = manager.get_or_make_user_metadata(identity, false);
         REQUIRE(second_metadata->is_valid());
         REQUIRE(second_metadata->access_token() == token_2);
@@ -245,7 +244,7 @@ TEST_CASE("sync_user: user persistence", "[sync][user]") {
         const std::string refresh_token = ENCODE_FAKE_JWT("r-token-3");
         const std::string access_token = ENCODE_FAKE_JWT("a-token-3");
         // Create the user and validate it.
-        auto user = sync_manager->get_user(identity, refresh_token, access_token, dummy_device_id);
+        auto user = backing_store->get_user(identity, refresh_token, access_token, dummy_device_id);
         auto marked_users = manager.all_users_marked_for_removal();
         REQUIRE(marked_users.size() == 0);
         // Log out the user.
@@ -259,13 +258,13 @@ TEST_CASE("sync_user: user persistence", "[sync][user]") {
         const std::string refresh_token = ENCODE_FAKE_JWT("r-token-3");
         const std::string access_token = ENCODE_FAKE_JWT("a-token-3");
         // Create the user and validate it.
-        auto user = sync_manager->get_user(identity, refresh_token, access_token, dummy_device_id);
+        auto user = backing_store->get_user(identity, refresh_token, access_token, dummy_device_id);
         user->update_user_profile({{"id", app::IdentityProviderAnonymous}}, {});
         auto marked_users = manager.all_users_marked_for_removal();
         REQUIRE(marked_users.size() == 0);
         // Log out the user.
         user->log_out();
-        REQUIRE(sync_manager->all_users().size() == 0);
+        REQUIRE(backing_store->all_users().size() == 0);
     }
 
     SECTION("properly revives a logged-out user when it's requested again") {
@@ -273,16 +272,16 @@ TEST_CASE("sync_user: user persistence", "[sync][user]") {
         const std::string refresh_token = ENCODE_FAKE_JWT("r-token-4a");
         const std::string access_token = ENCODE_FAKE_JWT("a-token-4a");
         // Create the user and log it out.
-        auto first = sync_manager->get_user(identity, refresh_token, access_token, dummy_device_id);
+        auto first = backing_store->get_user(identity, refresh_token, access_token, dummy_device_id);
         first->log_out();
-        REQUIRE(sync_manager->all_users().size() == 1);
-        REQUIRE(sync_manager->all_users()[0]->state() == SyncUser::State::LoggedOut);
+        REQUIRE(backing_store->all_users().size() == 1);
+        REQUIRE(backing_store->all_users()[0]->state() == SyncUser::State::LoggedOut);
         // Log the user back in.
         const std::string r_token_2 = ENCODE_FAKE_JWT("r-token-4b");
         const std::string a_token_2 = ENCODE_FAKE_JWT("atoken-4b");
-        auto second = sync_manager->get_user(identity, r_token_2, a_token_2, dummy_device_id);
-        REQUIRE(sync_manager->all_users().size() == 1);
-        REQUIRE(sync_manager->all_users()[0]->state() == SyncUser::State::LoggedIn);
+        auto second = backing_store->get_user(identity, r_token_2, a_token_2, dummy_device_id);
+        REQUIRE(backing_store->all_users().size() == 1);
+        REQUIRE(backing_store->all_users()[0]->state() == SyncUser::State::LoggedIn);
     }
 
     SECTION("properly deletes a user") {
@@ -290,12 +289,12 @@ TEST_CASE("sync_user: user persistence", "[sync][user]") {
         const std::string refresh_token = ENCODE_FAKE_JWT("r-token-3");
         const std::string access_token = ENCODE_FAKE_JWT("a-token-3");
         // Create the user and validate it.
-        auto user = sync_manager->get_user(identity, refresh_token, access_token, dummy_device_id);
-        sync_manager->set_current_user(identity);
-        REQUIRE(sync_manager->get_current_user() == user);
-        REQUIRE(sync_manager->all_users().size() == 1);
-        sync_manager->delete_user(user->identity());
-        REQUIRE(sync_manager->all_users().size() == 0);
-        REQUIRE(sync_manager->get_current_user() == nullptr);
+        auto user = backing_store->get_user(identity, refresh_token, access_token, dummy_device_id);
+        backing_store->set_current_user(identity);
+        REQUIRE(backing_store->get_current_user() == user);
+        REQUIRE(backing_store->all_users().size() == 1);
+        backing_store->delete_user(user->identity());
+        REQUIRE(backing_store->all_users().size() == 0);
+        REQUIRE(backing_store->get_current_user() == nullptr);
     }
 }

--- a/test/object-store/util/sync/baas_admin_api.cpp
+++ b/test/object-store/util/sync/baas_admin_api.cpp
@@ -20,12 +20,16 @@
 
 #include <realm/object-store/sync/app_credentials.hpp>
 
+#include <external/json/json.hpp>
 #include <external/mpark/variant.hpp>
 
 #if REALM_ENABLE_AUTH_TESTS
 
 #include <realm/exceptions.hpp>
 #include <realm/object_id.hpp>
+#include <realm/object-store/property.hpp>
+#include <realm/object-store/schema.hpp>
+#include <realm/object-store/sync/generic_network_transport.hpp>
 
 #include <realm/util/scope_exit.hpp>
 

--- a/test/object-store/util/sync/baas_admin_api.hpp
+++ b/test/object-store/util/sync/baas_admin_api.hpp
@@ -18,7 +18,6 @@
 
 #pragma once
 
-#ifdef REALM_ENABLE_SYNC
 #ifdef REALM_ENABLE_AUTH_TESTS
 
 #include <util/sync/sync_test_utils.hpp>
@@ -300,4 +299,3 @@ inline app::App::Config get_config(Factory factory, const AppSession& app_sessio
 } // namespace realm
 
 #endif // REALM_ENABLE_AUTH_TESTS
-#endif // REALM_ENABLE_SYNC

--- a/test/object-store/util/sync/flx_sync_harness.hpp
+++ b/test/object-store/util/sync/flx_sync_harness.hpp
@@ -81,19 +81,22 @@ public:
         std::shared_ptr<GenericNetworkTransport> transport = instance_of<SynchronousTestTransport>;
         ReconnectMode reconnect_mode = ReconnectMode::testing;
         std::shared_ptr<realm::sync::SyncSocketProvider> custom_socket_provider = nullptr;
+        std::optional<app::App::StoreFactory> factory = std::nullopt;
     };
 
     explicit FLXSyncTestHarness(Config&& config)
-        : m_test_session(make_app_from_server_schema(config.test_name, config.server_schema), config.transport, true,
-                         config.reconnect_mode, config.custom_socket_provider)
+        : m_test_session(TestAppSession::Config{make_app_from_server_schema(config.test_name, config.server_schema),
+                                                config.transport, true, config.reconnect_mode,
+                                                config.custom_socket_provider, config.factory})
         , m_schema(std::move(config.server_schema.schema))
     {
     }
     FLXSyncTestHarness(const std::string& test_name, ServerSchema server_schema = default_server_schema(),
                        std::shared_ptr<GenericNetworkTransport> transport = instance_of<SynchronousTestTransport>,
                        std::shared_ptr<realm::sync::SyncSocketProvider> custom_socket_provider = nullptr)
-        : m_test_session(make_app_from_server_schema(test_name, server_schema), std::move(transport), true,
-                         realm::ReconnectMode::normal, custom_socket_provider)
+        : m_test_session(TestAppSession::Config{make_app_from_server_schema(test_name, server_schema),
+                                                std::move(transport), true, realm::ReconnectMode::normal,
+                                                custom_socket_provider})
         , m_schema(std::move(server_schema.schema))
     {
     }

--- a/test/object-store/util/sync/session_util.hpp
+++ b/test/object-store/util/sync/session_util.hpp
@@ -130,7 +130,7 @@ std::shared_ptr<SyncSession> sync_session(
     std::shared_ptr<SyncSession> session;
     {
         auto realm = Realm::get_shared_realm(config);
-        session = user->sync_manager()->get_existing_session(config.path);
+        session = realm->sync_session();
     }
     return session;
 }


### PR DESCRIPTION
This moves much of the App specific functionality
out of the SyncManager interface and redefines the relationships between SyncUser, and Sessions.

This is a simplified version of https://github.com/realm/realm-core/pull/7216:
- no attempt to support a build with AppServices but without Sync
- no movement of PBS tests out of the app.cpp test file.

This is an initial step in the direction of compiling out the AppServices code and allowing SDKs to bring their own user provider.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [x] C-API, if public C++ API changed
* [x] `bindgen/spec.yml`, if public C++ API changed
