### PR TITLE
fix == NONE {x} queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Updated bundled OpenSSL version to 3.2.0 (PR [#7303](https://github.com/realm/realm-core/pull/7303))
 
 ### Fixed
+* Fixed queries like `indexed_property == NONE {x}` which mistakenly matched on only x instead of not x. This only applies when an indexed property with equality (==, or IN) matches with `NONE` on a list of one item. If the constant list contained more than one value then it was working correctly. ([realm-js #7862](https://github.com/realm/realm-java/issues/7862), since v12.5.0) 
 * Uploading the changesets recovered during an automatic client reset recovery may lead to 'Bad server version' errors and a new client reset. ([#7279](https://github.com/realm/realm-core/issues/7279), since v13.24.1)
 * Fixed invalid data in error reason string when registering a subscription change notification after the subscription has already failed. ([#6839](https://github.com/realm/realm-core/issues/6839), since v11.8.0)
 * Fixed crash in fulltext index using prefix search with no matches ([#7309](https://github.com/realm/realm-core/issues/7309), since v13.18.0)

--- a/src/realm/query_expression.hpp
+++ b/src/realm/query_expression.hpp
@@ -4262,18 +4262,22 @@ public:
                 // finding all matches up front.
                 Mixed const_value;
                 Subexpr* column;
+                std::optional<ExpressionComparisonType> const_value_cmp_type;
                 if (m_left->has_single_value()) {
                     const_value = m_left->get_mixed();
+                    const_value_cmp_type = m_left->get_comparison_type();
                     column = m_right.get();
                 }
                 else {
                     const_value = m_right->get_mixed();
+                    const_value_cmp_type = m_right->get_comparison_type();
                     column = m_left.get();
                 }
 
                 if (column->has_search_index() &&
                     column->get_comparison_type().value_or(ExpressionComparisonType::Any) ==
-                        ExpressionComparisonType::Any) {
+                        ExpressionComparisonType::Any &&
+                    const_value_cmp_type.value_or(ExpressionComparisonType::Any) != ExpressionComparisonType::None) {
                     if (const_value.is_null()) {
                         const ObjPropertyBase* prop = dynamic_cast<const ObjPropertyBase*>(m_right.get());
                         // when checking for null across links, null links are considered matches,

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -724,6 +724,19 @@ TEST_TYPES(Parser_Numerics, Prop<Int>, Nullable<Int>, Indexed<Int>, NullableInde
         verify_query_sub(test_context, t, util::format("values == $%1", i), args, 1);
     }
     verify_query(test_context, t, "values == null", nullable ? 1 : 0);
+    verify_query(test_context, t, "values == ANY {-1, 0, 1}", 3);
+    verify_query(test_context, t, "values == NONE {-1, 0, 1}", t->size() - 3);
+    verify_query(test_context, t, "values == NONE {-1, 0}", t->size() - 2);
+    verify_query(test_context, t, "values == NONE {-1}", t->size() - 1);
+    verify_query(test_context, t, "values == NONE {}", t->size());
+    verify_query(test_context, t, "values != ALL {-1, 0, 1}", t->size() - 3);
+    verify_query(test_context, t, "values != ALL {-1, 0}", t->size() - 2);
+    verify_query(test_context, t, "values != ALL {-1}", t->size() - 1);
+    verify_query(test_context, t, "values != ALL {}", t->size());
+    verify_query(test_context, t, "values == ALL {-1, 0, 1}", 0);
+    verify_query(test_context, t, "values == ALL {-1, 0}", 0);
+    verify_query(test_context, t, "values == ALL {-1}", 1);
+    verify_query(test_context, t, "values == ALL {}", t->size());
 }
 
 TEST(Parser_LinksToSameTable)

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -723,20 +723,37 @@ TEST_TYPES(Parser_Numerics, Prop<Int>, Nullable<Int>, Indexed<Int>, NullableInde
         verify_query(test_context, t, out.str(), 1);
         verify_query_sub(test_context, t, util::format("values == $%1", i), args, 1);
     }
+    size_t sz = t->size();
     verify_query(test_context, t, "values == null", nullable ? 1 : 0);
     verify_query(test_context, t, "values == ANY {-1, 0, 1}", 3);
-    verify_query(test_context, t, "values == NONE {-1, 0, 1}", t->size() - 3);
-    verify_query(test_context, t, "values == NONE {-1, 0}", t->size() - 2);
-    verify_query(test_context, t, "values == NONE {-1}", t->size() - 1);
-    verify_query(test_context, t, "values == NONE {}", t->size());
-    verify_query(test_context, t, "values != ALL {-1, 0, 1}", t->size() - 3);
-    verify_query(test_context, t, "values != ALL {-1, 0}", t->size() - 2);
-    verify_query(test_context, t, "values != ALL {-1}", t->size() - 1);
-    verify_query(test_context, t, "values != ALL {}", t->size());
+    verify_query(test_context, t, "values == ANY {0, 1}", 2);
+    verify_query(test_context, t, "values == ANY {1}", 1);
+    verify_query(test_context, t, "values == ANY {}", 0);
+
+    verify_query(test_context, t, "values == NONE {-1, 0, 1}", sz - 3);
+    verify_query(test_context, t, "values == NONE {-1, 0}", sz - 2);
+    verify_query(test_context, t, "values == NONE {-1}", sz - 1);
+    verify_query(test_context, t, "values == NONE {}", sz);
+
     verify_query(test_context, t, "values == ALL {-1, 0, 1}", 0);
     verify_query(test_context, t, "values == ALL {-1, 0}", 0);
     verify_query(test_context, t, "values == ALL {-1}", 1);
-    verify_query(test_context, t, "values == ALL {}", t->size());
+    verify_query(test_context, t, "values == ALL {}", sz);
+
+    verify_query(test_context, t, "values != NONE {-1, 0, 1}", 0);
+    verify_query(test_context, t, "values != NONE {-1, 0}", 0);
+    verify_query(test_context, t, "values != NONE {-1}", 1);
+    verify_query(test_context, t, "values != NONE {}", sz);
+
+    verify_query(test_context, t, "values != ANY {-1, 0, 1}", sz);
+    verify_query(test_context, t, "values != ANY {0, 1}", sz);
+    verify_query(test_context, t, "values != ANY {1}", sz - 1);
+    verify_query(test_context, t, "values != ANY {}", 0);
+
+    verify_query(test_context, t, "values != ALL {-1, 0, 1}", sz - 3);
+    verify_query(test_context, t, "values != ALL {-1, 0}", sz - 2);
+    verify_query(test_context, t, "values != ALL {-1}", sz - 1);
+    verify_query(test_context, t, "values != ALL {}", sz);
 }
 
 TEST(Parser_LinksToSameTable)


### PR DESCRIPTION
Fixes https://github.com/realm/realm-java/issues/7862

We had an optimization in Comparison nodes that would try to use an index if comparing a single value constant to an indexed property. This optimization should only apply if the constant's expression comparison type is ALL or ANY because NONE produces different results.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [x] C-API, if public C++ API changed
* [x] `bindgen/spec.yml`, if public C++ API changed