### PR TITLE
Mitigate races in accessing `m_initated` and `m_finalized` in various REALM_ASSERTs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 * Fixed crash in fulltext index using prefix search with no matches ([#7309](https://github.com/realm/realm-core/issues/7309), since v13.18.0)
 * Fix compilation and some warnings when building with Xcode 15.3 ([PR #7297](https://github.com/realm/realm-core/pull/7297)).
 * util::make_dir_recursive() attempted to create a directory named "\0" if the path did not have a trailing slash ([PR #7329](https://github.com/realm/realm-core/pull/7329)).
+* Fixed a crash with `Assertion failed: m_initiated` during sync session startup ([#7074](https://github.com/realm/realm-core/issues/7074), since v10.0.0).
+* Fixed a TSAN violation where the user thread could race to read `m_finalized` with the sync event loop ([#6844](https://github.com/realm/realm-core/issues/6844), since v13.15.1)
  
 ### Breaking changes
 * None.

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -1373,7 +1373,6 @@ void SessionWrapper::async_wait_for(bool upload_completion, bool download_comple
 {
     REALM_ASSERT(upload_completion || download_completion);
     REALM_ASSERT(m_initiated);
-    REALM_ASSERT(!m_abandoned);
 
     util::bind_ptr<SessionWrapper> self{this};
     m_client.post([self = std::move(self), handler = std::move(handler), upload_completion,

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -1384,7 +1384,6 @@ void SessionWrapper::async_wait_for(bool upload_completion, bool download_comple
             throw Exception(status);
 
         REALM_ASSERT(self->m_actualized);
-        REALM_ASSERT(!self->m_finalized);
         if (REALM_UNLIKELY(!self->m_sess)) {
             // Already finalized
             handler({ErrorCodes::OperationAborted, "Session finalized before callback could run"}); // Throws
@@ -1516,7 +1515,6 @@ void SessionWrapper::refresh(std::string signed_access_token)
             throw Exception(status);
 
         REALM_ASSERT(self->m_actualized);
-        REALM_ASSERT(!self->m_finalized);
         if (REALM_UNLIKELY(!self->m_sess))
             return; // Already finalized
         self->m_signed_access_token = std::move(token);

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -130,12 +130,14 @@ public:
 protected:
     friend class ClientImpl;
 
-    // m_initiated is used to check that we aren't trying to update immutable properties like the progress handler or
-    // connection state listener after we've bound the session. We read the variable a bunch in REALM_ASSERTS on the
-    // event loop and on the user's thread, but we only set it once and while we're registering the session wrapper to
-    // be actualized. This function gets called from ClientImpl::register_unactualized_session_wrapper() to
-    // synchronize updating this variable on the main thread with reading the variable on the event loop.
+    // m_initiated/m_abandoned is used to check that we aren't trying to update immutable properties like the progress
+    // handler or connection state listener after we've bound the session. We read the variable a bunch in
+    // REALM_ASSERTS on the event loop and on the user's thread, but we only set it once and while we're registering
+    // the session wrapper to be actualized. This function gets called from
+    // ClientImpl::register_unactualized_session_wrapper() to synchronize updating this variable on the main thread
+    // with reading the variable on the event loop.
     void mark_initiated();
+    void mark_abandoned();
 
 private:
     ClientImpl& m_client;
@@ -210,6 +212,8 @@ private:
 
     bool m_suspended = false;
 
+    // Set when the session has been abandoned, but before it's been finalized.
+    bool m_abandoned = false;
     // Has the SessionWrapper been finalized?
     bool m_finalized = false;
 
@@ -519,37 +523,24 @@ void ClientImpl::shutdown() noexcept
 
 void ClientImpl::register_unactualized_session_wrapper(SessionWrapper* wrapper, ServerEndpoint endpoint)
 {
-    bool retrigger;
     // Thread safety required.
     {
         std::lock_guard lock{m_mutex};
         REALM_ASSERT(m_actualize_and_finalize);
         wrapper->mark_initiated();
         m_unactualized_session_wrappers.emplace(wrapper, std::move(endpoint)); // Throws
-        retrigger = !m_actualize_and_finalize_needed;
-        m_actualize_and_finalize_needed = true;
-        // The conditional triggering needs to happen before releasing the mutex,
-        // because if two threads call register_unactualized_session_wrapper()
-        // roughly concurrently, then only the first one is guaranteed to be asked
-        // to retrigger, but that retriggering must have happened before the other
-        // thread returns from register_unactualized_session_wrapper().
-        //
-        // Note that a similar argument applies when two threads call
-        // register_abandoned_session_wrapper(), and when one thread calls one of
-        // them and another thread call the other.
     }
-    if (retrigger)
-        m_actualize_and_finalize->trigger();
+    m_actualize_and_finalize->trigger();
 }
 
 
 void ClientImpl::register_abandoned_session_wrapper(util::bind_ptr<SessionWrapper> wrapper) noexcept
 {
     // Thread safety required.
-    bool retrigger;
     {
         std::lock_guard lock{m_mutex};
         REALM_ASSERT(m_actualize_and_finalize);
+        wrapper->mark_abandoned();
 
         // If the session wrapper has not yet been actualized (on the event loop
         // thread), it can be immediately finalized. This ensures that we will
@@ -562,14 +553,8 @@ void ClientImpl::register_abandoned_session_wrapper(util::bind_ptr<SessionWrappe
             return;
         }
         m_abandoned_session_wrappers.push(std::move(wrapper));
-        retrigger = !m_actualize_and_finalize_needed;
-        m_actualize_and_finalize_needed = true;
-        // The conditional triggering needs to happen before releasing the
-        // mutex. See implementation of register_unactualized_session_wrapper() for
-        // details.
     }
-    if (retrigger)
-        m_actualize_and_finalize->trigger();
+    m_actualize_and_finalize->trigger();
 }
 
 
@@ -581,7 +566,6 @@ void ClientImpl::actualize_and_finalize_session_wrappers()
     bool stopped;
     {
         std::lock_guard lock{m_mutex};
-        m_actualize_and_finalize_needed = false;
         swap(m_unactualized_session_wrappers, unactualized_session_wrappers);
         swap(m_abandoned_session_wrappers, abandoned_session_wrappers);
         stopped = m_stopped;
@@ -1296,8 +1280,17 @@ MigrationStore* SessionWrapper::get_migration_store()
 inline void SessionWrapper::mark_initiated()
 {
     REALM_ASSERT(!m_initiated);
+    REALM_ASSERT(!m_abandoned);
     m_initiated = true;
 }
+
+
+inline void SessionWrapper::mark_abandoned()
+{
+    REALM_ASSERT(!m_abandoned);
+    m_abandoned = true;
+}
+
 
 inline void SessionWrapper::set_progress_handler(util::UniqueFunction<ProgressHandler> handler)
 {
@@ -1327,10 +1320,6 @@ void SessionWrapper::on_commit(version_type new_version)
     // Thread safety required
     REALM_ASSERT(m_initiated);
 
-    if (REALM_UNLIKELY(m_finalized || m_force_closed)) {
-        return;
-    }
-
     util::bind_ptr<SessionWrapper> self{this};
     m_client.post([self = std::move(self), new_version](Status status) {
         if (status == ErrorCodes::OperationAborted)
@@ -1339,6 +1328,10 @@ void SessionWrapper::on_commit(version_type new_version)
             throw Exception(status);
 
         REALM_ASSERT(self->m_actualized);
+        if (REALM_UNLIKELY(self->m_finalized || self->m_force_closed)) {
+            return;
+        }
+
         if (REALM_UNLIKELY(!self->m_sess))
             return; // Already finalized
         SessionImpl& sess = *self->m_sess;
@@ -1354,10 +1347,6 @@ void SessionWrapper::cancel_reconnect_delay()
     // Thread safety required
     REALM_ASSERT(m_initiated);
 
-    if (REALM_UNLIKELY(m_finalized || m_force_closed)) {
-        return;
-    }
-
     util::bind_ptr<SessionWrapper> self{this};
     m_client.post([self = std::move(self)](Status status) {
         if (status == ErrorCodes::OperationAborted)
@@ -1366,6 +1355,10 @@ void SessionWrapper::cancel_reconnect_delay()
             throw Exception(status);
 
         REALM_ASSERT(self->m_actualized);
+        if (REALM_UNLIKELY(self->m_finalized || self->m_force_closed)) {
+            return;
+        }
+
         if (REALM_UNLIKELY(!self->m_sess))
             return; // Already finalized
         SessionImpl& sess = *self->m_sess;
@@ -1380,7 +1373,7 @@ void SessionWrapper::async_wait_for(bool upload_completion, bool download_comple
 {
     REALM_ASSERT(upload_completion || download_completion);
     REALM_ASSERT(m_initiated);
-    REALM_ASSERT(!m_finalized);
+    REALM_ASSERT(!m_abandoned);
 
     util::bind_ptr<SessionWrapper> self{this};
     m_client.post([self = std::move(self), handler = std::move(handler), upload_completion,
@@ -1391,6 +1384,7 @@ void SessionWrapper::async_wait_for(bool upload_completion, bool download_comple
             throw Exception(status);
 
         REALM_ASSERT(self->m_actualized);
+        REALM_ASSERT(!self->m_finalized);
         if (REALM_UNLIKELY(!self->m_sess)) {
             // Already finalized
             handler({ErrorCodes::OperationAborted, "Session finalized before callback could run"}); // Throws
@@ -1423,7 +1417,7 @@ bool SessionWrapper::wait_for_upload_complete_or_client_stopped()
 {
     // Thread safety required
     REALM_ASSERT(m_initiated);
-    REALM_ASSERT(!m_finalized);
+    REALM_ASSERT(!m_abandoned);
 
     std::int_fast64_t target_mark;
     {
@@ -1439,6 +1433,7 @@ bool SessionWrapper::wait_for_upload_complete_or_client_stopped()
             throw Exception(status);
 
         REALM_ASSERT(self->m_actualized);
+        REALM_ASSERT(!self->m_finalized);
         // The session wrapper may already have been finalized. This can only
         // happen if it was abandoned, but in that case, the call of
         // wait_for_upload_complete_or_client_stopped() must have returned
@@ -1467,7 +1462,7 @@ bool SessionWrapper::wait_for_download_complete_or_client_stopped()
 {
     // Thread safety required
     REALM_ASSERT(m_initiated);
-    REALM_ASSERT(!m_finalized);
+    REALM_ASSERT(!m_abandoned);
 
     std::int_fast64_t target_mark;
     {
@@ -1483,6 +1478,7 @@ bool SessionWrapper::wait_for_download_complete_or_client_stopped()
             throw Exception(status);
 
         REALM_ASSERT(self->m_actualized);
+        REALM_ASSERT(!self->m_finalized);
         // The session wrapper may already have been finalized. This can only
         // happen if it was abandoned, but in that case, the call of
         // wait_for_download_complete_or_client_stopped() must have returned
@@ -1511,7 +1507,7 @@ void SessionWrapper::refresh(std::string signed_access_token)
 {
     // Thread safety required
     REALM_ASSERT(m_initiated);
-    REALM_ASSERT(!m_finalized);
+    REALM_ASSERT(!m_abandoned);
 
     m_client.post([self = util::bind_ptr(this), token = std::move(signed_access_token)](Status status) {
         if (status == ErrorCodes::OperationAborted)
@@ -1520,6 +1516,7 @@ void SessionWrapper::refresh(std::string signed_access_token)
             throw Exception(status);
 
         REALM_ASSERT(self->m_actualized);
+        REALM_ASSERT(!self->m_finalized);
         if (REALM_UNLIKELY(!self->m_sess))
             return; // Already finalized
         self->m_signed_access_token = std::move(token);
@@ -1636,6 +1633,7 @@ void SessionWrapper::force_close()
 void SessionWrapper::finalize()
 {
     REALM_ASSERT(m_actualized);
+    REALM_ASSERT(m_abandoned);
 
     // Already finalized?
     if (m_finalized) {

--- a/src/realm/sync/noinst/client_impl_base.hpp
+++ b/src/realm/sync/noinst/client_impl_base.hpp
@@ -292,7 +292,6 @@ private:
 
     bool m_stopped = false;                       // Protected by `m_mutex`
     bool m_sessions_terminated = false;           // Protected by `m_mutex`
-    bool m_actualize_and_finalize_needed = false; // Protected by `m_mutex`
 
     // The set of session wrappers that are not yet wrapping a session object,
     // and are not yet abandoned (still referenced by the application).


### PR DESCRIPTION
## What, How & Why?
This fixes #7074 and #6844. The problem turned out to be a pretty basic race between the user thread calling `Session::bind()` which sets `m_initiated` to true and the event loop thread trying to activate the session which reads `m_initiated`. Usually there's some waiting for mutexes and some networking activity that has made this race unlikely, but I was able to verify the bug by adding a check for `m_initiated` just earlier in the session setup code.

The fix is to make sure what we update `m_initiated` while holding the sync client's mutex (which also protects the list of tasks to run on the event loop) - that way we know that `m_initiated` cannot be read by the event loop while it's being updated by the user's thread.

There was also a race between the event loop setting `m_finalized` to true and various methods checking `m_finalized` on the user thread. What the methods checking `m_finalized` really wanted to check on the user thread was whether the `Session` had been abandoned and then check `m_finalized` once running on the event loop - this PR introduces some new tracking info for that and adjusts the checks appropriately.

## ☑️ ToDos
* [x] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed
* [ ] `bindgen/spec.yml`, if public C++ API changed
