### PR TITLE
Schema migration tests to use admin API rather than querying backing cluster

### DIFF
--- a/test/object-store/util/sync/baas_admin_api.cpp
+++ b/test/object-store/util/sync/baas_admin_api.cpp
@@ -735,6 +735,20 @@ AdminAPISession::ServiceConfig AdminAPISession::set_disable_recovery_to(const st
     return sync_config;
 }
 
+std::vector<AdminAPISession::SchemaVersionInfo> AdminAPISession::get_schema_versions(const std::string& app_id) const
+{
+    std::vector<AdminAPISession::SchemaVersionInfo> ret;
+    auto endpoint = apps()[app_id]["sync"]["schemas"]["versions"];
+    auto res = endpoint.get_json();
+    for (auto&& version : res["versions"].get<std::vector<nlohmann::json>>()) {
+        SchemaVersionInfo info;
+        info.version_major = version["version_major"];
+        ret.push_back(std::move(info));
+    }
+
+    return ret;
+}
+
 AdminAPISession::ServiceConfig AdminAPISession::get_config(const std::string& app_id,
                                                            const AdminAPISession::Service& service) const
 {

--- a/test/object-store/util/sync/baas_admin_api.hpp
+++ b/test/object-store/util/sync/baas_admin_api.hpp
@@ -124,6 +124,10 @@ public:
                               ServiceConfig sync_config) const;
     ServiceConfig set_disable_recovery_to(const std::string& app_id, const std::string& service_id,
                                           ServiceConfig sync_config, bool disable) const;
+    struct SchemaVersionInfo {
+        int64_t version_major;
+    };
+    std::vector<SchemaVersionInfo> get_schema_versions(const std::string& app_id) const;
     bool is_sync_enabled(const std::string& app_id) const;
     bool is_sync_terminated(const std::string& app_id) const;
     bool is_initial_sync_complete(const std::string& app_id) const;


### PR DESCRIPTION
In the new baasaas world we don't have access to the backing cluster and the schema migration tests fail. Fortunately there is an admin API endpoint that does exactly what we need. This just updates our tests to use the correct API.

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- Link to relevant issue this fixes -->

## ☑️ ToDos
* [ ] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed
* [ ] `bindgen/spec.yml`, if public C++ API changed
