### PR TITLE
Assorted sync metadata storage refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Fixed invalid data in error reason string when registering a subscription change notification after the subscription has already failed. ([#6839](https://github.com/realm/realm-core/issues/6839), since v11.8.0)
 * Fixed crash in fulltext index using prefix search with no matches ([#7309](https://github.com/realm/realm-core/issues/7309), since v13.18.0)
 * Fix compilation and some warnings when building with Xcode 15.3 ([PR #7297](https://github.com/realm/realm-core/pull/7297)).
+* util::make_dir_recursive() attempted to create a directory named "\0" if the path did not have a trailing slash ([PR #7329](https://github.com/realm/realm-core/pull/7329)).
  
 ### Breaking changes
 * None.

--- a/src/realm/db.hpp
+++ b/src/realm/db.hpp
@@ -482,7 +482,7 @@ private:
     class ReadLockGuard;
 
     // Member variables
-    mutable util::CheckedMutex m_mutex;
+    util::CheckedMutex m_mutex;
     int m_transaction_count GUARDED_BY(m_mutex) = 0;
     SlabAlloc m_alloc;
     std::unique_ptr<Replication> m_history;

--- a/src/realm/obj.cpp
+++ b/src/realm/obj.cpp
@@ -898,11 +898,9 @@ void out_string(std::ostream& out, std::string str)
 
 void out_binary(std::ostream& out, BinaryData bin)
 {
-    const char* start = bin.data();
-    const size_t len = bin.size();
     std::string encode_buffer;
-    encode_buffer.resize(util::base64_encoded_size(len));
-    util::base64_encode(start, len, encode_buffer.data(), encode_buffer.size());
+    encode_buffer.resize(util::base64_encoded_size(bin.size()));
+    util::base64_encode(bin, encode_buffer);
     out << encode_buffer;
 }
 

--- a/src/realm/object-store/CMakeLists.txt
+++ b/src/realm/object-store/CMakeLists.txt
@@ -92,20 +92,21 @@ set(HEADERS
 if(REALM_ENABLE_SYNC)
     list(APPEND HEADERS
         sync/app.hpp
-        sync/app_utils.hpp
         sync/app_credentials.hpp
-        sync/generic_network_transport.hpp
-        sync/async_open_task.hpp
-        sync/sync_manager.hpp
-        sync/sync_session.hpp
-        sync/sync_user.hpp
         sync/app_service_client.hpp
+        sync/app_utils.hpp
+        sync/async_open_task.hpp
         sync/auth_request_client.hpp
+        sync/generic_network_transport.hpp
+        sync/jwt.hpp
         sync/mongo_client.hpp
         sync/mongo_collection.hpp
         sync/mongo_database.hpp
         sync/push_client.hpp
         sync/subscribable.hpp
+        sync/sync_manager.hpp
+        sync/sync_session.hpp
+        sync/sync_user.hpp
 
         sync/impl/sync_client.hpp
         sync/impl/sync_file.hpp
@@ -114,19 +115,20 @@ if(REALM_ENABLE_SYNC)
 
     list(APPEND SOURCES
         sync/app.cpp
-        sync/app_utils.cpp
         sync/app_credentials.cpp
-        sync/generic_network_transport.cpp
+        sync/app_utils.cpp
         sync/async_open_task.cpp
-        sync/sync_manager.cpp
-        sync/sync_session.cpp
-        sync/sync_user.cpp
+        sync/generic_network_transport.cpp
+        sync/impl/sync_file.cpp
+        sync/impl/sync_metadata.cpp
+        sync/jwt.cpp
         sync/mongo_client.cpp
         sync/mongo_collection.cpp
         sync/mongo_database.cpp
         sync/push_client.cpp
-        sync/impl/sync_file.cpp
-        sync/impl/sync_metadata.cpp)
+        sync/sync_manager.cpp
+        sync/sync_session.cpp
+        sync/sync_user.cpp)
     if(APPLE)
         list(APPEND HEADERS
             sync/impl/apple/network_reachability_observer.hpp

--- a/src/realm/object-store/c_api/app.cpp
+++ b/src/realm/object-store/c_api/app.cpp
@@ -121,7 +121,7 @@ static inline bson::BsonArray parse_ejson_array(const char* serialized)
         return {};
     }
     else {
-        return bson::BsonArray(bson::parse(serialized));
+        return bson::BsonArray(bson::parse({serialized, strlen(serialized)}));
     }
 }
 

--- a/src/realm/object-store/impl/realm_coordinator.hpp
+++ b/src/realm/object-store/impl/realm_coordinator.hpp
@@ -233,7 +233,7 @@ private:
     Realm::Config m_config;
     std::shared_ptr<DB> m_db;
 
-    mutable util::CheckedMutex m_schema_cache_mutex;
+    util::CheckedMutex m_schema_cache_mutex;
     util::Optional<Schema> m_cached_schema GUARDED_BY(m_schema_cache_mutex);
     uint64_t m_schema_version GUARDED_BY(m_schema_cache_mutex) = -1;
     uint64_t m_schema_transaction_version_min GUARDED_BY(m_schema_cache_mutex) = 0;

--- a/src/realm/object-store/sync/app.cpp
+++ b/src/realm/object-store/sync/app.cpp
@@ -1344,7 +1344,7 @@ Request App::make_streaming_request(const std::shared_ptr<SyncUser>& user, const
     const auto args_json = Bson(args).to_string();
 
     auto args_base64 = std::string(util::base64_encoded_size(args_json.size()), '\0');
-    util::base64_encode(args_json.data(), args_json.size(), args_base64.data(), args_base64.size());
+    util::base64_encode(args_json, args_base64);
 
     auto url = function_call_url_path() + "?baas_request=" + util::uri_percent_encode(args_base64);
     if (user) {

--- a/src/realm/object-store/sync/app.hpp
+++ b/src/realm/object-store/sync/app.hpp
@@ -433,11 +433,9 @@ public:
     std::string get_ws_host_url() REQUIRES(!m_route_mutex);
 
 private:
-    // Local copy of app config
-    Config m_config;
+    const Config m_config;
 
-    // mutable to allow locking for reads in const functions
-    mutable util::CheckedMutex m_route_mutex;
+    util::CheckedMutex m_route_mutex;
 
     // The following variables hold the different paths to Atlas, depending on the
     // request being performed

--- a/src/realm/object-store/sync/app.hpp
+++ b/src/realm/object-store/sync/app.hpp
@@ -39,7 +39,6 @@ class SyncUser;
 class SyncSession;
 class SyncManager;
 struct SyncClientConfig;
-class SyncAppMetadata;
 
 namespace app {
 

--- a/src/realm/object-store/sync/async_open_task.hpp
+++ b/src/realm/object-store/sync/async_open_task.hpp
@@ -76,7 +76,7 @@ private:
     std::shared_ptr<_impl::RealmCoordinator> m_coordinator GUARDED_BY(m_mutex);
     std::shared_ptr<SyncSession> m_session GUARDED_BY(m_mutex);
     std::vector<uint64_t> m_registered_callbacks GUARDED_BY(m_mutex);
-    mutable util::CheckedMutex m_mutex;
+    util::CheckedMutex m_mutex;
     const bool m_db_first_open;
 };
 

--- a/src/realm/object-store/sync/impl/sync_metadata.hpp
+++ b/src/realm/object-store/sync/impl/sync_metadata.hpp
@@ -25,7 +25,6 @@
 
 #include <realm/obj.hpp>
 #include <realm/table.hpp>
-#include <realm/util/optional.hpp>
 #include <string>
 
 namespace realm {

--- a/src/realm/object-store/sync/impl/sync_metadata.hpp
+++ b/src/realm/object-store/sync/impl/sync_metadata.hpp
@@ -207,6 +207,8 @@ class SyncMetadataManager {
     friend class SyncFileActionMetadata;
 
 public:
+    std::vector<SyncUserMetadata> all_logged_in_users() const;
+
     // Return a Results object containing all users not marked for removal.
     SyncUserMetadataResults all_unmarked_users() const;
 

--- a/src/realm/object-store/sync/impl/sync_metadata.hpp
+++ b/src/realm/object-store/sync/impl/sync_metadata.hpp
@@ -29,6 +29,7 @@
 #include <string>
 
 namespace realm {
+class SyncFileManager;
 class SyncMetadataManager;
 
 // A facade for a metadata Realm object representing a sync user.
@@ -192,6 +193,9 @@ class SyncMetadataManager {
 public:
     std::vector<SyncUserMetadata> all_logged_in_users() const;
 
+    // Perform all pending file actions and delete any remaining data for removed users.
+    void perform_launch_actions(SyncFileManager& file_manager) const;
+
     // Return a Results object containing all users not marked for removal.
     SyncUserMetadataResults all_unmarked_users() const;
 
@@ -210,6 +214,8 @@ public:
 
     // Retrieve file action metadata.
     util::Optional<SyncFileActionMetadata> get_file_action_metadata(StringData path) const;
+    // Perform any stored file actions for the given path.
+    bool perform_file_actions(SyncFileManager& file_manager, StringData path) const;
 
     // Create file action metadata.
     void make_file_action_metadata(StringData original_name, StringData partition_key_value, StringData local_uuid,
@@ -235,6 +241,8 @@ private:
     std::shared_ptr<Realm> get_realm() const;
     std::shared_ptr<Realm> try_get_realm() const;
     std::shared_ptr<Realm> open_realm(bool should_encrypt, bool caller_supplied_key);
+
+    bool run_file_action(SyncFileManager& file_manager, SyncFileActionMetadata& md) const;
 };
 
 } // namespace realm

--- a/src/realm/object-store/sync/impl/sync_metadata.hpp
+++ b/src/realm/object-store/sync/impl/sync_metadata.hpp
@@ -31,23 +31,6 @@
 namespace realm {
 class SyncMetadataManager;
 
-// A facade for a metadata Realm object representing app metadata
-class SyncAppMetadata {
-public:
-    struct Schema {
-        ColKey id_col;
-        ColKey deployment_model_col;
-        ColKey location_col;
-        ColKey hostname_col;
-        ColKey ws_hostname_col;
-    };
-
-    std::string deployment_model;
-    std::string location;
-    std::string hostname;
-    std::string ws_hostname;
-};
-
 // A facade for a metadata Realm object representing a sync user.
 class SyncUserMetadata {
 public:
@@ -235,17 +218,6 @@ public:
     util::Optional<std::string> get_current_user_identity() const;
     void set_current_user_identity(const std::string& identity);
 
-    util::Optional<SyncAppMetadata> get_app_metadata();
-    /// Set or update the cached app server metadata. The metadata will not be updated if it has already been
-    /// set and the provided values are not different than the cached information. Returns true if the metadata
-    /// was updated.
-    /// @param deployment_model The deployment model reported by the app server
-    /// @param location The location name where the app server is located
-    /// @param hostname The hostname to use for the app server admin api
-    /// @param ws_hostname The hostname to use for the app server websocket connections
-    bool set_app_metadata(const std::string& deployment_model, const std::string& location,
-                          const std::string& hostname, const std::string& ws_hostname);
-
     /// Construct the metadata manager.
     ///
     /// If the platform supports it, setting `should_encrypt` to `true` and not specifying an encryption key will make
@@ -259,14 +231,10 @@ private:
     Realm::Config m_metadata_config;
     SyncUserMetadata::Schema m_user_schema;
     SyncFileActionMetadata::Schema m_file_action_schema;
-    SyncAppMetadata::Schema m_app_metadata_schema;
 
     std::shared_ptr<Realm> get_realm() const;
     std::shared_ptr<Realm> try_get_realm() const;
     std::shared_ptr<Realm> open_realm(bool should_encrypt, bool caller_supplied_key);
-
-
-    util::Optional<SyncAppMetadata> m_app_metadata;
 };
 
 } // namespace realm

--- a/src/realm/object-store/sync/jwt.cpp
+++ b/src/realm/object-store/sync/jwt.cpp
@@ -1,0 +1,89 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2024 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#include <realm/object-store/sync/jwt.hpp>
+
+#include <realm/object-store/sync/generic_network_transport.hpp>
+#include <realm/util/base64.hpp>
+
+namespace realm {
+
+static std::string_view split_token(std::string_view jwt) noexcept
+{
+    constexpr static char delimiter = '.';
+
+    auto pos = jwt.find(delimiter);
+    if (pos == 0 || pos == jwt.npos) {
+        return {};
+    }
+    jwt = jwt.substr(pos + 1);
+
+    pos = jwt.find(delimiter);
+    if (pos == jwt.npos) {
+        return {};
+    }
+    auto payload = jwt.substr(0, pos);
+    jwt = jwt.substr(pos + 1);
+
+    // We don't use the signature, but verify one is present
+    if (jwt.size() == 0 || std::count(jwt.begin(), jwt.end(), '.') != 0) {
+        return {};
+    }
+
+    return payload;
+}
+
+RealmJWT::RealmJWT(std::string_view token)
+{
+    auto payload = split_token(token);
+    if (!payload.data()) {
+        throw app::AppError(ErrorCodes::BadToken, "malformed JWT");
+    }
+
+    auto json_str = util::base64_decode_to_vector(payload);
+    if (!json_str) {
+        throw app::AppError(ErrorCodes::BadToken, "JWT payload could not be base64 decoded");
+    }
+
+    auto json = static_cast<bson::BsonDocument>(bson::parse(*json_str));
+
+    this->token = token;
+    this->expires_at = static_cast<int64_t>(json["exp"]);
+    this->issued_at = static_cast<int64_t>(json["iat"]);
+
+    if (json.find("user_data") != json.end()) {
+        this->user_data = static_cast<bson::BsonDocument>(json["user_data"]);
+    }
+}
+
+bool RealmJWT::validate(std::string_view token)
+{
+    auto payload = split_token(token);
+    if (!payload.data()) {
+        return false;
+    }
+
+    auto json_str = util::base64_decode_to_vector(payload);
+    if (!json_str) {
+        return false;
+    }
+
+    return bson::accept(*json_str);
+}
+
+} // namespace realm

--- a/src/realm/object-store/sync/jwt.hpp
+++ b/src/realm/object-store/sync/jwt.hpp
@@ -1,0 +1,66 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2024 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#ifndef REALM_OS_JWT_HPP
+#define REALM_OS_JWT_HPP
+
+#include <realm/util/bson/bson.hpp>
+
+#include <optional>
+#include <string>
+
+namespace realm {
+// A struct that decodes a given JWT.
+struct RealmJWT {
+    // The raw encoded token
+    std::string token;
+
+    // When the token expires.
+    int64_t expires_at = 0;
+    // When the token was issued.
+    int64_t issued_at = 0;
+    // Custom user data embedded in the encoded token.
+    std::optional<bson::BsonDocument> user_data;
+
+    RealmJWT() = default;
+    explicit RealmJWT(std::string_view token);
+    explicit RealmJWT(const std::string& token)
+        : RealmJWT(std::string_view(token))
+    {
+    }
+
+    static bool validate(std::string_view token);
+
+    bool operator==(const RealmJWT& other) const noexcept
+    {
+        return token == other.token;
+    }
+    bool operator!=(const RealmJWT& other) const noexcept
+    {
+        return token != other.token;
+    }
+
+    explicit operator bool() const noexcept
+    {
+        return !token.empty();
+    }
+};
+
+} // namespace realm
+
+#endif // REALM_OS_JWT_HPP

--- a/src/realm/object-store/sync/sync_manager.cpp
+++ b/src/realm/object-store/sync/sync_manager.cpp
@@ -101,14 +101,8 @@ void SyncManager::configure(std::shared_ptr<app::App> app, std::optional<std::st
             }
 
             // Load persisted users into the users map.
-            SyncUserMetadataResults users = m_metadata_manager->all_unmarked_users();
-            for (size_t i = 0; i < users.size(); i++) {
-                auto user_data = users.get(i);
-                auto refresh_token = user_data.refresh_token();
-                auto access_token = user_data.access_token();
-                if (!refresh_token.empty() && !access_token.empty()) {
-                    users_to_add.push_back(std::make_shared<SyncUser>(SyncUser::Private(), user_data, this));
-                }
+            for (auto user : m_metadata_manager->all_logged_in_users()) {
+                users_to_add.push_back(std::make_shared<SyncUser>(SyncUser::Private(), user, this));
             }
 
             // Delete any users marked for death.

--- a/src/realm/object-store/sync/sync_manager.cpp
+++ b/src/realm/object-store/sync/sync_manager.cpp
@@ -743,15 +743,6 @@ std::unique_ptr<SyncClient> SyncManager::create_sync_client() const
     return std::make_unique<SyncClient>(m_logger_ptr, m_config, weak_from_this());
 }
 
-util::Optional<SyncAppMetadata> SyncManager::app_metadata() const
-{
-    util::CheckedLockGuard lock(m_file_system_mutex);
-    if (!m_metadata_manager) {
-        return util::none;
-    }
-    return m_metadata_manager->get_app_metadata();
-}
-
 void SyncManager::close_all_sessions()
 {
     // log_out() will call unregister_session(), which requires m_session_mutex,

--- a/src/realm/object-store/sync/sync_manager.hpp
+++ b/src/realm/object-store/sync/sync_manager.hpp
@@ -297,7 +297,6 @@ private:
 
     mutable util::CheckedMutex m_mutex;
 
-    bool run_file_action(SyncFileActionMetadata&) REQUIRES(m_file_system_mutex);
     void init_metadata(SyncClientConfig config, const std::string& app_id);
 
     // internally create a new logger - used by configure() and set_logger_factory()

--- a/src/realm/object-store/sync/sync_manager.hpp
+++ b/src/realm/object-store/sync/sync_manager.hpp
@@ -44,7 +44,6 @@ class SyncUser;
 class SyncFileManager;
 class SyncMetadataManager;
 class SyncFileActionMetadata;
-class SyncAppMetadata;
 
 namespace _impl {
 struct SyncClient;
@@ -221,8 +220,6 @@ public:
     // calling this method.
     void reset_for_testing() REQUIRES(!m_mutex, !m_file_system_mutex, !m_user_mutex, !m_session_mutex);
 
-    // Get the app metadata for the active app.
-    util::Optional<SyncAppMetadata> app_metadata() const REQUIRES(!m_file_system_mutex);
 
     // Immediately closes any open sync sessions for this sync manager
     void close_all_sessions() REQUIRES(!m_mutex, !m_session_mutex);

--- a/src/realm/object-store/sync/sync_manager.hpp
+++ b/src/realm/object-store/sync/sync_manager.hpp
@@ -295,7 +295,7 @@ private:
     std::shared_ptr<SyncUser> get_user_for_identity(std::string const& identity) const noexcept
         REQUIRES(m_user_mutex);
 
-    mutable util::CheckedMutex m_mutex;
+    util::CheckedMutex m_mutex;
 
     void init_metadata(SyncClientConfig config, const std::string& app_id);
 
@@ -303,7 +303,7 @@ private:
     void do_make_logger() REQUIRES(m_mutex);
 
     // Protects m_users
-    mutable util::CheckedMutex m_user_mutex;
+    util::CheckedMutex m_user_mutex;
 
     // A vector of all SyncUser objects.
     std::vector<std::shared_ptr<SyncUser>> m_users GUARDED_BY(m_user_mutex);
@@ -315,12 +315,12 @@ private:
     mutable std::shared_ptr<util::Logger> m_logger_ptr GUARDED_BY(m_mutex);
 
     // Protects m_file_manager and m_metadata_manager
-    mutable util::CheckedMutex m_file_system_mutex;
+    util::CheckedMutex m_file_system_mutex;
     std::unique_ptr<SyncFileManager> m_file_manager GUARDED_BY(m_file_system_mutex);
     std::unique_ptr<SyncMetadataManager> m_metadata_manager GUARDED_BY(m_file_system_mutex);
 
     // Protects m_sessions
-    mutable util::CheckedMutex m_session_mutex;
+    util::CheckedMutex m_session_mutex;
 
     // Map of sessions by path name.
     // Sessions remove themselves from this map by calling `unregister_session` once they're

--- a/src/realm/object-store/sync/sync_session.hpp
+++ b/src/realm/object-store/sync/sync_session.hpp
@@ -446,8 +446,8 @@ private:
     // Return the subscription_store_base - to be used only for testing
     std::shared_ptr<sync::SubscriptionStore> get_subscription_store_base() REQUIRES(!m_state_mutex);
 
-    mutable util::CheckedMutex m_state_mutex;
-    mutable util::CheckedMutex m_connection_state_mutex;
+    util::CheckedMutex m_state_mutex;
+    util::CheckedMutex m_connection_state_mutex;
 
     State m_state GUARDED_BY(m_state_mutex) = State::Inactive;
 
@@ -457,7 +457,7 @@ private:
     ConnectionState m_connection_state GUARDED_BY(m_connection_state_mutex) = ConnectionState::Disconnected;
     size_t m_death_count GUARDED_BY(m_state_mutex) = 0;
 
-    mutable util::CheckedMutex m_config_mutex;
+    util::CheckedMutex m_config_mutex;
     RealmConfig m_config GUARDED_BY(m_config_mutex);
     const std::shared_ptr<DB> m_db;
     // The subscription store base is lazily created when needed, but never destroyed
@@ -492,7 +492,7 @@ private:
     _impl::SyncProgressNotifier m_progress_notifier;
     ConnectionChangeNotifier m_connection_change_notifier;
 
-    mutable util::CheckedMutex m_external_reference_mutex;
+    util::CheckedMutex m_external_reference_mutex;
     class ExternalReference;
     std::weak_ptr<ExternalReference> m_external_reference GUARDED_BY(m_external_reference_mutex);
 

--- a/src/realm/object-store/sync/sync_user.cpp
+++ b/src/realm/object-store/sync/sync_user.cpp
@@ -65,14 +65,7 @@ SyncUser::SyncUser(Private, const SyncUserMetadata& data, SyncManager* sync_mana
     , m_device_id(data.device_id())
     , m_sync_manager(sync_manager)
 {
-    // Check for inconsistent state in the metadata Realm. This shouldn't happen,
-    // but previous versions could sometimes mark a user as logged in with an
-    // empty refresh token.
-    if (m_state == State::LoggedIn && (m_refresh_token.token.empty() || m_access_token.token.empty())) {
-        m_state = State::LoggedOut;
-        m_refresh_token = {};
-        m_access_token = {};
-    }
+    REALM_ASSERT(m_state == State::LoggedIn && !m_access_token.token.empty() && !m_refresh_token.token.empty());
 }
 
 std::shared_ptr<SyncManager> SyncUser::sync_manager() const

--- a/src/realm/object-store/sync/sync_user.hpp
+++ b/src/realm/object-store/sync/sync_user.hpp
@@ -19,13 +19,10 @@
 #ifndef REALM_OS_SYNC_USER_HPP
 #define REALM_OS_SYNC_USER_HPP
 
-#include <realm/object-store/util/atomic_shared_ptr.hpp>
-#include <realm/util/bson/bson.hpp>
+#include <realm/object-store/sync/jwt.hpp>
 #include <realm/object-store/sync/subscribable.hpp>
-
+#include <realm/util/bson/bson.hpp>
 #include <realm/util/checked_mutex.hpp>
-#include <realm/util/optional.hpp>
-#include <realm/table.hpp>
 
 #include <memory>
 #include <mutex>
@@ -41,27 +38,6 @@ class MongoClient;
 class SyncManager;
 class SyncSession;
 class SyncUserMetadata;
-
-// A struct that decodes a given JWT.
-struct RealmJWT {
-    // The token being decoded from.
-    std::string token;
-
-    // When the token expires.
-    int64_t expires_at = 0;
-    // When the token was issued.
-    int64_t issued_at = 0;
-    // Custom user data embedded in the encoded token.
-    util::Optional<bson::BsonDocument> user_data;
-
-    explicit RealmJWT(const std::string& token);
-    RealmJWT() = default;
-
-    bool operator==(const RealmJWT& other) const
-    {
-        return token == other.token;
-    }
-};
 
 struct SyncUserProfile {
     // The full name of the user.

--- a/src/realm/object-store/sync/sync_user.hpp
+++ b/src/realm/object-store/sync/sync_user.hpp
@@ -257,7 +257,7 @@ private:
     // used to locate existing files.
     std::vector<std::string> m_legacy_identities;
 
-    mutable util::CheckedMutex m_mutex;
+    util::CheckedMutex m_mutex;
 
     // Set by the server. The unique ID of the user account on the Realm Application.
     const std::string m_identity;
@@ -269,7 +269,7 @@ private:
     // Waiting sessions are those that should be asked to connect once this user is logged in.
     std::unordered_map<std::string, std::weak_ptr<SyncSession>> m_waiting_sessions;
 
-    mutable util::CheckedMutex m_tokens_mutex;
+    util::CheckedMutex m_tokens_mutex;
 
     // The user's refresh token.
     RealmJWT m_refresh_token GUARDED_BY(m_tokens_mutex);

--- a/src/realm/parser/driver.cpp
+++ b/src/realm/parser/driver.cpp
@@ -1274,7 +1274,7 @@ std::unique_ptr<Subexpr> ConstantNode::visit(ParserDriver* drv, DataType hint)
             size_t buffer_size = util::base64_decoded_size(encoded_size);
             std::string decode_buffer(buffer_size, char(0));
             StringData window(text.c_str() + 4, encoded_size);
-            util::Optional<size_t> decoded_size = util::base64_decode(window, decode_buffer.data(), buffer_size);
+            util::Optional<size_t> decoded_size = util::base64_decode(window, decode_buffer);
             if (!decoded_size) {
                 throw SyntaxError("Invalid base64 value");
             }

--- a/src/realm/sync/network/websocket.cpp
+++ b/src/realm/sync/network/websocket.cpp
@@ -45,7 +45,7 @@ std::string make_random_sec_websocket_key(std::mt19937_64& random)
     }
 
     char out_buffer[24];
-    size_t encoded_size = util::base64_encode(random_bytes, 16, out_buffer, 24);
+    size_t encoded_size = util::base64_encode(random_bytes, out_buffer);
     REALM_ASSERT(encoded_size == 24);
 
     return std::string{out_buffer, 24};
@@ -62,11 +62,11 @@ std::string make_sec_websocket_accept(StringData sec_websocket_key)
     sha1_input.append(sec_websocket_key.data(), sec_websocket_key.size());
     sha1_input.append(websocket_magic_string.data(), websocket_magic_string.size());
 
-    unsigned char sha1_output[20];
-    util::sha1(sha1_input.data(), sha1_input.length(), sha1_output);
+    char sha1_output[20];
+    util::sha1(sha1_input.data(), sha1_input.length(), reinterpret_cast<unsigned char*>(sha1_output));
 
     char base64_output[28];
-    size_t base64_output_size = util::base64_encode(reinterpret_cast<char*>(sha1_output), 20, base64_output, 28);
+    size_t base64_output_size = util::base64_encode(sha1_output, base64_output);
     REALM_ASSERT(base64_output_size == 28);
 
     return std::string(base64_output, 28);

--- a/src/realm/sync/noinst/protocol_codec.cpp
+++ b/src/realm/sync/noinst/protocol_codec.cpp
@@ -174,7 +174,7 @@ std::string ClientProtocol::compressed_hex_dump(BinaryData blob)
     std::string encode_buffer;
     auto encoded_size = util::base64_encoded_size(buf.size());
     encode_buffer.resize(encoded_size);
-    util::base64_encode(buf.data(), buf.size(), encode_buffer.data(), encode_buffer.size());
+    util::base64_encode(buf, encode_buffer);
 
     return encode_buffer;
 }

--- a/src/realm/sync/noinst/server/access_token.cpp
+++ b/src/realm/sync/noinst/server/access_token.cpp
@@ -245,8 +245,7 @@ bool AccessToken::parseJWT(StringData signed_token, AccessToken& token, ParseErr
         StringData signature_base64 = StringData{sep2 + 1, signed_token.size() - sep2_pos - 1};
         std::vector<char> signature_buffer;
         signature_buffer.resize(base64_decoded_size(signature_base64.size()));
-        Optional<std::size_t> num_bytes_signature =
-            base64_decode(signature_base64, signature_buffer.data(), signature_base64.size());
+        Optional<std::size_t> num_bytes_signature = base64_decode(signature_base64, signature_buffer);
         if (!num_bytes_signature) {
             error = ParseError::invalid_base64;
             return false;
@@ -315,7 +314,7 @@ bool AccessToken::parse(StringData signed_token, AccessToken& token, ParseError&
     token_buffer.resize(base64_decoded_size(token_base64.size())); // Throws
     StringData token_2;
     {
-        Optional<std::size_t> num_bytes = base64_decode(token_base64, token_buffer.data(), token_buffer.size());
+        Optional<std::size_t> num_bytes = base64_decode(token_base64, token_buffer);
         if (!num_bytes) {
             error = ParseError::invalid_base64;
             return false;
@@ -327,7 +326,7 @@ bool AccessToken::parse(StringData signed_token, AccessToken& token, ParseError&
     if (verifier) {
         std::vector<char> buffer;
         buffer.resize(base64_decoded_size(signature_base64.size()));
-        Optional<std::size_t> num_bytes = base64_decode(signature_base64, buffer.data(), buffer.size());
+        Optional<std::size_t> num_bytes = base64_decode(signature_base64, buffer);
         if (!num_bytes) {
             error = ParseError::invalid_base64;
             return false;

--- a/src/realm/sync/tools/print_changeset.cpp
+++ b/src/realm/sync/tools/print_changeset.cpp
@@ -51,11 +51,10 @@ std::string changeset_compressed_to_binary(const std::string& changeset_compress
 
     // Decode from BASE64
     const size_t encoded_size = changeset_compressed.size() - (p - start);
-    size_t buffer_size = util::base64_decoded_size(encoded_size);
     std::string decode_buffer;
-    decode_buffer.resize(buffer_size);
+    decode_buffer.resize(util::base64_decoded_size(encoded_size));
     StringData window(p, encoded_size);
-    util::Optional<size_t> decoded_size = util::base64_decode(window, decode_buffer.data(), buffer_size);
+    util::Optional<size_t> decoded_size = util::base64_decode(window, decode_buffer);
     if (!decoded_size || *decoded_size > encoded_size) {
         throw std::runtime_error("Invalid base64 value");
     }

--- a/src/realm/util/base64.hpp
+++ b/src/realm/util/base64.hpp
@@ -19,21 +19,17 @@
 #ifndef REALM_UTIL_BASE64_HPP
 #define REALM_UTIL_BASE64_HPP
 
+#include <realm/util/span.hpp>
+#include <optional>
 #include <vector>
-#include <realm/string_data.hpp>
-#include <realm/util/optional.hpp>
 
-namespace realm {
-namespace util {
+namespace realm::util {
 
-
-/// base64_encode() encodes the bnary data in \param in_buffer of size \param in_buffer_size .
-/// The encoded data is placed in \param out_buffer . The size of \param \out_buffer is passed in
-/// \param out_buffer_size . The output buffer out_buffer must be
-/// large enough to hold the base64 encoded data. The size can be obtained from the function
-/// base64_encoded_size. out_buffer_size is only used to assert that the output buffer is
-/// large enough.
-size_t base64_encode(const char *in_buffer, size_t in_buffer_size, char* out_buffer, size_t out_buffer_size) noexcept;
+/// `base64_encode()` encodes the binary data in \param in_buffer .
+/// The encoded data is placed in \param out_buffer , which must be large
+/// enough to hold the base64 encoded data. The size can be obtained from the function
+/// `base64_encoded_size()`.
+size_t base64_encode(Span<const char> in_buffer, Span<char> out_buffer) noexcept;
 
 /// base64_encoded_size() returns the exact size of the base64 encoded
 /// data as a function of the size of the input data.
@@ -43,7 +39,7 @@ inline size_t base64_encoded_size(size_t in_buffer_size) noexcept
 }
 
 
-/// Decode base64-encoded string in input, and places the result in out_buffer.
+/// Decode base64-encoded string in `input`, and places the result in `out_buffer`.
 /// The length of the out_buffer must be at least 3 * input.size() / 4.
 ///
 /// The input must be padded base64 (i.e. the number of non-whitespace
@@ -55,7 +51,7 @@ inline size_t base64_encoded_size(size_t in_buffer_size) noexcept
 ///
 /// \returns the number of successfully decoded bytes written to out_buffer, or
 /// none if the whole input was not valid base64.
-Optional<size_t> base64_decode(StringData input, char* out_buffer, size_t out_buffer_len) noexcept;
+std::optional<size_t> base64_decode(Span<const char> input, Span<char> out_buffer) noexcept;
 
 /// Return an upper bound on the decoded size of a Base64-encoded data
 /// stream of length \a base64_size. The returned value is suitable for
@@ -70,10 +66,9 @@ inline size_t base64_decoded_size(size_t base64_size) noexcept
 /// base64_decode_to_vector() is a convenience function that decodes \param
 /// encoded and returns the result in a std::vector<char> with the correct size.
 /// This function returns none if the input is invalid.
-Optional<std::vector<char>> base64_decode_to_vector(StringData encoded);
+std::optional<std::vector<char>> base64_decode_to_vector(Span<const char> encoded);
 
-} // namespace util
-} // namespace realm
+} // namespace realm::util
 
 #endif // REALM_UTIL_BASE64_HPP
 

--- a/src/realm/util/bson/bson.cpp
+++ b/src/realm/util/bson/bson.cpp
@@ -659,8 +659,7 @@ static constexpr std::pair<std::string_view, FancyParser> bson_fancy_parsers[] =
          if (!base64 || !subType)
              throw BsonError("invalid extended json $binary");
          if (subType == 0x04) { // UUID
-             auto stringData = StringData(reinterpret_cast<const char*>(base64->data()), base64->size());
-             util::Optional<std::vector<char>> uuidChrs = util::base64_decode_to_vector(stringData);
+             util::Optional<std::vector<char>> uuidChrs = util::base64_decode_to_vector(*base64);
              if (!uuidChrs)
                  throw BsonError("Invalid base64 in $binary");
              UUID::UUIDBytes bytes{};
@@ -795,9 +794,14 @@ Bson dom_obj_to_bson(const Json& json)
 
 } // anonymous namespace
 
-Bson parse(const std::string_view& json)
+Bson parse(util::Span<const char> json)
 {
     return dom_elem_to_bson(Json::parse(json));
+}
+
+bool accept(util::Span<const char> json) noexcept
+{
+    return Json::accept(json);
 }
 
 } // namespace bson

--- a/src/realm/util/bson/bson.hpp
+++ b/src/realm/util/bson/bson.hpp
@@ -24,6 +24,7 @@
 #include <realm/util/bson/min_key.hpp>
 #include <realm/util/bson/max_key.hpp>
 #include <realm/util/bson/mongo_timestamp.hpp>
+#include <realm/util/span.hpp>
 
 #include <realm/binary_data.hpp>
 #include <realm/timestamp.hpp>
@@ -389,7 +390,8 @@ using BsonArray = std::vector<Bson>;
 
 std::ostream& operator<<(std::ostream& out, const Bson& b);
 
-Bson parse(const std::string_view& json);
+Bson parse(util::Span<const char> json);
+bool accept(util::Span<const char> json) noexcept;
 
 } // namespace bson
 } // namespace realm

--- a/src/realm/util/file.cpp
+++ b/src/realm/util/file.cpp
@@ -247,9 +247,13 @@ void make_dir_recursive(std::string path)
             path[sep] = 0;
         }
         try_make_dir(path);
-        if (sep < path.size())
+        if (c) {
             path[sep] = c;
-        pos = sep + 1;
+            pos = sep + 1;
+        }
+        else {
+            break;
+        }
     }
 #endif
 }

--- a/src/realm/util/serializer.cpp
+++ b/src/realm/util/serializer.cpp
@@ -227,7 +227,7 @@ std::string print_value<>(StringData data)
     if (contains_invalids(data)) {
         std::string encode_buffer;
         encode_buffer.resize(util::base64_encoded_size(len));
-        util::base64_encode(start, len, encode_buffer.data(), encode_buffer.size());
+        util::base64_encode(data, encode_buffer);
         out = "B64\"" + encode_buffer + "\"";
     }
     else {

--- a/src/realm/uuid.cpp
+++ b/src/realm/uuid.cpp
@@ -116,11 +116,10 @@ std::string UUID::to_base64() const
 {
     char bytes[UUID::num_bytes];
     std::copy(std::begin(m_bytes), std::end(m_bytes), std::begin(bytes));
-    char* bytes_ptr = &bytes[0];
 
     std::string encode_buffer;
     encode_buffer.resize(util::base64_encoded_size(UUID::num_bytes));
-    util::base64_encode(bytes_ptr, UUID::num_bytes, encode_buffer.data(), encode_buffer.size());
+    util::base64_encode(bytes, encode_buffer);
     return encode_buffer;
 }
 

--- a/test/object-store/c_api/c_api.cpp
+++ b/test/object-store/c_api/c_api.cpp
@@ -5293,13 +5293,7 @@ TEST_CASE("C API - async_open", "[sync][pbs][c_api]") {
     }
 
     SECTION("cancels download and reports an error on auth error") {
-        // Create a token which can be parsed as a JWT but is not valid
-        std::string unencoded_body = nlohmann::json({{"exp", 123}, {"iat", 456}}).dump();
-        std::string encoded_body;
-        encoded_body.resize(util::base64_encoded_size(unencoded_body.size()));
-        util::base64_encode(unencoded_body.data(), unencoded_body.size(), &encoded_body[0], encoded_body.size());
-        auto invalid_token = "." + encoded_body + ".";
-
+        auto expired_token = encode_fake_jwt("", 123, 456);
 
         realm_config_t* config = realm_config_new();
         config->schema = Schema{object_schema};
@@ -5307,7 +5301,7 @@ TEST_CASE("C API - async_open", "[sync][pbs][c_api]") {
         realm_sync_config_t* sync_config = realm_sync_config_new(&user, "realm");
         realm_sync_config_set_initial_subscription_handler(sync_config, task_init_subscription, false, nullptr,
                                                            nullptr);
-        sync_config->user->log_in(invalid_token, invalid_token);
+        sync_config->user->log_in(expired_token, expired_token);
 
         realm_config_set_path(config, test_config.path.c_str());
         realm_config_set_schema_version(config, 1);

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -162,16 +162,16 @@ static std::string create_jwt(const std::string& appId)
     payload["my_metadata"]["name"] = "Bar Foo";
     payload["my_metadata"]["occupation"] = "stock analyst";
 
-    std::string headerStr = header.dump();
-    std::string payloadStr = payload.dump();
+    std::string header_str = header.dump();
+    std::string payload_str = payload.dump();
 
     std::string encoded_header;
-    encoded_header.resize(util::base64_encoded_size(headerStr.length()));
-    util::base64_encode(headerStr.data(), headerStr.length(), encoded_header.data(), encoded_header.size());
+    encoded_header.resize(util::base64_encoded_size(header_str.length()));
+    util::base64_encode(header_str, encoded_header);
 
     std::string encoded_payload;
-    encoded_payload.resize(util::base64_encoded_size(payloadStr.length()));
-    util::base64_encode(payloadStr.data(), payloadStr.length(), encoded_payload.data(), encoded_payload.size());
+    encoded_payload.resize(util::base64_encoded_size(payload_str.length()));
+    util::base64_encode(payload_str, encoded_payload);
 
     // Remove padding characters.
     while (encoded_header.back() == '=')
@@ -181,13 +181,14 @@ static std::string create_jwt(const std::string& appId)
 
     std::string jwtPayload = encoded_header + "." + encoded_payload;
 
-    std::array<unsigned char, 32> hmac;
+    std::array<char, 32> hmac;
     unsigned char key[] = "My_very_confidential_secretttttt";
-    util::hmac_sha256(util::unsafe_span_cast<unsigned char>(jwtPayload), hmac, util::Span<uint8_t, 32>(key, 32));
+    util::hmac_sha256(util::unsafe_span_cast<uint8_t>(jwtPayload), util::unsafe_span_cast<uint8_t>(hmac),
+                      util::Span<uint8_t, 32>(key, 32));
 
     std::string signature;
     signature.resize(util::base64_encoded_size(hmac.size()));
-    util::base64_encode(reinterpret_cast<char*>(hmac.data()), hmac.size(), signature.data(), signature.size());
+    util::base64_encode(hmac, signature);
     while (signature.back() == '=')
         signature.pop_back();
     std::replace(signature.begin(), signature.end(), '+', '-');
@@ -4797,7 +4798,7 @@ TEST_CASE("app: login_with_credentials unit_tests", "[sync][app][user]") {
         config.transport = instance_of<transport>;
         TestSyncManager tsm(config);
         auto error = failed_log_in(tsm.app());
-        CHECK(error.reason() == std::string("jwt missing parts"));
+        CHECK(error.reason() == std::string("malformed JWT"));
         CHECK(error.code_string() == "BadToken");
         CHECK(error.is_json_error());
         CHECK(error.code() == ErrorCodes::BadToken);
@@ -5416,7 +5417,7 @@ TEST_CASE("app: refresh access token unit tests", "[sync][app][user][token]") {
 
         bool processed = false;
         app->refresh_custom_data(app->sync_manager()->get_current_user(), [&](const Optional<AppError>& error) {
-            CHECK(error->reason() == "jwt missing parts");
+            CHECK(error->reason() == "malformed JWT");
             CHECK(error->code() == ErrorCodes::BadToken);
             CHECK(session_route_hit);
             processed = true;

--- a/test/object-store/util/test_utils.cpp
+++ b/test/object-store/util/test_utils.cpp
@@ -147,8 +147,8 @@ std::string encode_fake_jwt(const std::string& in, util::Optional<int64_t> exp, 
     std::string encoded_prefix, encoded_body;
     encoded_prefix.resize(util::base64_encoded_size(unencoded_prefix.size()));
     encoded_body.resize(util::base64_encoded_size(unencoded_body.size()));
-    util::base64_encode(unencoded_prefix.data(), unencoded_prefix.size(), &encoded_prefix[0], encoded_prefix.size());
-    util::base64_encode(unencoded_body.data(), unencoded_body.size(), &encoded_body[0], encoded_body.size());
+    util::base64_encode(unencoded_prefix, encoded_prefix);
+    util::base64_encode(unencoded_body, encoded_body);
     std::string suffix = "Et9HFtf9R3GEMA0IICOfFMVXY7kkTX1wr4qCyhIf58U";
     return encoded_prefix + "." + encoded_body + "." + suffix;
 }

--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -3887,7 +3887,7 @@ TEST(Table_CollisionMapping)
             char buffer[12];
             for (size_t i = 0; i < num_objects_with_guaranteed_collision; ++i) {
                 const char* in = reinterpret_cast<char*>(&i);
-                size_t len = base64_encode(in, sizeof(i), buffer, sizeof(buffer));
+                size_t len = base64_encode({in, sizeof(i)}, buffer);
 
                 t0->create_object_with_primary_key(StringData{buffer, len});
             }
@@ -3921,7 +3921,7 @@ TEST(Table_CollisionMapping)
             for (size_t i = 0; i < num_objects_with_guaranteed_collision; ++i) {
                 size_t foo = num_objects_with_guaranteed_collision + i;
                 const char* in = reinterpret_cast<char*>(&foo);
-                size_t len = base64_encode(in, sizeof(foo), buffer, sizeof(buffer));
+                size_t len = base64_encode({in, sizeof(foo)}, buffer);
 
                 t0->create_object_with_primary_key(StringData{buffer, len});
             }

--- a/test/test_util_base64.cpp
+++ b/test/test_util_base64.cpp
@@ -55,7 +55,7 @@ TEST(Base64_Decode)
     static const size_t num_tests = sizeof(inputs) / sizeof(inputs[0]);
 
     for (size_t i = 0; i < num_tests; ++i) {
-        r = base64_decode(inputs[i], buffer.data(), buffer.size());
+        r = base64_decode({inputs[i], strlen(inputs[i])}, buffer);
         CHECK(r);
         CHECK_EQUAL(StringData(buffer.data(), *r), expected[i]);
     }
@@ -71,7 +71,7 @@ TEST(Base64_Decode)
     static const size_t num_bad_tests = sizeof(bad_inputs) / sizeof(bad_inputs[0]);
 
     for (size_t i = 0; i < num_bad_tests; ++i) {
-        r = base64_decode(bad_inputs[i], buffer.data(), buffer.size());
+        r = base64_decode({bad_inputs[i], strlen(bad_inputs[i])}, buffer);
         CHECK(!r);
     }
 }
@@ -81,7 +81,7 @@ TEST(Base64_Decode_AdjacentBuffers)
 {
     char buffer[10] = "Zg==\0"; // "f" + blank space + terminating zero
     const char expected[] = "f";
-    Optional<size_t> r = base64_decode(buffer, buffer + 4, 3);
+    Optional<size_t> r = base64_decode({buffer, 4}, {buffer + 4, 3});
     CHECK(r);
     CHECK_EQUAL(*r, 1);
     CHECK_EQUAL(StringData{buffer + 4}, StringData{expected});
@@ -90,7 +90,6 @@ TEST(Base64_Decode_AdjacentBuffers)
 namespace {
 
 struct TestBuffers {
-
     const char* decoded_buffer;
     size_t decoded_buffer_size;
     const char* encoded_buffer;
@@ -105,22 +104,22 @@ TEST(Base64_Encode)
     buffer.resize(100);
 
     TestBuffers tbs[] = {
-        TestBuffers {"", 0, "", 0},
-        TestBuffers {"\x00\x00\x00", 3, "AAAA", 4},
-        TestBuffers {"\x00\x00\x01", 3, "AAAB", 4},
-        TestBuffers {"\x80", 1, "gA==", 4},
-        TestBuffers {"\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10", 16, "AQIDBAUGBwgJCgsMDQ4PEA==", 24}
-
+        TestBuffers{"", 0, "", 0},
+        TestBuffers{"\x00\x00\x00", 3, "AAAA", 4},
+        TestBuffers{"\x00\x00\x01", 3, "AAAB", 4},
+        TestBuffers{"\x80", 1, "gA==", 4},
+        TestBuffers{"\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10", 16,
+                    "AQIDBAUGBwgJCgsMDQ4PEA==", 24},
     };
 
     const size_t num_tests = sizeof(tbs) / sizeof(tbs[0]);
 
     for (size_t i = 0; i < num_tests; ++i) {
-        size_t return_size = base64_encode(tbs[i].decoded_buffer, tbs[i].decoded_buffer_size, buffer.data(), buffer.size());
+        size_t return_size = base64_encode({tbs[i].decoded_buffer, tbs[i].decoded_buffer_size}, buffer);
         CHECK_EQUAL(return_size, tbs[i].encoded_buffer_size);
         CHECK_EQUAL(StringData(buffer.data(), return_size), tbs[i].encoded_buffer);
 
-        Optional<size_t> return_size_opt = base64_decode(StringData(tbs[i].encoded_buffer, tbs[i].encoded_buffer_size), buffer.data(), buffer.size());
+        Optional<size_t> return_size_opt = base64_decode({tbs[i].encoded_buffer, tbs[i].encoded_buffer_size}, buffer);
         CHECK(return_size_opt);
         CHECK_EQUAL(*return_size_opt, tbs[i].decoded_buffer_size);
         for (size_t j = 0; j < *return_size_opt; ++j) {
@@ -131,13 +130,14 @@ TEST(Base64_Encode)
 
 TEST(Base64_DecodeToVector)
 {
+    using namespace std::string_view_literals;
     {
-        Optional<std::vector<char>> vec = base64_decode_to_vector("======");
+        Optional<std::vector<char>> vec = base64_decode_to_vector("======"sv);
         CHECK(!vec);
     }
 
     {
-        Optional<std::vector<char>> vec = base64_decode_to_vector("SGVsb G8sIF\ndvc mxkIQ==");
+        Optional<std::vector<char>> vec = base64_decode_to_vector("SGVsb G8sIF\ndvc mxkIQ=="sv);
         std::string str(vec->begin(), vec->end());
         CHECK_EQUAL("Hello, World!", str);
     }


### PR DESCRIPTION
This is pulling some of the incidental changes out of #7300 since that PR is growing far too large. None of this has meaningful functional changes on its own and is mostly just pushing code around.

One of the upcoming changes is making SyncUsers lazily loaded and reloaded when the data in the metadata store changes, which benefits from it being relatively cheap to validate that the stored user is valid. Changing RealmJWT to operate on a string view had cascading effects on base64 and exjson parsing, which I also updated to use Span rather than a pointer+size while I was touching it.

Checking if the data in the metadata realm is valid was done incompletely in three different places, and now is just in SyncMetadataManager. File action handling is also there now as that's going to be required for it to be multiprocess safe. Most of SyncMetadataManager's API is now unused outside of tests, but is left in place for now as removing it requires rewriting the tests (which is done in #7300).

CheckedMutex::lock() is `const`, so it doesn't have to be declared as `mutable`.