### PR TITLE
Fix a race condition in audit tests 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add support in the C API for receiving a notification when sync user state changes. ([#7302](https://github.com/realm/realm-core/pull/7302))
 * Allow the query builder to construct >, >=, <, <= queries for string constants. This is a case sensitive lexicographical comparison. Improved performance of RQL (parsed) queries on a non-linked string property using: >, >=, <, <=, operators and fixed behaviour that a null string should be evaulated as less than everything, previously nulls were not matched. ([#3939](https://github.com/realm/realm-core/issues/3939), this is a prerequisite for https://github.com/realm/realm-swift/issues/8008).
 * Updated bundled OpenSSL version to 3.2.0 (PR [#7303](https://github.com/realm/realm-core/pull/7303))
+* Audit event scopes containing zero events to save no longer open the audit realm unneccesarily ([PR #7332](https://github.com/realm/realm-core/pull/7332)).
 
 ### Fixed
 * Uploading the changesets recovered during an automatic client reset recovery may lead to 'Bad server version' errors and a new client reset. ([#7279](https://github.com/realm/realm-core/issues/7279), since v13.24.1)

--- a/src/realm/object-store/audit.mm
+++ b/src/realm/object-store/audit.mm
@@ -1173,6 +1173,14 @@ bool AuditContext::is_scope_valid(uint64_t id)
 void AuditContext::process_scope(AuditContext::Scope& scope) const
 {
     m_logger->info("Events: Processing scope for '%1'", m_source_db->get_path());
+    if (scope.events.empty()) {
+        m_logger->detail("Events: Scope is empty");
+        if (scope.completion)
+            scope.completion(nullptr);
+        m_serializer->scope_complete();
+        return;
+    }
+
     try {
         // Merge single object reads following a query into that query and discard
         // duplicate reads on objects.


### PR DESCRIPTION
Some tests triggered background work without waiting for it to complete, resulting in a race condition when tearing down.

The specific test where I hit this didn't even need to be opening the audit realm at all so I added a minor optimization to the implementation for that scenario. Setting `automatic_change_notifications` on the test configs is also just a minor optimization that makes the tests a little faster.