### PR TITLE
File a minor race condition in the backup realm file action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * util::make_dir_recursive() attempted to create a directory named "\0" if the path did not have a trailing slash ([PR #7329](https://github.com/realm/realm-core/pull/7329)).
 * Fixed a crash with `Assertion failed: m_initiated` during sync session startup ([#7074](https://github.com/realm/realm-core/issues/7074), since v10.0.0).
 * Fixed a TSAN violation where the user thread could race to read `m_finalized` with the sync event loop ([#6844](https://github.com/realm/realm-core/issues/6844), since v13.15.1)
+* Fix a minor race condition when backing up Realm files before a client reset which could have lead to overwriting an existing file. ([PR #7341](https://github.com/realm/realm-core/pull/7341)).
  
 ### Breaking changes
 * None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * (bindgen) Upgrade `eslint-config-prettier` & `eslint-plugin-prettier` and add a missing peer dependency on `prettier`.
 * The minimum CMake version has changed from 3.15 to 3.22.1. ([#6537](https://github.com/realm/realm-core/issues/6537))
 * Update Catch2 to v3.5.2 ([PR #7297](https://github.com/realm/realm-core/pull/7297)).
+* The unused `partition` and `user_local_uuid()` fields have been removed from `FileActionMetadata`. ([PR #7341](https://github.com/realm/realm-core/pull/7341)).
 
 ----------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Added `SyncSession::get_file_ident()` so you can trigger a client reset via the BAAS admin API ([PR #7203](https://github.com/realm/realm-core/pull/7203)).
 * Audit event scopes containing zero events to save no longer open the audit realm unneccesarily ([PR #7332](https://github.com/realm/realm-core/pull/7332)).
 * Added a method to check if a file needs upgrade. ([#7140](https://github.com/realm/realm-core/issues/7140))
+* Use `clonefile()` when possible in `File::copy()` on Apple platforms for faster copying. ([PR #7341](https://github.com/realm/realm-core/pull/7341)).
 
 ### Fixed
 * Fixed queries like `indexed_property == NONE {x}` which mistakenly matched on only x instead of not x. This only applies when an indexed property with equality (==, or IN) matches with `NONE` on a list of one item. If the constant list contained more than one value then it was working correctly. ([realm-js #7862](https://github.com/realm/realm-java/issues/7862), since v12.5.0) 

--- a/src/realm/object-store/sync/impl/sync_file.cpp
+++ b/src/realm/object-store/sync/impl/sync_file.cpp
@@ -289,10 +289,8 @@ bool SyncFileManager::copy_realm_file(const std::string& old_path, const std::st
 {
     REALM_ASSERT(old_path.length() > 0);
     try {
-        if (File::exists(new_path)) {
-            return false;
-        }
-        File::copy(old_path, new_path);
+        const bool overwrite_existing = false;
+        return File::copy(old_path, new_path, overwrite_existing);
     }
     catch (FileAccessError const&) {
         return false;

--- a/src/realm/object-store/sync/impl/sync_metadata.hpp
+++ b/src/realm/object-store/sync/impl/sync_metadata.hpp
@@ -116,10 +116,6 @@ public:
         ColKey idx_new_name;
         // An enum describing the action to take.
         ColKey idx_action;
-        // The partition key of the Realm.
-        ColKey idx_partition;
-        // The local UUID of the user to whom the file action applies (despite the internal column name).
-        ColKey idx_user_identity;
     };
 
     enum class Action {
@@ -138,11 +134,7 @@ public:
     // For all other `Action`s, it is ignored.
     util::Optional<std::string> new_name() const;
 
-    // Get the local UUID of the user associated with this file action metadata.
-    std::string user_local_uuid() const;
-
     Action action() const;
-    std::string partition() const;
     void remove();
     void set_action(Action new_action);
 
@@ -217,8 +209,8 @@ public:
     bool perform_file_actions(SyncFileManager& file_manager, StringData path) const;
 
     // Create file action metadata.
-    void make_file_action_metadata(StringData original_name, StringData partition_key_value, StringData local_uuid,
-                                   SyncFileActionMetadata::Action action, StringData new_name = {}) const;
+    void make_file_action_metadata(StringData original_name, SyncFileActionMetadata::Action action,
+                                   StringData new_name = {}) const;
 
     util::Optional<std::string> get_current_user_identity() const;
     void set_current_user_identity(const std::string& identity);

--- a/src/realm/object-store/sync/sync_session.cpp
+++ b/src/realm/object-store/sync/sync_session.cpp
@@ -455,10 +455,8 @@ void SyncSession::update_error_and_mark_file_for_deletion(SyncError& error, Shou
     using Action = SyncFileActionMetadata::Action;
     auto action = should_backup == ShouldBackup::yes ? Action::BackUpThenDeleteRealm : Action::DeleteRealm;
     m_sync_manager->perform_metadata_update([action, original_path = std::move(original_path),
-                                             recovery_path = std::move(recovery_path),
-                                             partition_value = m_config.sync_config->partition_value,
-                                             identity = m_config.sync_config->user->identity()](const auto& manager) {
-        manager.make_file_action_metadata(original_path, partition_value, identity, action, recovery_path);
+                                             recovery_path = std::move(recovery_path)](const auto& manager) {
+        manager.make_file_action_metadata(original_path, action, recovery_path);
     });
 }
 

--- a/src/realm/util/file.hpp
+++ b/src/realm/util/file.hpp
@@ -34,12 +34,12 @@
 #include <sys/stat.h>
 #endif
 
-#include <realm/utilities.hpp>
-#include <realm/util/assert.hpp>
 #include <realm/exceptions.hpp>
+#include <realm/util/assert.hpp>
 #include <realm/util/features.h>
 #include <realm/util/function_ref.hpp>
 #include <realm/util/safe_int_ops.hpp>
+#include <realm/utilities.hpp>
 
 #if defined(_MSVC_LANG) // compiling with MSVC
 #include <filesystem>
@@ -516,7 +516,7 @@ public:
     static void move(const std::string& old_path, const std::string& new_path);
 
     /// Copy the file at the specified origin path to the specified target path.
-    static void copy(const std::string& origin_path, const std::string& target_path);
+    static bool copy(const std::string& origin_path, const std::string& target_path, bool overwrite_existing = true);
 
     /// Compare the two files at the specified paths for equality. Returns true
     /// if, and only if they are equal.

--- a/test/object-store/sync/metadata.cpp
+++ b/test/object-store/sync/metadata.cpp
@@ -177,13 +177,11 @@ TEST_CASE("sync_metadata: file action metadata", "[sync][metadata]") {
 
     SECTION("can be properly constructed") {
         const auto original_name = util::make_temp_dir() + "foobar/test1";
-        manager.make_file_action_metadata(original_name, url_1, local_uuid_1, SyncAction::BackUpThenDeleteRealm);
+        manager.make_file_action_metadata(original_name, SyncAction::BackUpThenDeleteRealm);
         auto metadata = *manager.get_file_action_metadata(original_name);
         REQUIRE(metadata.original_name() == original_name);
         REQUIRE(metadata.new_name() == none);
         REQUIRE(metadata.action() == SyncAction::BackUpThenDeleteRealm);
-        REQUIRE(metadata.partition() == url_1);
-        REQUIRE(metadata.user_local_uuid() == local_uuid_1);
     }
 
     SECTION("properly reflects updating state, across multiple instances") {
@@ -191,16 +189,13 @@ TEST_CASE("sync_metadata: file action metadata", "[sync][metadata]") {
         const std::string new_name_1 = util::make_temp_dir() + "foobar/test2b";
         const std::string new_name_2 = util::make_temp_dir() + "foobar/test2c";
 
-        manager.make_file_action_metadata(original_name, url_1, local_uuid_1, SyncAction::BackUpThenDeleteRealm,
-                                          new_name_1);
+        manager.make_file_action_metadata(original_name, SyncAction::BackUpThenDeleteRealm, new_name_1);
         auto metadata_1 = *manager.get_file_action_metadata(original_name);
         REQUIRE(metadata_1.original_name() == original_name);
         REQUIRE(metadata_1.new_name() == new_name_1);
         REQUIRE(metadata_1.action() == SyncAction::BackUpThenDeleteRealm);
-        REQUIRE(metadata_1.partition() == url_1);
-        REQUIRE(metadata_1.user_local_uuid() == local_uuid_1);
 
-        manager.make_file_action_metadata(original_name, url_2, local_uuid_2, SyncAction::DeleteRealm, new_name_2);
+        manager.make_file_action_metadata(original_name, SyncAction::DeleteRealm, new_name_2);
         auto metadata_2 = *manager.get_file_action_metadata(original_name);
         REQUIRE(metadata_1.original_name() == original_name);
         REQUIRE(metadata_1.new_name() == new_name_2);
@@ -208,8 +203,6 @@ TEST_CASE("sync_metadata: file action metadata", "[sync][metadata]") {
         REQUIRE(metadata_2.original_name() == original_name);
         REQUIRE(metadata_2.new_name() == new_name_2);
         REQUIRE(metadata_2.action() == SyncAction::DeleteRealm);
-        REQUIRE(metadata_1.partition() == url_2);
-        REQUIRE(metadata_1.user_local_uuid() == local_uuid_2);
     }
 }
 
@@ -224,12 +217,9 @@ TEST_CASE("sync_metadata: file action metadata APIs", "[sync][metadata]") {
         const auto filename1 = util::make_temp_dir() + "foobar/file1";
         const auto filename2 = util::make_temp_dir() + "foobar/file2";
         const auto filename3 = util::make_temp_dir() + "foobar/file3";
-        manager.make_file_action_metadata(filename1, "asdf", "realm://realm.example.com/1",
-                                          SyncAction::BackUpThenDeleteRealm);
-        manager.make_file_action_metadata(filename2, "asdf", "realm://realm.example.com/2",
-                                          SyncAction::BackUpThenDeleteRealm);
-        manager.make_file_action_metadata(filename3, "asdf", "realm://realm.example.com/3",
-                                          SyncAction::BackUpThenDeleteRealm);
+        manager.make_file_action_metadata(filename1, SyncAction::BackUpThenDeleteRealm);
+        manager.make_file_action_metadata(filename2, SyncAction::BackUpThenDeleteRealm);
+        manager.make_file_action_metadata(filename3, SyncAction::BackUpThenDeleteRealm);
         auto actions = manager.all_pending_actions();
         REQUIRE(actions.size() == 3);
         REQUIRE(results_contains_original_name(actions, filename1));

--- a/test/object-store/sync/sync_manager.cpp
+++ b/test/object-store/sync/sync_manager.cpp
@@ -499,7 +499,7 @@ TEST_CASE("sync_manager: file actions", "[sync][sync manager]") {
         REQUIRE(locked_realm);
 
         TestSyncManager tsm(config);
-        manager.make_file_action_metadata(realm_path_1, realm_url, "user1", Action::DeleteRealm);
+        manager.make_file_action_metadata(realm_path_1, Action::DeleteRealm);
 
         REQUIRE_FALSE(tsm.app()->sync_manager()->immediately_run_file_actions(realm_path_1));
     }
@@ -508,9 +508,9 @@ TEST_CASE("sync_manager: file actions", "[sync][sync manager]") {
     SECTION("Action::DeleteRealm") {
 
         // Create some file actions
-        manager.make_file_action_metadata(realm_path_1, realm_url, "user1", Action::DeleteRealm);
-        manager.make_file_action_metadata(realm_path_2, realm_url, "user2", Action::DeleteRealm);
-        manager.make_file_action_metadata(realm_path_3, realm_url, "user3", Action::DeleteRealm);
+        manager.make_file_action_metadata(realm_path_1, Action::DeleteRealm);
+        manager.make_file_action_metadata(realm_path_2, Action::DeleteRealm);
+        manager.make_file_action_metadata(realm_path_3, Action::DeleteRealm);
 
         SECTION("should properly delete the Realm") {
             // Create some Realms
@@ -560,12 +560,9 @@ TEST_CASE("sync_manager: file actions", "[sync][sync manager]") {
         const std::string recovery_1 = util::file_path_by_appending_component(recovery_dir, "recovery-1");
         const std::string recovery_2 = util::file_path_by_appending_component(recovery_dir, "recovery-2");
         const std::string recovery_3 = util::file_path_by_appending_component(recovery_dir, "recovery-3");
-        manager.make_file_action_metadata(realm_path_1, realm_url, "user1", Action::BackUpThenDeleteRealm,
-                                          recovery_1);
-        manager.make_file_action_metadata(realm_path_2, realm_url, "user2", Action::BackUpThenDeleteRealm,
-                                          recovery_2);
-        manager.make_file_action_metadata(realm_path_3, realm_url, "user3", Action::BackUpThenDeleteRealm,
-                                          recovery_3);
+        manager.make_file_action_metadata(realm_path_1, Action::BackUpThenDeleteRealm, recovery_1);
+        manager.make_file_action_metadata(realm_path_2, Action::BackUpThenDeleteRealm, recovery_2);
+        manager.make_file_action_metadata(realm_path_3, Action::BackUpThenDeleteRealm, recovery_3);
 
         SECTION("should properly copy the Realm file and delete the Realm") {
             // Create some Realms
@@ -595,8 +592,7 @@ TEST_CASE("sync_manager: file actions", "[sync][sync manager]") {
             REQUIRE_REALM_EXISTS(realm_base_path);
             REQUIRE(!File::exists(recovery_path));
             // Manually create a file action metadata entry to simulate a client reset.
-            manager.make_file_action_metadata(realm_base_path, realm_url, identity, Action::BackUpThenDeleteRealm,
-                                              recovery_path);
+            manager.make_file_action_metadata(realm_base_path, Action::BackUpThenDeleteRealm, recovery_path);
             auto pending_actions = manager.all_pending_actions();
             REQUIRE(pending_actions.size() == 4);
 
@@ -633,8 +629,7 @@ TEST_CASE("sync_manager: file actions", "[sync][sync manager]") {
             // Add a file action after the system is configured.
             REQUIRE_REALM_EXISTS(realm_path_4);
             REQUIRE(File::exists(file_manager.recovery_directory_path()));
-            manager.make_file_action_metadata(realm_path_4, realm_url, "user4", Action::BackUpThenDeleteRealm,
-                                              recovery_1);
+            manager.make_file_action_metadata(realm_path_4, Action::BackUpThenDeleteRealm, recovery_1);
             REQUIRE(manager.all_pending_actions().size() == 1);
             // Force the recovery. (In a real application, the user would have closed the files by now.)
             REQUIRE(tsm.app()->sync_manager()->immediately_run_file_actions(realm_path_4));


### PR DESCRIPTION
Checking if the destination of a copy exists before trying to copy is a TOCTOU race because the state of the filesystem can change between when we check and when we perform the copy. We should instead just open the target file and not perform the copy if it already existed.

`clonefile()` is an APFS feature to perform copy-on-write clones of files. This is much faster, and makes it so that the copy and then delete original that we do doesn't consume extra disk space. It's not always supported, so we fall back to manual copying if it fails.

Two of the file action fields weren't actually used for anything.