### PR TITLE
Begin decoupling sync tests from App

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 * Fix a minor race condition when backing up Realm files before a client reset which could have lead to overwriting an existing file. ([PR #7341](https://github.com/realm/realm-core/pull/7341)).
  
 ### Breaking changes
-* None.
+* SyncManager no longer supports reconfiguring after calling reset_for_testing(). SyncManager::configure() has been folded into the constructor, and reset_for_testing() has been renamed to tear_down_for_testing(). ([PR #7351](https://github.com/realm/realm-core/pull/7351))
 
 ### Compatibility
 * Fileformat: Generates files with format v23. Reads and automatically upgrade from fileformat v5.

--- a/src/realm/object-store/audit.mm
+++ b/src/realm/object-store/audit.mm
@@ -683,7 +683,7 @@ std::shared_ptr<AuditRealmPool> AuditRealmPool::get_pool(std::shared_ptr<SyncUse
                                  }),
                   s_pools.end());
 
-    auto app_id = user->sync_manager()->app().lock()->config().app_id;
+    auto app_id = user->sync_manager()->app_id();
     auto it = std::find_if(s_pools.begin(), s_pools.end(), [&](auto& pool) {
         return pool.user_identity == user->identity() && pool.partition_prefix == partition_prefix &&
                pool.app_id == app_id;
@@ -889,7 +889,6 @@ void AuditRealmPool::open_new_realm()
 
     Realm::Config config;
     config.automatic_change_notifications = false;
-    config.cache = false;
     config.path = util::format("%1%2.realm", m_path_root, partition);
     config.scheduler = util::Scheduler::make_dummy();
     config.schema = Schema{schema};

--- a/src/realm/object-store/sync/app.cpp
+++ b/src/realm/object-store/sync/app.cpp
@@ -313,8 +313,7 @@ void App::configure(const SyncClientConfig& sync_client_config)
     // Start with an empty sync route in the sync manager. It will ensure the
     // location has been updated at least once when the first sync session is
     // started by requesting a new access token.
-    m_sync_manager = std::make_shared<SyncManager>();
-    m_sync_manager->configure(shared_from_this(), util::none, sync_client_config);
+    m_sync_manager = SyncManager::create(shared_from_this(), {}, sync_client_config, config().app_id);
 }
 
 bool App::init_logger()

--- a/src/realm/object-store/sync/sync_manager.cpp
+++ b/src/realm/object-store/sync/sync_manager.cpp
@@ -43,58 +43,37 @@ SyncClientTimeouts::SyncClientTimeouts()
 {
 }
 
-SyncManager::SyncManager() = default;
-
-void SyncManager::configure(std::shared_ptr<app::App> app, std::optional<std::string> sync_route,
-                            const SyncClientConfig& config)
+std::shared_ptr<SyncManager> SyncManager::create(std::shared_ptr<app::App> app, std::optional<std::string> sync_route,
+                                                 const SyncClientConfig& config, const std::string& app_id)
 {
-    std::vector<std::shared_ptr<SyncUser>> users_to_add;
-    {
-        // Locking the mutex here ensures that it is released before locking m_user_mutex
-        util::CheckedLockGuard lock(m_mutex);
-        m_app = app;
-        m_sync_route = sync_route;
-        m_config = std::move(config);
-        if (m_sync_client)
-            return;
+    return std::make_shared<SyncManager>(Private(), std::move(app), std::move(sync_route), config, app_id);
+}
 
-        // create a new logger - if the logger_factory is updated later, a new
-        // logger will be created at that time.
-        do_make_logger();
+SyncManager::SyncManager(Private, std::shared_ptr<app::App> app, std::optional<std::string> sync_route,
+                         const SyncClientConfig& config, const std::string& app_id)
+    : m_config(config)
+    , m_file_manager(std::make_unique<SyncFileManager>(m_config.base_file_path, app_id))
+    , m_sync_route(sync_route)
+    , m_app(app)
+    , m_app_id(app_id)
+{
+    // create the initial logger - if the logger_factory is updated later, a new
+    // logger will be created at that time.
+    do_make_logger();
 
-        {
-            util::CheckedLockGuard lock(m_file_system_mutex);
-
-            // Set up the file manager.
-            if (m_file_manager) {
-                // Changing the base path for tests requires calling reset_for_testing()
-                // first, and otherwise isn't supported
-                REALM_ASSERT(m_file_manager->base_path() == m_config.base_file_path);
-            }
-            else {
-                m_file_manager = std::make_unique<SyncFileManager>(m_config.base_file_path, app->config().app_id);
-            }
-
-            // Set up the metadata manager, and perform initial loading/purging work.
-            if (m_metadata_manager || m_config.metadata_mode == MetadataMode::NoMetadata) {
-                return;
-            }
-
-            bool encrypt = m_config.metadata_mode == MetadataMode::Encryption;
-            m_metadata_manager = std::make_unique<SyncMetadataManager>(m_file_manager->metadata_path(), encrypt,
-                                                                       m_config.custom_encryption_key);
-
-            m_metadata_manager->perform_launch_actions(*m_file_manager);
-
-            // Load persisted users into the users map.
-            for (auto user : m_metadata_manager->all_logged_in_users()) {
-                users_to_add.push_back(std::make_shared<SyncUser>(SyncUser::Private(), user, this));
-            }
-        }
+    if (m_config.metadata_mode == MetadataMode::NoMetadata) {
+        return;
     }
-    {
-        util::CheckedLockGuard lock(m_user_mutex);
-        m_users.insert(m_users.end(), users_to_add.begin(), users_to_add.end());
+
+    bool encrypt = m_config.metadata_mode == MetadataMode::Encryption;
+    m_metadata_manager = std::make_unique<SyncMetadataManager>(m_file_manager->metadata_path(), encrypt,
+                                                               m_config.custom_encryption_key);
+
+    m_metadata_manager->perform_launch_actions(*m_file_manager);
+
+    // Load persisted users into the users map.
+    for (auto user : m_metadata_manager->all_logged_in_users()) {
+        m_users.push_back(std::make_shared<SyncUser>(SyncUser::Private(), user, this));
     }
 }
 
@@ -107,8 +86,10 @@ bool SyncManager::immediately_run_file_actions(const std::string& realm_path)
     return false;
 }
 
-void SyncManager::reset_for_testing()
+void SyncManager::tear_down_for_testing()
 {
+    close_all_sessions();
+
     {
         util::CheckedLockGuard lock(m_file_system_mutex);
         m_metadata_manager = nullptr;
@@ -146,8 +127,8 @@ void SyncManager::reset_for_testing()
             std::this_thread::sleep_for(std::chrono::milliseconds(10));
             lock.lock();
         }
-        // Callers of `SyncManager::reset_for_testing` should ensure there are no existing sessions
-        // prior to calling `reset_for_testing`.
+        // Callers of `SyncManager::tear_down_for_testing` should ensure there are no existing sessions
+        // prior to calling `tear_down_for_testing`.
         if (!no_sessions) {
             util::CheckedLockGuard lock(m_mutex);
             for (auto session : m_sessions) {
@@ -168,9 +149,6 @@ void SyncManager::reset_for_testing()
         util::CheckedLockGuard lock(m_mutex);
         // Destroy the client now that we have no remaining sessions.
         m_sync_client = nullptr;
-
-        // Reset even more state.
-        m_config = {};
         m_logger_ptr.reset();
         m_sync_route.reset();
     }

--- a/src/realm/object-store/sync/sync_manager.hpp
+++ b/src/realm/object-store/sync/sync_manager.hpp
@@ -105,9 +105,7 @@ struct SyncClientConfig {
 };
 
 class SyncManager : public std::enable_shared_from_this<SyncManager> {
-    friend class SyncSession;
-    friend class ::TestSyncManager;
-    friend class ::TestAppSession;
+    struct Private {};
 
 public:
     using MetadataMode = SyncClientConfig::MetadataMode;
@@ -215,11 +213,11 @@ public:
     std::string recovery_directory_path(util::Optional<std::string> const& custom_dir_name = none) const
         REQUIRES(!m_file_system_mutex);
 
-    // Reset the singleton state for testing purposes. DO NOT CALL OUTSIDE OF TESTING CODE.
-    // Precondition: any synced Realms or `SyncSession`s must be closed or rendered inactive prior to
-    // calling this method.
-    void reset_for_testing() REQUIRES(!m_mutex, !m_file_system_mutex, !m_user_mutex, !m_session_mutex);
-
+    // DO NOT CALL OUTSIDE OF TESTING CODE.
+    // Forcibly close all remaining sync sessions, stop the sync client, and
+    // discard all state. The SyncManager must never be used again after this
+    // function has been called.
+    void tear_down_for_testing() REQUIRES(!m_mutex, !m_file_system_mutex, !m_user_mutex, !m_session_mutex);
 
     // Immediately closes any open sync sessions for this sync manager
     void close_all_sessions() REQUIRES(!m_mutex, !m_session_mutex);
@@ -249,6 +247,11 @@ public:
         return m_app;
     }
 
+    const std::string& app_id() const
+    {
+        return m_app_id;
+    }
+
     SyncClientConfig config() const REQUIRES(!m_mutex)
     {
         util::CheckedLockGuard lock(m_mutex);
@@ -258,29 +261,23 @@ public:
     // Return the cached logger
     const std::shared_ptr<util::Logger>& get_logger() const REQUIRES(!m_mutex);
 
-    SyncManager();
-    SyncManager(const SyncManager&) = delete;
-    SyncManager& operator=(const SyncManager&) = delete;
-
     struct OnlyForTesting {
         friend class TestHelper;
 
         static void voluntary_disconnect_all_connections(SyncManager&);
     };
 
-protected:
-    friend class SyncUser;
-    friend class SyncSesson;
-
-    using std::enable_shared_from_this<SyncManager>::shared_from_this;
-    using std::enable_shared_from_this<SyncManager>::weak_from_this;
+    static std::shared_ptr<SyncManager> create(std::shared_ptr<app::App> app, std::optional<std::string> sync_route,
+                                               const SyncClientConfig& config, const std::string& app_id);
+    SyncManager(Private, std::shared_ptr<app::App> app, std::optional<std::string> sync_route,
+                const SyncClientConfig& config, const std::string& app_id);
 
 private:
     friend class app::App;
-
-    void configure(std::shared_ptr<app::App> app, std::optional<std::string> sync_route,
-                   const SyncClientConfig& config)
-        REQUIRES(!m_mutex, !m_file_system_mutex, !m_user_mutex, !m_session_mutex);
+    friend class SyncSession;
+    friend class SyncUser;
+    friend class ::TestSyncManager;
+    friend class ::TestAppSession;
 
     // Stop tracking the session for the given path if it is inactive.
     // No-op if the session is either still active or in the active sessions list
@@ -332,10 +329,11 @@ private:
     bool do_has_existing_sessions() REQUIRES(m_session_mutex);
 
     // The sync route URL to connect to the server. This can be initially empty, but should not
-    // be cleared once it has been set to a value, except by `reset_for_testing()`.
+    // be cleared once it has been set to a value, except by `tear_down_for_testing()`.
     std::optional<std::string> m_sync_route GUARDED_BY(m_mutex);
 
     std::weak_ptr<app::App> m_app GUARDED_BY(m_mutex);
+    const std::string m_app_id;
 };
 
 } // namespace realm

--- a/test/object-store/audit.cpp
+++ b/test/object-store/audit.cpp
@@ -78,7 +78,7 @@ util::Optional<std::string> to_optional_string(StringData sd)
 std::vector<AuditEvent> get_audit_events(TestSyncManager& manager, bool parse_events = true)
 {
     // Wait for all sessions to be fully uploaded and then tear them down
-    auto sync_manager = manager.app()->sync_manager();
+    auto sync_manager = manager.sync_manager();
     REALM_ASSERT(sync_manager);
     auto sessions = sync_manager->get_all_sessions();
     for (auto& session : sessions) {
@@ -1572,7 +1572,7 @@ TEST_CASE("audit realm sharding", "[sync][pbs][audit]") {
     auto close_all_sessions = [&] {
         realm->close();
         realm = nullptr;
-        auto sync_manager = test_session.app()->sync_manager();
+        auto sync_manager = test_session.sync_manager();
         for (auto& session : sync_manager->get_all_sessions()) {
             session->shutdown_and_wait();
         }
@@ -1785,7 +1785,7 @@ TEST_CASE("audit integration tests", "[sync][pbs][audit][baas]") {
         auto audit_user = session.app()->current_user();
         config.audit_config->audit_user = audit_user;
         auto realm = Realm::get_shared_realm(config);
-        session.app()->sync_manager()->remove_user(audit_user->identity());
+        session.sync_manager()->remove_user(audit_user->identity());
 
         auto audit = realm->audit_context();
         auto scope = audit->begin_scope("scope");

--- a/test/object-store/audit.cpp
+++ b/test/object-store/audit.cpp
@@ -265,7 +265,7 @@ struct TestClock {
 
 TEST_CASE("audit object serialization", "[sync][pbs][audit]") {
     TestSyncManager test_session;
-    SyncTestFile config(test_session.app(), "parent");
+    SyncTestFile config(test_session, "parent");
     config.automatic_change_notifications = false;
     config.schema_version = 1;
     config.schema = Schema{
@@ -1066,7 +1066,7 @@ TEST_CASE("audit management", "[sync][pbs][audit]") {
     TestClock clock;
 
     TestSyncManager test_session;
-    SyncTestFile config(test_session.app(), "parent");
+    SyncTestFile config(test_session, "parent");
     config.automatic_change_notifications = false;
     config.schema_version = 1;
     config.schema = Schema{
@@ -1087,7 +1087,7 @@ TEST_CASE("audit management", "[sync][pbs][audit]") {
     realm->sync_session()->close();
 
     SECTION("config validation") {
-        SyncTestFile config(test_session.app(), "parent2");
+        SyncTestFile config(test_session, "parent2");
         config.automatic_change_notifications = false;
         config.audit_config = std::make_shared<AuditConfig>();
         SECTION("invalid prefix") {
@@ -1495,7 +1495,7 @@ TEST_CASE("audit realm sharding", "[sync][pbs][audit]") {
     // a lot of local unuploaded data.
     TestSyncManager test_session{{}, {.start_immediately = false}};
 
-    SyncTestFile config(test_session.app(), "parent");
+    SyncTestFile config(test_session, "parent");
     config.automatic_change_notifications = false;
     config.schema_version = 1;
     config.schema = Schema{
@@ -1604,7 +1604,7 @@ TEST_CASE("audit realm sharding", "[sync][pbs][audit]") {
         test_session.sync_server().start();
 
         // Open a different Realm with the same user and audit prefix
-        SyncTestFile config(test_session.app(), "other");
+        SyncTestFile config(test_session, "other");
         config.audit_config = std::make_shared<AuditConfig>();
         config.audit_config->logger = audit_logger;
         auto realm = Realm::get_shared_realm(config);
@@ -1631,7 +1631,7 @@ TEST_CASE("audit realm sharding", "[sync][pbs][audit]") {
         test_session.sync_server().start();
 
         // Open the same Realm with a different audit prefix
-        SyncTestFile config(test_session.app(), "parent");
+        SyncTestFile config(test_session, "parent");
         config.audit_config = std::make_shared<AuditConfig>();
         config.audit_config->logger = audit_logger;
         config.audit_config->partition_value_prefix = "other";
@@ -1719,7 +1719,7 @@ TEST_CASE("audit integration tests", "[sync][pbs][audit][baas]") {
         realm->sync_session()->close();
         generate_event(realm);
 
-        auto events = get_audit_events_from_baas(session, *config.sync_config->user, 1);
+        auto events = get_audit_events_from_baas(session, *session.app()->current_user(), 1);
         REQUIRE(events.size() == 1);
         REQUIRE(events[0].activity == "scope");
         REQUIRE(events[0].event == "read");
@@ -1728,18 +1728,20 @@ TEST_CASE("audit integration tests", "[sync][pbs][audit][baas]") {
     }
 
     SECTION("different user from parent Realm") {
+        auto sync_user = session.app()->current_user();
         create_user_and_log_in(session.app());
-        config.audit_config->audit_user = session.app()->current_user();
+        auto audit_user = session.app()->current_user();
+        config.audit_config->audit_user = audit_user;
         auto realm = Realm::get_shared_realm(config);
         // If audit uses the sync user this'll make it fail as that user is logged out
-        config.sync_config->user->log_out();
+        sync_user->log_out();
 
         generate_event(realm);
-        REQUIRE(get_audit_events_from_baas(session, *config.audit_config->audit_user, 1).size() == 1);
+        REQUIRE(get_audit_events_from_baas(session, *audit_user, 1).size() == 1);
     }
 
     SECTION("different app from parent Realm") {
-        auto audit_user = config.sync_config->user;
+        auto audit_user = session.app()->current_user();
 
         // Create an app which does not include AuditEvent in the schema so that
         // things will break if audit tries to use it
@@ -1766,7 +1768,7 @@ TEST_CASE("audit integration tests", "[sync][pbs][audit][baas]") {
         generate_event(realm, 3);
 
         using Metadata = std::map<std::string, std::string>;
-        auto events = get_audit_events_from_baas(session, *config.sync_config->user, 4);
+        auto events = get_audit_events_from_baas(session, *session.app()->current_user(), 4);
         REQUIRE(events[0].metadata.empty());
         REQUIRE(events[1].metadata == Metadata({{"metadata 1", "value 1"}}));
         REQUIRE(events[2].metadata == Metadata({{"metadata 2", "value 2"}}));
@@ -1814,7 +1816,7 @@ TEST_CASE("audit integration tests", "[sync][pbs][audit][baas]") {
     }
 
     SECTION("incoming changesets are discarded") {
-        app::MongoClient remote_client = config.sync_config->user->mongo_client("BackingDB");
+        app::MongoClient remote_client = session.app()->current_user()->mongo_client("BackingDB");
         app::MongoDatabase db = remote_client.db(session.app_session().config.mongo_dbname);
         app::MongoCollection collection = db["AuditEvent"];
 
@@ -1905,7 +1907,7 @@ TEST_CASE("audit integration tests", "[sync][pbs][audit][baas]") {
 
             realm->sync_session()->force_close();
             generate_event(realm, 0);
-            get_audit_events_from_baas(session, *config.audit_config->audit_user, 1);
+            get_audit_events_from_baas(session, *session.app()->current_user(), 1);
         }
     }
 

--- a/test/object-store/benchmarks/client_reset.cpp
+++ b/test/object-store/benchmarks/client_reset.cpp
@@ -192,13 +192,12 @@ TEST_CASE("client reset", "[sync][pbs][benchmark][client reset]") {
     };
 
     TestSyncManager init_sync_manager;
-    SyncTestFile config(init_sync_manager.app(), "default");
-    config.cache = false;
+    SyncTestFile config(init_sync_manager, "default");
     config.automatic_change_notifications = false;
     config.schema = schema;
     ClientResyncMode reset_mode = GENERATE(ClientResyncMode::DiscardLocal, ClientResyncMode::Recover);
     config.sync_config->client_resync_mode = reset_mode;
-    SyncTestFile config2(init_sync_manager.app(), "default");
+    SyncTestFile config2(init_sync_manager, "default");
 
     auto populate_objects = [&](SharedRealm realm, size_t num_objects) {
         TableRef table = get_table(*realm, "object");

--- a/test/object-store/benchmarks/object.cpp
+++ b/test/object-store/benchmarks/object.cpp
@@ -781,7 +781,6 @@ TEST_CASE("Benchmark object notification delivery", "[benchmark][notifications]"
     InMemoryTestFile config;
     config.automatic_change_notifications = false;
     config.schema = Schema{{"object", {{"value", PropertyType::Int}}}};
-    config.cache = false;
     auto r = Realm::get_shared_realm(config);
 
     r->begin_transaction();

--- a/test/object-store/c_api/c_api.cpp
+++ b/test/object-store/c_api/c_api.cpp
@@ -41,6 +41,7 @@
 #if REALM_ENABLE_SYNC
 #include "util/sync/flx_sync_harness.hpp"
 #include "util/sync/sync_test_utils.hpp"
+#include "util/test_path.hpp"
 #include "util/unit_test_transport.hpp"
 
 #include <realm/object-store/sync/app_utils.hpp>
@@ -590,10 +591,7 @@ TEST_CASE("C API (non-database)", "[c_api]") {
         realm_app_config_set_bundle_id(app_config.get(), "some_bundle_id");
         CHECK(app_config->device_info.bundle_id == "some_bundle_id");
 
-        std::string temp_dir = util::make_temp_dir();
-        auto guard = util::make_scope_exit([&temp_dir]() noexcept {
-            util::try_remove_dir_recursive(temp_dir);
-        });
+        test_util::TestDirGuard temp_dir(util::make_temp_dir());
         auto sync_client_config = cptr(realm_sync_client_config_new());
         realm_sync_client_config_set_base_file_path(sync_client_config.get(), temp_dir.c_str());
         realm_sync_client_config_set_metadata_mode(sync_client_config.get(), RLM_SYNC_CLIENT_METADATA_MODE_DISABLED);

--- a/test/object-store/dictionary.cpp
+++ b/test/object-store/dictionary.cpp
@@ -73,7 +73,6 @@ TEMPLATE_TEST_CASE("dictionary types", "[dictionary]", cf::MixedVal, cf::Int, cf
     using W = typename TestType::Wrapped;
 
     InMemoryTestFile config;
-    config.cache = false;
     config.automatic_change_notifications = false;
     config.schema = Schema{
         {"object",
@@ -883,7 +882,6 @@ TEMPLATE_TEST_CASE("dictionary types", "[dictionary]", cf::MixedVal, cf::Int, cf
 
 TEST_CASE("embedded dictionary", "[dictionary]") {
     InMemoryTestFile config;
-    config.cache = false;
     config.automatic_change_notifications = false;
     config.schema = Schema{
         {"origin", {{"links", PropertyType::Dictionary | PropertyType::Object | PropertyType::Nullable, "target"}}},
@@ -940,7 +938,6 @@ TEMPLATE_TEST_CASE("dictionary of objects", "[dictionary][links]", cf::MixedVal,
     using T = typename TestType::Type;
     using W = typename TestType::Wrapped;
     InMemoryTestFile config;
-    config.cache = false;
     config.automatic_change_notifications = false;
     config.schema = Schema{
         {"object", {{"links", PropertyType::Dictionary | PropertyType::Object | PropertyType::Nullable, "target"}}},
@@ -1050,7 +1047,6 @@ TEMPLATE_TEST_CASE("dictionary of objects", "[dictionary][links]", cf::MixedVal,
 
 TEST_CASE("dictionary with mixed links", "[dictionary]") {
     InMemoryTestFile config;
-    config.cache = false;
     config.automatic_change_notifications = false;
     config.schema = Schema{
         {"object", {{"value", PropertyType::Dictionary | PropertyType::Mixed | PropertyType::Nullable}}},
@@ -1586,7 +1582,6 @@ TEST_CASE("dictionary sort by keyPath value", "[dictionary]") {
 
 TEST_CASE("dictionary sort by linked object value", "[dictionary]") {
     InMemoryTestFile config;
-    config.cache = false;
     config.automatic_change_notifications = false;
     config.schema = Schema{
         {"object",

--- a/test/object-store/frozen_objects.cpp
+++ b/test/object-store/frozen_objects.cpp
@@ -500,10 +500,7 @@ TEST_CASE("Reclaim Frozen", "[frozen]") {
     std::vector<Entry> refs;
     refs.resize(num_pending_transactions);
     TestFile config;
-
     config.schema_version = 1;
-    config.automatic_change_notifications = true;
-    config.cache = false;
     config.schema = Schema{
         {"table", {{"value", PropertyType::Int}, {"link", PropertyType::Object | PropertyType::Nullable, "table"}}}};
     auto realm = Realm::get_shared_realm(config);

--- a/test/object-store/list.cpp
+++ b/test/object-store/list.cpp
@@ -44,7 +44,6 @@ using util::any_cast;
 
 TEST_CASE("list", "[list]") {
     InMemoryTestFile config;
-    config.cache = false;
     config.automatic_change_notifications = false;
     auto r = Realm::get_shared_realm(config);
     r->update_schema({
@@ -1842,7 +1841,7 @@ TEST_CASE("list with unresolved links", "[list]") {
     TestSyncManager init_sync_manager({}, {false});
     auto& server = init_sync_manager.sync_server();
 
-    SyncTestFile config1(init_sync_manager.app(), "shared");
+    SyncTestFile config1(init_sync_manager, "shared");
     config1.schema = Schema{
         {"origin",
          {{"_id", PropertyType::Int, Property::IsPrimary(true)},
@@ -1850,7 +1849,7 @@ TEST_CASE("list with unresolved links", "[list]") {
         {"target", {{"_id", PropertyType::Int, Property::IsPrimary(true)}, {"value", PropertyType::Int}}},
     };
 
-    SyncTestFile config2(init_sync_manager.app(), "shared");
+    SyncTestFile config2(init_sync_manager, "shared");
 
     auto r1 = Realm::get_shared_realm(config1);
     auto r2 = Realm::get_shared_realm(config2);

--- a/test/object-store/migrations.cpp
+++ b/test/object-store/migrations.cpp
@@ -2159,7 +2159,6 @@ TEST_CASE("migration: Additive", "[migration]") {
     };
 
     TestFile config;
-    config.cache = false;
     config.schema = schema;
     config.schema_mode = GENERATE(SchemaMode::AdditiveDiscovered, SchemaMode::AdditiveExplicit);
     auto realm = Realm::get_shared_realm(config);

--- a/test/object-store/object.cpp
+++ b/test/object-store/object.cpp
@@ -1982,9 +1982,9 @@ TEST_CASE("object") {
     SECTION("defaults do not override values explicitly passed to create()") {
         TestSyncManager init_sync_manager({}, {false});
         auto& server = init_sync_manager.sync_server();
-        SyncTestFile config1(init_sync_manager.app(), "shared");
+        SyncTestFile config1(init_sync_manager, "shared");
         config1.schema = config.schema;
-        SyncTestFile config2(init_sync_manager.app(), "shared");
+        SyncTestFile config2(init_sync_manager, "shared");
         config2.schema = config.schema;
 
         AnyDict v1{

--- a/test/object-store/primitive_list.cpp
+++ b/test/object-store/primitive_list.cpp
@@ -118,7 +118,6 @@ TEMPLATE_TEST_CASE("primitive list", "[primitives]", cf::MixedVal, cf::Int, cf::
     using Boxed = typename TestType::Boxed;
 
     InMemoryTestFile config;
-    config.cache = false;
     config.automatic_change_notifications = false;
     config.schema = Schema{
         {"object", {{"value", PropertyType::Array | TestType::property_type}}},
@@ -848,7 +847,6 @@ TEMPLATE_TEST_CASE("primitive list", "[primitives]", cf::MixedVal, cf::Int, cf::
 
 TEST_CASE("list of mixed links", "[primitives]") {
     InMemoryTestFile config;
-    config.cache = false;
     config.automatic_change_notifications = false;
     config.schema = Schema{
         {"object", {{"value", PropertyType::Array | PropertyType::Mixed | PropertyType::Nullable}}},

--- a/test/object-store/realm.cpp
+++ b/test/object-store/realm.cpp
@@ -387,11 +387,7 @@ TEST_CASE("SharedRealm: get_shared_realm()") {
     }
 
     SECTION("should sensibly handle opening an uninitialized file without a schema specified") {
-        SECTION("cached") {
-        }
-        SECTION("uncached") {
-            config.cache = false;
-        }
+        config.cache = GENERATE(false, true);
 
         // create an empty file
         util::File(config.path, util::File::mode_Write);
@@ -926,16 +922,15 @@ TEST_CASE("Get Realm using Async Open", "[sync][pbs][async open]") {
     if (!util::EventLoop::has_implementation())
         return;
 
-    TestSyncManager init_sync_manager;
-    SyncTestFile config(init_sync_manager.app(), "default");
-    config.cache = false;
+    TestSyncManager tsm;
+    SyncTestFile config(tsm, "default");
     ObjectSchema object_schema = {"object",
                                   {
                                       {"_id", PropertyType::Int, Property::IsPrimary{true}},
                                       {"value", PropertyType::Int},
                                   }};
     config.schema = Schema{object_schema};
-    SyncTestFile config2(init_sync_manager.app(), "default");
+    SyncTestFile config2(tsm, "default");
     config2.schema = config.schema;
 
     std::mutex mutex;
@@ -965,7 +960,7 @@ TEST_CASE("Get Realm using Async Open", "[sync][pbs][async open]") {
 
     SECTION("can write a realm file without client file id") {
         ThreadSafeReference realm_ref;
-        SyncTestFile config3(init_sync_manager.app(), "default");
+        SyncTestFile config3(tsm, "default");
         config3.schema = config.schema;
         uint64_t client_file_id;
 
@@ -1116,10 +1111,10 @@ TEST_CASE("Get Realm using Async Open", "[sync][pbs][async open]") {
     }
 
     SECTION("can download multiple Realms at a time") {
-        SyncTestFile config1(init_sync_manager.app(), "realm1");
-        SyncTestFile config2(init_sync_manager.app(), "realm2");
-        SyncTestFile config3(init_sync_manager.app(), "realm3");
-        SyncTestFile config4(init_sync_manager.app(), "realm4");
+        SyncTestFile config1(tsm, "realm1");
+        SyncTestFile config2(tsm, "realm2");
+        SyncTestFile config3(tsm, "realm3");
+        SyncTestFile config4(tsm, "realm4");
 
         std::vector<std::shared_ptr<AsyncOpenTask>> tasks = {
             Realm::get_synchronized_realm(config1),
@@ -1142,9 +1137,10 @@ TEST_CASE("Get Realm using Async Open", "[sync][pbs][async open]") {
     auto expired_token = encode_fake_jwt("", 123, 456);
 
     SECTION("can async open while waiting for a token refresh") {
-        SyncTestFile config(init_sync_manager.app(), "realm");
-        auto valid_token = config.sync_config->user->access_token();
-        config.sync_config->user->update_access_token(std::move(expired_token));
+        SyncTestFile config(tsm, "realm");
+        auto user = config.sync_config->user;
+        auto valid_token = user->access_token();
+        user->update_access_token(std::move(expired_token));
 
         std::atomic<bool> called{false};
         auto task = Realm::get_synchronized_realm(config);
@@ -1154,9 +1150,11 @@ TEST_CASE("Get Realm using Async Open", "[sync][pbs][async open]") {
             REQUIRE(!error);
             called = true;
         });
+        auto session = tsm.sync_manager()->get_existing_session(config.path);
+        REQUIRE(session);
+        CHECK(session->state() == SyncSession::State::WaitingForAccessToken);
 
-        auto body = nlohmann::json({{"access_token", valid_token}}).dump();
-        init_sync_manager.network_callback(app::Response{200, 0, {}, body});
+        session->update_access_token(valid_token);
         util::EventLoop::main().run_until([&] {
             return called.load();
         });
@@ -1165,19 +1163,24 @@ TEST_CASE("Get Realm using Async Open", "[sync][pbs][async open]") {
     }
 
     SECTION("cancels download and reports an error on auth error") {
-        struct Transport : realm::app::GenericNetworkTransport {
+        struct Transport : UnitTestTransport {
             void send_request_to_server(
-                const realm::app::Request&,
+                const realm::app::Request& req,
                 realm::util::UniqueFunction<void(const realm::app::Response&)>&& completion) override
             {
-                completion(app::Response{403});
+                if (req.url.find("/auth/session") != std::string::npos) {
+                    completion(app::Response{403});
+                }
+                else {
+                    UnitTestTransport::send_request_to_server(req, std::move(completion));
+                }
             }
         };
-        TestSyncManager::Config tsm_config;
-        tsm_config.transport = std::make_shared<Transport>();
-        TestSyncManager tsm(tsm_config);
+        OfflineAppSession::Config oas_config;
+        oas_config.transport = std::make_shared<Transport>();
+        OfflineAppSession oas(oas_config);
 
-        SyncTestFile config(tsm.app(), "realm");
+        SyncTestFile config(oas, "realm");
         config.sync_config->user->log_in(expired_token, expired_token);
 
         bool got_error = false;
@@ -1345,7 +1348,7 @@ TEST_CASE("SharedRealm: convert", "[sync][pbs][convert]") {
                                   }};
     Schema schema{object_schema};
 
-    SyncTestFile sync_config1(tsm.app(), "default");
+    SyncTestFile sync_config1(tsm, "default");
     sync_config1.schema = schema;
     TestFile local_config1;
     local_config1.schema = schema;
@@ -1360,7 +1363,7 @@ TEST_CASE("SharedRealm: convert", "[sync][pbs][convert]") {
         wait_for_download(*sync_realm1);
 
         // Copy to a new sync config
-        SyncTestFile sync_config2(tsm.app(), "default");
+        SyncTestFile sync_config2(tsm, "default");
         sync_config2.schema = schema;
 
         sync_realm1->convert(sync_config2);
@@ -1447,7 +1450,7 @@ TEST_CASE("SharedRealm: convert - embedded objects", "[sync][pbs][convert][embed
                                     }};
     Schema schema{object_schema, embedded_schema};
 
-    SyncTestFile sync_config1(tsm.app(), "default");
+    SyncTestFile sync_config1(tsm, "default");
     sync_config1.schema = schema;
     TestFile local_config1;
     local_config1.schema = schema;
@@ -1472,7 +1475,7 @@ TEST_CASE("SharedRealm: convert - embedded objects", "[sync][pbs][convert][embed
         wait_for_download(*sync_realm1);
 
         // Copy to a new sync config
-        SyncTestFile sync_config2(tsm.app(), "default");
+        SyncTestFile sync_config2(tsm, "default");
         sync_config2.schema = schema;
 
         sync_realm1->convert(sync_config2);
@@ -2614,7 +2617,6 @@ TEST_CASE("SharedRealm: async_writes_2") {
         return;
 
     TestFile config;
-    config.cache = false;
     config.schema_version = 0;
     config.schema = Schema{
         {"object", {{"value", PropertyType::Int}}},

--- a/test/object-store/results.cpp
+++ b/test/object-store/results.cpp
@@ -901,7 +901,6 @@ TEST_CASE("notifications: async delivery", "[notifications]") {
 TEST_CASE("notifications: skip", "[notifications]") {
     _impl::RealmCoordinator::assert_no_open_realms();
     InMemoryTestFile config;
-    config.cache = false;
     config.automatic_change_notifications = false;
 
     auto r = Realm::get_shared_realm(config);
@@ -1430,8 +1429,7 @@ TEST_CASE("notifications: sync", "[sync][pbs][notifications]") {
     TestSyncManager init_sync_manager({}, {false});
     auto& server = init_sync_manager.sync_server();
 
-    SyncTestFile config(init_sync_manager.app(), "test");
-    config.cache = false;
+    SyncTestFile config(init_sync_manager, "test");
     config.schema = Schema{
         {"object",
          {
@@ -1476,7 +1474,6 @@ TEST_CASE("notifications: sync", "[sync][pbs][notifications]") {
 TEST_CASE("notifications: results", "[notifications][results]") {
     _impl::RealmCoordinator::assert_no_open_realms();
     InMemoryTestFile config;
-    config.cache = false;
     config.automatic_change_notifications = false;
 
     auto r = Realm::get_shared_realm(config);
@@ -3277,7 +3274,6 @@ TEST_CASE("results: notifications after move", "[notifications][results]") {
 TEST_CASE("results: notifier with no callbacks", "[notifications][results]") {
     _impl::RealmCoordinator::assert_no_open_realms();
     InMemoryTestFile config;
-    config.cache = false;
     config.automatic_change_notifications = false;
 
     auto coordinator = _impl::RealmCoordinator::get_coordinator(config.path);
@@ -3353,7 +3349,6 @@ TEST_CASE("results: notifier with no callbacks", "[notifications][results]") {
 
 TEST_CASE("results: snapshots", "[results]") {
     InMemoryTestFile config;
-    config.cache = false;
     config.automatic_change_notifications = false;
     config.schema = Schema{
         {"object",
@@ -3674,7 +3669,6 @@ TEST_CASE("results: snapshots", "[results]") {
 TEST_CASE("results: distinct", "[results]") {
     const int N = 10;
     InMemoryTestFile config;
-    config.cache = false;
     config.automatic_change_notifications = false;
 
     auto r = Realm::get_shared_realm(config);
@@ -3885,7 +3879,6 @@ TEST_CASE("results: distinct", "[results]") {
 
 TEST_CASE("results: sort", "[results]") {
     InMemoryTestFile config;
-    config.cache = false;
     config.schema = Schema{
         {"object",
          {
@@ -4792,7 +4785,6 @@ TEST_CASE("results: nullable list of primitives", "[results]") {
 
 TEST_CASE("results: limit", "[results][limit]") {
     InMemoryTestFile config;
-    // config.cache = false;
     config.automatic_change_notifications = false;
     config.schema = Schema{
         {"object",
@@ -4918,7 +4910,6 @@ TEST_CASE("results: limit", "[results][limit]") {
 
 TEST_CASE("results: filter", "[results]") {
     InMemoryTestFile config;
-    config.cache = false;
     config.automatic_change_notifications = false;
 
     auto r = Realm::get_shared_realm(config);
@@ -4974,7 +4965,6 @@ TEST_CASE("results: filter", "[results]") {
 
 TEST_CASE("results: public name declared", "[results]") {
     InMemoryTestFile config;
-    // config.cache = false;
     config.automatic_change_notifications = false;
     config.schema = Schema{
         {"object",
@@ -5021,7 +5011,6 @@ TEST_CASE("results: public name declared", "[results]") {
 TEST_CASE("notifications: objects with PK recreated", "[results]") {
     _impl::RealmCoordinator::assert_no_open_realms();
     InMemoryTestFile config;
-    config.cache = false;
     config.automatic_change_notifications = false;
 
     auto r = Realm::get_shared_realm(config);

--- a/test/object-store/set.cpp
+++ b/test/object-store/set.cpp
@@ -1390,7 +1390,6 @@ TEMPLATE_TEST_CASE("set", "[set]", CreateNewSet<void>, ReuseSet<void>)
 
 TEST_CASE("set with mixed links", "[set]") {
     InMemoryTestFile config;
-    config.cache = false;
     config.automatic_change_notifications = false;
     config.schema = Schema{
         {"object", {{"value", PropertyType::Set | PropertyType::Mixed | PropertyType::Nullable}}},

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -19,6 +19,7 @@
 #include "collection_fixtures.hpp"
 #include "util/sync/baas_admin_api.hpp"
 #include "util/sync/sync_test_utils.hpp"
+#include "util/test_path.hpp"
 #include "util/unit_test_transport.hpp"
 
 #include <realm/object-store/impl/object_accessor_impl.hpp>
@@ -47,7 +48,6 @@
 #include <external/mpark/variant.hpp>
 
 #include <condition_variable>
-#include <future>
 #include <iostream>
 #include <list>
 #include <mutex>
@@ -735,26 +735,24 @@ TEST_CASE("app: login_with_credentials integration", "[sync][app][user][baas]") 
         app->log_out([](auto) {});
 
         int subscribe_processed = 0;
-        auto token = app->subscribe([&subscribe_processed](auto& app) {
-            if (!subscribe_processed) {
-                REQUIRE(app.current_user());
-            }
-            else {
-                REQUIRE_FALSE(app.current_user());
-            }
+
+        auto token = app->subscribe([&subscribe_processed](auto&) {
             subscribe_processed++;
         });
 
+        REQUIRE_FALSE(app->current_user());
         auto user = log_in(app);
         CHECK(!user->device_id().empty());
         CHECK(user->has_device_id());
+        REQUIRE(app->current_user());
+        CHECK(subscribe_processed == 1);
 
         bool processed = false;
         app->log_out([&](auto error) {
             REQUIRE_FALSE(error);
             processed = true;
         });
-
+        REQUIRE_FALSE(app->current_user());
         CHECK(processed);
         CHECK(subscribe_processed == 2);
 
@@ -909,8 +907,8 @@ TEST_CASE("app: UsernamePasswordProviderClient integration", "[sync][app][user][
 
     SECTION("log in, remove, log in") {
         app->remove_user(app->current_user(), [](auto) {});
-        CHECK(app->sync_manager()->all_users().size() == 0);
-        CHECK(app->sync_manager()->get_current_user() == nullptr);
+        CHECK(app->all_users().size() == 0);
+        CHECK(app->current_user() == nullptr);
 
         auto user = log_in(app, AppCredentials::username_password(email, password));
         CHECK(user->user_profile().email() == email);
@@ -930,7 +928,7 @@ TEST_CASE("app: UsernamePasswordProviderClient integration", "[sync][app][user][
 
         app->remove_user(user, [&](Optional<AppError> error) {
             REQUIRE(!error);
-            CHECK(app->sync_manager()->all_users().size() == 0);
+            CHECK(app->all_users().size() == 0);
             processed = true;
         });
 
@@ -1276,7 +1274,7 @@ TEST_CASE("app: delete anonymous user integration", "[sync][app][user][baas]") {
     auto app = session.app();
 
     SECTION("delete user expect success") {
-        CHECK(app->sync_manager()->all_users().size() == 1);
+        CHECK(app->all_users().size() == 1);
 
         // Log in user 1
         auto user_a = app->current_user();
@@ -1286,26 +1284,26 @@ TEST_CASE("app: delete anonymous user integration", "[sync][app][user][baas]") {
             // a logged out anon user will be marked as Removed, not LoggedOut
             CHECK(user_a->state() == SyncUser::State::Removed);
         });
-        CHECK(app->sync_manager()->all_users().empty());
-        CHECK(app->sync_manager()->get_current_user() == nullptr);
+        CHECK(app->all_users().empty());
+        CHECK(app->current_user() == nullptr);
 
         app->delete_user(user_a, [&](Optional<app::AppError> error) {
             CHECK(error->reason() == "User must be logged in to be deleted.");
-            CHECK(app->sync_manager()->all_users().size() == 0);
+            CHECK(app->all_users().size() == 0);
         });
 
         // Log in user 2
         auto user_b = log_in(app);
-        CHECK(app->sync_manager()->get_current_user() == user_b);
+        CHECK(app->current_user() == user_b);
         CHECK(user_b->state() == SyncUser::State::LoggedIn);
-        CHECK(app->sync_manager()->all_users().size() == 1);
+        CHECK(app->all_users().size() == 1);
 
         app->delete_user(user_b, [&](Optional<app::AppError> error) {
             REQUIRE_FALSE(error);
-            CHECK(app->sync_manager()->all_users().size() == 0);
+            CHECK(app->all_users().size() == 0);
         });
 
-        CHECK(app->sync_manager()->get_current_user() == nullptr);
+        CHECK(app->current_user() == nullptr);
 
         // check both handles are no longer valid
         CHECK(user_a->state() == SyncUser::State::Removed);
@@ -1319,35 +1317,35 @@ TEST_CASE("app: delete user with credentials integration", "[sync][app][user][ba
     app->remove_user(app->current_user(), [](auto) {});
 
     SECTION("log in and delete") {
-        CHECK(app->sync_manager()->all_users().size() == 0);
-        CHECK(app->sync_manager()->get_current_user() == nullptr);
+        CHECK(app->all_users().size() == 0);
+        CHECK(app->current_user() == nullptr);
 
         auto credentials = create_user_and_log_in(app);
         auto user = app->current_user();
 
-        CHECK(app->sync_manager()->get_current_user() == user);
+        CHECK(app->current_user() == user);
         CHECK(user->state() == SyncUser::State::LoggedIn);
         app->delete_user(user, [&](Optional<app::AppError> error) {
             REQUIRE_FALSE(error);
-            CHECK(app->sync_manager()->all_users().size() == 0);
+            CHECK(app->all_users().size() == 0);
         });
         CHECK(user->state() == SyncUser::State::Removed);
-        CHECK(app->sync_manager()->get_current_user() == nullptr);
+        CHECK(app->current_user() == nullptr);
 
         app->log_in_with_credentials(credentials, [](std::shared_ptr<SyncUser> user, util::Optional<AppError> error) {
             CHECK(!user);
             REQUIRE(error);
             REQUIRE(error->code() == ErrorCodes::InvalidPassword);
         });
-        CHECK(app->sync_manager()->get_current_user() == nullptr);
+        CHECK(app->current_user() == nullptr);
 
-        CHECK(app->sync_manager()->all_users().size() == 0);
+        CHECK(app->all_users().size() == 0);
         app->delete_user(user, [](Optional<app::AppError> err) {
             CHECK(err->code() > 0);
         });
 
-        CHECK(app->sync_manager()->get_current_user() == nullptr);
-        CHECK(app->sync_manager()->all_users().size() == 0);
+        CHECK(app->current_user() == nullptr);
+        CHECK(app->all_users().size() == 0);
         CHECK(user->state() == SyncUser::State::Removed);
     }
 }
@@ -1365,7 +1363,7 @@ TEST_CASE("app: call function", "[sync][app][function][baas]") {
         CHECK(*sum == 15);
     };
     app->call_function<int64_t>("sumFunc", toSum, checkFn);
-    app->call_function<int64_t>(app->sync_manager()->get_current_user(), "sumFunc", toSum, checkFn);
+    app->call_function<int64_t>(app->current_user(), "sumFunc", toSum, checkFn);
 }
 
 // MARK: - Remote Mongo Client Tests
@@ -2183,7 +2181,7 @@ TEST_CASE("app: mixed lists with object links", "[sync][pbs][app][links][baas]")
     };
     {
         TestAppSession test_session(app_session, nullptr, DeleteApp{false});
-        SyncTestFile config(test_session.app(), partition, schema);
+        SyncTestFile config(test_session.app()->current_user(), partition, schema);
         auto realm = Realm::get_shared_realm(config);
 
         CppContext c(realm);
@@ -2785,16 +2783,14 @@ TEST_CASE("app: sync integration", "[sync][pbs][app][baas]") {
 
     {
         std::unique_ptr<realm::AppSession> app_session;
-        std::string base_file_path = util::make_temp_dir() + random_string(10);
         auto redir_transport = std::make_shared<HookedTransport>();
         AutoVerifiedEmailCredentials creds;
 
         auto app_config = get_config(redir_transport, session.app_session());
         set_app_config_defaults(app_config, redir_transport);
 
-        util::try_make_dir(base_file_path);
         SyncClientConfig sc_config;
-        sc_config.base_file_path = base_file_path;
+        sc_config.base_file_path = util::make_temp_dir();
         sc_config.metadata_mode = realm::SyncManager::MetadataMode::NoEncryption;
 
         // initialize app and sync client
@@ -2955,16 +2951,14 @@ TEST_CASE("app: sync integration", "[sync][pbs][app][baas]") {
     }
     SECTION("Test app redirect with no metadata") {
         std::unique_ptr<realm::AppSession> app_session;
-        std::string base_file_path = util::make_temp_dir() + random_string(10);
         auto redir_transport = std::make_shared<HookedTransport>();
         AutoVerifiedEmailCredentials creds, creds2;
 
         auto app_config = get_config(redir_transport, session.app_session());
         set_app_config_defaults(app_config, redir_transport);
 
-        util::try_make_dir(base_file_path);
         SyncClientConfig sc_config;
-        sc_config.base_file_path = base_file_path;
+        sc_config.base_file_path = util::make_temp_dir();
         sc_config.metadata_mode = realm::SyncManager::MetadataMode::NoMetadata;
 
         // initialize app and sync client
@@ -3495,7 +3489,7 @@ TEST_CASE("app: sync integration", "[sync][pbs][app][baas]") {
             {
                 std::atomic<bool> called{false};
                 session->wait_for_upload_completion([&](Status stat) {
-                    std::lock_guard<std::mutex> lock(mtx);
+                    std::lock_guard lock(mtx);
                     called.store(true);
                     REQUIRE(stat.code() == ErrorCodes::InvalidSession);
                 });
@@ -3503,7 +3497,7 @@ TEST_CASE("app: sync integration", "[sync][pbs][app][baas]") {
                 timed_wait_for([&] {
                     return called.load();
                 });
-                std::lock_guard<std::mutex> lock(mtx);
+                std::lock_guard lock(mtx);
                 REQUIRE(called);
             }
 
@@ -3513,7 +3507,7 @@ TEST_CASE("app: sync integration", "[sync][pbs][app][baas]") {
                          Catch::Matchers::StartsWith("Unable to refresh the user access token"));
 
             // the failed refresh logs out the user
-            std::lock_guard<std::mutex> lock(mtx);
+            std::lock_guard lock(mtx);
             REQUIRE(!user->is_logged_in());
         };
 
@@ -3926,7 +3920,6 @@ TEST_CASE("app: base_url", "[sync][app][base_url]") {
     };
 
     std::unique_ptr<realm::AppSession> app_session;
-    std::string base_file_path = util::make_temp_dir() + random_string(10);
     auto redir_transport = std::make_shared<BaseUrlTransport>();
     AutoVerifiedEmailCredentials creds;
     util::Logger::set_default_level_threshold(realm::util::Logger::Level::TEST_LOGGING_LEVEL);
@@ -3935,9 +3928,8 @@ TEST_CASE("app: base_url", "[sync][app][base_url]") {
     App::Config app_config = {"fake-app-id"};
     set_app_config_defaults(app_config, redir_transport);
 
-    util::try_make_dir(base_file_path);
     SyncClientConfig sc_config;
-    sc_config.base_file_path = base_file_path;
+    sc_config.base_file_path = util::make_temp_dir();
     sc_config.metadata_mode = realm::SyncManager::MetadataMode::NoEncryption;
     sc_config.logger_factory = [](util::Logger::Level) {
         return util::Logger::get_default_logger();
@@ -3953,7 +3945,6 @@ TEST_CASE("app: base_url", "[sync][app][base_url]") {
     };
 
     SECTION("Test app config baseurl") {
-        // Metadata mode doesn't matter, since App isn't using it anymore
         {
             redir_transport->reset("https://realm.mongodb.com");
 
@@ -4664,10 +4655,10 @@ TEST_CASE("app: custom error handling", "[sync][app][custom errors]") {
     };
 
     SECTION("custom code and message is sent back") {
-        TestSyncManager::Config config;
+        OfflineAppSession::Config config;
         config.transport = std::make_shared<CustomErrorTransport>(1001, "Boom!");
-        TestSyncManager tsm(config);
-        auto error = failed_log_in(tsm.app());
+        OfflineAppSession oas(config);
+        auto error = failed_log_in(oas.app());
         CHECK(error.is_custom_error());
         CHECK(*error.additional_status_code == 1001);
         CHECK(error.reason() == "Boom!");
@@ -4675,11 +4666,6 @@ TEST_CASE("app: custom error handling", "[sync][app][custom errors]") {
 }
 
 // MARK: - Unit Tests
-
-static TestSyncManager::Config get_config()
-{
-    return get_config(instance_of<UnitTestTransport>);
-}
 
 static const std::string bad_access_token = "lolwut";
 static const std::string dummy_device_id = "123400000000000000000000";
@@ -4754,17 +4740,17 @@ TEST_CASE("subscribable unit tests", "[sync][app]") {
 }
 
 TEST_CASE("app: login_with_credentials unit_tests", "[sync][app][user]") {
-    auto config = get_config();
+    OfflineAppSession::Config config{std::make_shared<UnitTestTransport>()};
     static_cast<UnitTestTransport*>(config.transport.get())->set_profile(profile_0);
 
     SECTION("login_anonymous good") {
         UnitTestTransport::access_token = good_access_token;
-        config.base_path = util::make_temp_dir();
-        config.should_teardown_test_directory = false;
+        config.delete_storage = false;
         config.metadata_mode = SyncManager::MetadataMode::NoEncryption;
+        config.storage_path = util::make_temp_dir();
         {
-            TestSyncManager tsm(config);
-            auto app = tsm.app();
+            OfflineAppSession oas(config);
+            auto app = oas.app();
 
             auto user = log_in(app);
 
@@ -4785,8 +4771,9 @@ TEST_CASE("app: login_with_credentials unit_tests", "[sync][app][user]") {
         App::clear_cached_apps();
         // assert everything is stored properly between runs
         {
-            TestSyncManager tsm(config);
-            auto app = tsm.app();
+            config.delete_storage = true; // clean up after this session
+            OfflineAppSession oas(config);
+            auto app = oas.app();
             REQUIRE(app->all_users().size() == 1);
             auto user = app->all_users()[0];
             REQUIRE(user->identities().size() == 1);
@@ -4820,8 +4807,8 @@ TEST_CASE("app: login_with_credentials unit_tests", "[sync][app][user]") {
         };
 
         config.transport = instance_of<transport>;
-        TestSyncManager tsm(config);
-        auto error = failed_log_in(tsm.app());
+        OfflineAppSession oas(config);
+        auto error = failed_log_in(oas.app());
         CHECK(error.reason() == std::string("malformed JWT"));
         CHECK(error.code_string() == "BadToken");
         CHECK(error.is_json_error());
@@ -4830,10 +4817,8 @@ TEST_CASE("app: login_with_credentials unit_tests", "[sync][app][user]") {
 
     SECTION("login_anonynous multiple users") {
         UnitTestTransport::access_token = good_access_token;
-        config.base_path = util::make_temp_dir();
-        config.should_teardown_test_directory = false;
-        TestSyncManager tsm(config);
-        auto app = tsm.app();
+        OfflineAppSession oas(config);
+        auto app = oas.app();
 
         auto user1 = log_in(app);
         auto user2 = log_in(app, AppCredentials::anonymous(false));
@@ -4842,11 +4827,10 @@ TEST_CASE("app: login_with_credentials unit_tests", "[sync][app][user]") {
 }
 
 TEST_CASE("app: UserAPIKeyProviderClient unit_tests", "[sync][app][user][api key]") {
-    TestSyncManager sync_manager(get_config(), {});
-    auto app = sync_manager.app();
-    auto client = app->provider_client<App::UserAPIKeyProviderClient>();
+    OfflineAppSession oas({std::make_shared<UnitTestTransport>()});
+    auto client = oas.app()->provider_client<App::UserAPIKeyProviderClient>();
 
-    auto logged_in_user = sync_manager.fake_user();
+    auto logged_in_user = oas.make_user();
     bool processed = false;
     ObjectId obj_id(UnitTestTransport::api_key_id.c_str());
 
@@ -4888,8 +4872,8 @@ TEST_CASE("app: UserAPIKeyProviderClient unit_tests", "[sync][app][user][api key
 
 
 TEST_CASE("app: user_semantics", "[sync][app][user]") {
-    TestSyncManager tsm(get_config(), {});
-    auto app = tsm.app();
+    OfflineAppSession oas(instance_of<UnitTestTransport>);
+    auto app = oas.app();
 
     const auto login_user_email_pass = [=] {
         return log_in(app, AppCredentials::username_password("bob", "thompson"));
@@ -5018,6 +5002,7 @@ TEST_CASE("app: user_semantics", "[sync][app][user]") {
     }
 }
 
+namespace {
 struct ErrorCheckingTransport : public GenericNetworkTransport {
     ErrorCheckingTransport(Response* r)
         : m_response(r)
@@ -5042,6 +5027,7 @@ struct ErrorCheckingTransport : public GenericNetworkTransport {
 private:
     Response* m_response;
 };
+} // namespace
 
 TEST_CASE("app: response error handling", "[sync][app]") {
     std::string response_body = nlohmann::json({{"access_token", good_access_token},
@@ -5052,8 +5038,8 @@ TEST_CASE("app: response error handling", "[sync][app]") {
 
     Response response{200, 0, {{"Content-Type", "text/plain"}}, response_body};
 
-    TestSyncManager tsm(get_config(std::make_shared<ErrorCheckingTransport>(&response)));
-    auto app = tsm.app();
+    OfflineAppSession oas({std::make_shared<ErrorCheckingTransport>(&response)});
+    auto app = oas.app();
 
     SECTION("http 404") {
         response.http_status_code = 404;
@@ -5127,67 +5113,64 @@ TEST_CASE("app: response error handling", "[sync][app]") {
 }
 
 TEST_CASE("app: switch user", "[sync][app][user]") {
-    TestSyncManager tsm(get_config(), {});
-    auto app = tsm.app();
+    OfflineAppSession oas;
+    auto app = oas.app();
 
     bool processed = false;
 
     SECTION("switch user expect success") {
-        CHECK(app->sync_manager()->all_users().size() == 0);
+        CHECK(app->all_users().size() == 0);
 
         // Log in user 1
         auto user_a = log_in(app, AppCredentials::username_password("test@10gen.com", "password"));
-        CHECK(app->sync_manager()->get_current_user() == user_a);
+        CHECK(app->current_user() == user_a);
 
         // Log in user 2
         auto user_b = log_in(app, AppCredentials::username_password("test2@10gen.com", "password"));
-        CHECK(app->sync_manager()->get_current_user() == user_b);
+        CHECK(app->current_user() == user_b);
 
-        CHECK(app->sync_manager()->all_users().size() == 2);
+        CHECK(app->all_users().size() == 2);
 
-        auto user1 = app->switch_user(user_a);
-        CHECK(user1 == user_a);
+        app->switch_user(user_a);
+        CHECK(app->current_user() == user_a);
 
-        CHECK(app->sync_manager()->get_current_user() == user_a);
+        app->switch_user(user_b);
 
-        auto user2 = app->switch_user(user_b);
-        CHECK(user2 == user_b);
-
-        CHECK(app->sync_manager()->get_current_user() == user_b);
+        CHECK(app->current_user() == user_b);
         processed = true;
         CHECK(processed);
     }
 
-    SECTION("cannot switch to a logged out but not removed user") {
-        CHECK(app->sync_manager()->all_users().size() == 0);
+    SECTION("cannot switch to a logged out user") {
+        CHECK(app->all_users().size() == 0);
 
         // Log in user 1
         auto user_a = log_in(app, AppCredentials::username_password("test@10gen.com", "password"));
-        CHECK(app->sync_manager()->get_current_user() == user_a);
+        CHECK(app->current_user() == user_a);
 
         app->log_out([&](Optional<AppError> error) {
             REQUIRE_FALSE(error);
         });
 
-        CHECK(app->sync_manager()->get_current_user() == nullptr);
+        CHECK(app->current_user() == nullptr);
         CHECK(user_a->state() == SyncUser::State::LoggedOut);
 
         // Log in user 2
         auto user_b = log_in(app, AppCredentials::username_password("test2@10gen.com", "password"));
-        CHECK(app->sync_manager()->get_current_user() == user_b);
-        CHECK(app->sync_manager()->all_users().size() == 2);
+        CHECK(app->current_user() == user_b);
+        CHECK(app->all_users().size() == 2);
 
         REQUIRE_THROWS_AS(app->switch_user(user_a), AppError);
-        CHECK(app->sync_manager()->get_current_user() == user_b);
+        CHECK(app->current_user() == user_b);
     }
 }
 
-TEST_CASE("app: remove anonymous user", "[sync][app][user]") {
-    TestSyncManager tsm(get_config(), {});
-    auto app = tsm.app();
+TEST_CASE("app: remove user", "[sync][app][user]") {
+    OfflineAppSession oas;
+    auto app = oas.app();
 
-    SECTION("remove user expect success") {
-        CHECK(app->sync_manager()->all_users().size() == 0);
+    SECTION("remove anonymous user") {
+        CHECK(app->all_users().size() == 0);
 
         // Log in user 1
         auto user_a = log_in(app);
@@ -5198,39 +5181,34 @@ TEST_CASE("app: remove anonymous user", "[sync][app][user]") {
             // a logged out anon user will be marked as Removed, not LoggedOut
             CHECK(user_a->state() == SyncUser::State::Removed);
         });
-        CHECK(app->sync_manager()->all_users().empty());
+        CHECK(app->all_users().empty());
 
         app->remove_user(user_a, [&](Optional<AppError> error) {
             CHECK(error->reason() == "User has already been removed");
-            CHECK(app->sync_manager()->all_users().size() == 0);
+            CHECK(app->all_users().size() == 0);
         });
 
         // Log in user 2
         auto user_b = log_in(app);
-        CHECK(app->sync_manager()->get_current_user() == user_b);
+        CHECK(app->current_user() == user_b);
         CHECK(user_b->state() == SyncUser::State::LoggedIn);
-        CHECK(app->sync_manager()->all_users().size() == 1);
+        CHECK(app->all_users().size() == 1);
 
         app->remove_user(user_b, [&](Optional<AppError> error) {
             REQUIRE_FALSE(error);
-            CHECK(app->sync_manager()->all_users().size() == 0);
+            CHECK(app->all_users().size() == 0);
         });
 
-        CHECK(app->sync_manager()->get_current_user() == nullptr);
+        CHECK(app->current_user() == nullptr);
 
         // check both handles are no longer valid
         CHECK(user_a->state() == SyncUser::State::Removed);
         CHECK(user_b->state() == SyncUser::State::Removed);
     }
-}
 
-TEST_CASE("app: remove user with credentials", "[sync][app][user]") {
-    TestSyncManager tsm(get_config(), {});
-    auto app = tsm.app();
-
-    SECTION("log in, log out and remove") {
-        CHECK(app->sync_manager()->all_users().size() == 0);
-        CHECK(app->sync_manager()->get_current_user() == nullptr);
+    SECTION("remove user with credentials") {
+        CHECK(app->all_users().size() == 0);
+        CHECK(app->current_user() == nullptr);
 
         auto user = log_in(app, AppCredentials::username_password("email", "pass"));
 
@@ -5245,21 +5223,21 @@ TEST_CASE("app: remove user with credentials", "[sync][app][user]") {
         app->remove_user(user, [&](Optional<AppError> error) {
             REQUIRE_FALSE(error);
         });
-        CHECK(app->sync_manager()->all_users().size() == 0);
+        CHECK(app->all_users().size() == 0);
 
         Optional<AppError> error;
         app->remove_user(user, [&](Optional<AppError> err) {
             error = err;
         });
         CHECK(error->code() > 0);
-        CHECK(app->sync_manager()->all_users().size() == 0);
+        CHECK(app->all_users().size() == 0);
         CHECK(user->state() == SyncUser::State::Removed);
     }
 }
 
 TEST_CASE("app: link_user", "[sync][app][user]") {
-    TestSyncManager tsm(get_config(), {});
-    auto app = tsm.app();
+    OfflineAppSession oas;
+    auto app = oas.app();
 
     auto email = util::format("realm_tests_do_autoverify%1@%2.com", random_string(10), random_string(10));
     auto password = random_string(10);
@@ -5395,13 +5373,12 @@ TEST_CASE("app: refresh access token unit tests", "[sync][app][user][token]") {
                 }
             }
         };
-
-        TestSyncManager sync_manager(get_config(instance_of<transport>));
-        auto app = sync_manager.app();
-        auto user = sync_manager.fake_user();
+        OfflineAppSession oas(OfflineAppSession::Config{instance_of<transport>});
+        auto app = oas.app();
+        oas.make_user();
 
         bool processed = false;
-        app->refresh_custom_data(user, [&](const Optional<AppError>& error) {
+        app->refresh_custom_data(app->current_user(), [&](const Optional<AppError>& error) {
             REQUIRE_FALSE(error);
             CHECK(session_route_hit);
             processed = true;
@@ -5427,12 +5404,12 @@ TEST_CASE("app: refresh access token unit tests", "[sync][app][user][token]") {
             }
         };
 
-        TestSyncManager sync_manager(get_config(instance_of<transport>));
-        auto app = sync_manager.app();
-        auto user = sync_manager.fake_user();
+        OfflineAppSession oas(OfflineAppSession::Config{instance_of<transport>});
+        auto app = oas.app();
+        oas.make_user();
 
         bool processed = false;
-        app->refresh_custom_data(user, [&](const Optional<AppError>& error) {
+        app->refresh_custom_data(app->current_user(), [&](const Optional<AppError>& error) {
             CHECK(error->reason() == "malformed JWT");
             CHECK(error->code() == ErrorCodes::BadToken);
             CHECK(session_route_hit);
@@ -5449,53 +5426,42 @@ TEST_CASE("app: refresh access token unit tests", "[sync][app][user][token]") {
          Refresh token - get a new token for the user
          Get profile - get the profile with the new token
          */
-
         struct transport : GenericNetworkTransport {
-            bool login_hit = false;
-            bool get_profile_1_hit = false;
-            bool get_profile_2_hit = false;
-            bool refresh_hit = false;
-
+            enum class TestState { unknown, location, login, profile_1, refresh, profile_2 };
+            TestingStateMachine<TestState> state{TestState::unknown};
             void send_request_to_server(const Request& request,
                                         util::UniqueFunction<void(const Response&)>&& completion) override
             {
                 if (request.url.find("/login") != std::string::npos) {
-                    login_hit = true;
+                    CHECK(state.get() == TestState::location);
+                    state.transition_to(TestState::login);
                     completion({200, 0, {}, user_json(good_access_token).dump()});
                 }
                 else if (request.url.find("/profile") != std::string::npos) {
-                    CHECK(login_hit);
-
                     auto item = AppUtils::find_header("Authorization", request.headers);
                     CHECK(item);
                     auto access_token = item->second;
                     // simulated bad token request
                     if (access_token.find(good_access_token2) != std::string::npos) {
-                        CHECK(login_hit);
-                        CHECK(get_profile_1_hit);
-                        CHECK(refresh_hit);
-
-                        get_profile_2_hit = true;
-
+                        CHECK(state.get() == TestState::refresh);
+                        state.transition_to(TestState::profile_2);
                         completion({200, 0, {}, user_profile_json().dump()});
                     }
                     else if (access_token.find(good_access_token) != std::string::npos) {
-                        CHECK(!get_profile_2_hit);
-                        get_profile_1_hit = true;
-
+                        CHECK(state.get() == TestState::login);
+                        state.transition_to(TestState::profile_1);
                         completion({401, 0, {}});
                     }
                 }
                 else if (request.url.find("/session") != std::string::npos && request.method == HttpMethod::post) {
-                    CHECK(login_hit);
-                    CHECK(get_profile_1_hit);
-                    CHECK(!get_profile_2_hit);
-                    refresh_hit = true;
-
+                    CHECK(state.get() == TestState::profile_1);
+                    state.transition_to(TestState::refresh);
                     nlohmann::json json{{"access_token", good_access_token2}};
                     completion({200, 0, {}, json.dump()});
                 }
                 else if (request.url.find("/location") != std::string::npos) {
+                    CHECK(state.get() == TestState::unknown);
+                    state.transition_to(TestState::location);
                     CHECK(request.method == HttpMethod::get);
                     completion({200,
                                 0,
@@ -5503,11 +5469,15 @@ TEST_CASE("app: refresh access token unit tests", "[sync][app][user][token]") {
                                 "{\"deployment_model\":\"GLOBAL\",\"location\":\"US-VA\",\"hostname\":"
                                 "\"http://localhost:9090\",\"ws_hostname\":\"ws://localhost:9090\"}"});
                 }
+                else {
+                    FAIL("Unexpected request in test code" + request.url);
+                }
             }
         };
 
-        TestSyncManager sync_manager(get_config(instance_of<transport>));
-        REQUIRE(log_in(sync_manager.app()));
+        OfflineAppSession oas(OfflineAppSession::Config{instance_of<transport>});
+        auto app = oas.app();
+        REQUIRE(log_in(app));
     }
 }
 
@@ -5519,39 +5489,42 @@ public:
     {
     }
 
+    ~AsyncMockNetworkTransport()
+    {
+        {
+            std::lock_guard lk(transport_work_mutex);
+            test_complete = true;
+        }
+        transport_work_cond.notify_one();
+        transport_thread.join();
+        REALM_ASSERT(transport_work.empty());
+    }
+
     void add_work_item(Response&& response, util::UniqueFunction<void(const Response&)>&& completion)
     {
-        std::lock_guard<std::mutex> lk(transport_work_mutex);
-        transport_work.push_front(ResponseWorkItem{std::move(response), std::move(completion)});
+        {
+            std::lock_guard lk(transport_work_mutex);
+            transport_work.push_front([response = std::move(response), completion = std::move(completion)] {
+                completion(response);
+            });
+        }
         transport_work_cond.notify_one();
     }
 
     void add_work_item(util::UniqueFunction<void()> cb)
     {
-        std::lock_guard<std::mutex> lk(transport_work_mutex);
-        transport_work.push_front(std::move(cb));
+        {
+            std::lock_guard lk(transport_work_mutex);
+            transport_work.push_front(std::move(cb));
+        }
         transport_work_cond.notify_one();
-    }
-
-    void mark_complete()
-    {
-        std::unique_lock<std::mutex> lk(transport_work_mutex);
-        test_complete = true;
-        transport_work_cond.notify_one();
-        lk.unlock();
-        transport_thread.join();
     }
 
 private:
-    struct ResponseWorkItem {
-        Response response;
-        util::UniqueFunction<void(const Response&)> completion;
-    };
-
     void worker_routine()
     {
-        std::unique_lock<std::mutex> lk(transport_work_mutex);
         for (;;) {
+            std::unique_lock lk(transport_work_mutex);
             transport_work_cond.wait(lk, [&] {
                 return test_complete || !transport_work.empty();
             });
@@ -5561,15 +5534,7 @@ private:
                 transport_work.pop_back();
                 lk.unlock();
 
-                mpark::visit(util::overload{[](ResponseWorkItem& work_item) {
-                                                work_item.completion(std::move(work_item.response));
-                                            },
-                                            [](util::UniqueFunction<void()>& cb) {
-                                                cb();
-                                            }},
-                             work_item);
-
-                lk.lock();
+                work_item();
                 continue;
             }
 
@@ -5582,7 +5547,7 @@ private:
     std::mutex transport_work_mutex;
     std::condition_variable transport_work_cond;
     bool test_complete = false;
-    std::list<mpark::variant<ResponseWorkItem, util::UniqueFunction<void()>>> transport_work;
+    std::list<util::UniqueFunction<void()>> transport_work;
     JoiningThread transport_thread;
 };
 
@@ -5657,8 +5622,8 @@ TEST_CASE("app: app destroyed during token refresh", "[sync][app][user][token]")
         AsyncMockNetworkTransport& mock_transport_worker;
         TestingStateMachine<TestState>& state;
     };
-    TestSyncManager sync_manager(get_config(std::make_shared<transport>(mock_transport_worker, state)));
-    auto app = sync_manager.app();
+    OfflineAppSession oas({std::make_shared<transport>(mock_transport_worker, state)});
+    auto app = oas.app();
 
     {
         auto [cur_user_promise, cur_user_future] = util::make_promise_future<std::shared_ptr<SyncUser>>();
@@ -5710,102 +5675,15 @@ TEST_CASE("app: app destroyed during token refresh", "[sync][app][user][token]")
     timed_wait_for([&] {
         return !app->sync_manager()->has_existing_sessions();
     });
-
-    mock_transport_worker.mark_complete();
-}
-
-TEST_CASE("app: metadata is persisted between sessions", "[sync][app][metadata]") {
-    const auto orig_hostname = "proto://host:1234";
-    const auto orig_ws_hostname = "wsproto://host:1234";
-
-    struct LocalTransport : UnitTestTransport {
-        void send_request_to_server(const Request& request,
-                                    util::UniqueFunction<void(const Response&)>&& completion) override
-        {
-            if (request.url.find("/location") != std::string::npos) {
-                CHECK(request.method == HttpMethod::get);
-                completion({200,
-                            0,
-                            {},
-                            nlohmann::json({{"deployment_model", "LOCAL"},
-                                            {"location", "IE"},
-                                            {"hostname", test_hostname},
-                                            {"ws_hostname", test_ws_hostname}})
-                                .dump()});
-            }
-            else if (request.url.find("functions/call") != std::string::npos) {
-                REQUIRE(request.url.rfind(test_hostname, 0) != std::string::npos);
-            }
-            else {
-                UnitTestTransport::send_request_to_server(request, std::move(completion));
-            }
-        }
-
-        void set_hostname(std::string hostname, std::string ws_hostname)
-        {
-            test_hostname = hostname;
-            test_ws_hostname = ws_hostname;
-        }
-        std::string test_hostname;
-        std::string test_ws_hostname;
-    };
-
-    auto transport = std::make_shared<LocalTransport>();
-    transport->set_hostname(orig_hostname, orig_ws_hostname);
-
-    TestSyncManager::Config config = get_config(transport);
-    config.base_path = util::make_temp_dir();
-    config.should_teardown_test_directory = false;
-    config.metadata_mode = SyncManager::MetadataMode::NoEncryption;
-
-    {
-        TestSyncManager sync_manager(config, {});
-        auto app = sync_manager.app();
-
-        // This is single threaded
-        app->log_in_with_credentials(AppCredentials::anonymous(), [](auto, auto error) {
-            REQUIRE_FALSE(error);
-        });
-        // Sync route is updated during first request
-        REQUIRE(app->sync_manager()->sync_route());
-        REQUIRE(app->sync_manager()->sync_route()->rfind(orig_ws_hostname, 0) != std::string::npos);
-    }
-
-    config.override_sync_route = false;
-    config.should_teardown_test_directory = true;
-    {
-        TestSyncManager sync_manager(config);
-        auto app = sync_manager.app();
-
-        std::string base_url = sync_manager.sync_server().base_url();
-        std::string ws_url = base_url;
-        size_t uri_scheme_start = ws_url.find("http");
-        if (uri_scheme_start == 0)
-            ws_url.replace(uri_scheme_start, 4, "ws");
-
-        transport->set_hostname(base_url, ws_url);
-
-        REQUIRE(!app->sync_manager()->sync_route()); // sync route is null to force location update on sync startup
-
-        app->call_function("function", {}, [](auto error, auto) {
-            REQUIRE_FALSE(error);
-        });
-
-        REQUIRE(app->sync_manager()->sync_route()); // sync route is updated after operation
-        REQUIRE(app->sync_manager()->sync_route()->rfind(ws_url, 0) != std::string::npos);
-    }
 }
 
 TEST_CASE("app: make_streaming_request", "[sync][app][streaming]") {
     UnitTestTransport::access_token = good_access_token;
+    constexpr uint64_t timeout_ms = 60000; // this is the default
+    OfflineAppSession oas({std::make_shared<UnitTestTransport>(timeout_ms)});
+    auto app = oas.app();
 
-    constexpr uint64_t timeout_ms = 60000;
-    auto config = get_config();
-    config.app_config.default_request_timeout_ms = timeout_ms;
-    TestSyncManager tsm(config);
-    auto app = tsm.app();
-
-    std::shared_ptr<SyncUser> user = log_in(app);
+    auto user = log_in(app);
 
     using Headers = decltype(Request().headers);
 
@@ -5907,10 +5785,9 @@ TEST_CASE("app: sync_user_profile unit tests", "[sync][app][user]") {
     }
 }
 
-#if 0
 TEST_CASE("app: app cannot get deallocated during log in", "[sync][app]") {
     AsyncMockNetworkTransport mock_transport_worker;
-    enum class TestState { unknown, location, login, app_deallocated, profile };
+    enum class TestState { unknown, app_released };
     TestingStateMachine<TestState> state(TestState::unknown);
     struct transport : public GenericNetworkTransport {
         transport(AsyncMockNetworkTransport& worker, TestingStateMachine<TestState>& state)
@@ -5922,20 +5799,17 @@ TEST_CASE("app: app cannot get deallocated during log in", "[sync][app]") {
         void send_request_to_server(const Request& request, util::UniqueFunction<void(const Response&)>&& completion) override
         {
             if (request.url.find("/login") != std::string::npos) {
-                state.transition_to(TestState::login);
-                state.wait_for(TestState::app_deallocated);
+                state.wait_for(TestState::app_released);
                 mock_transport_worker.add_work_item(
                     Response{200, 0, {}, user_json(encode_fake_jwt("access token")).dump()},
                     std::move(completion));
             }
             else if (request.url.find("/profile") != std::string::npos) {
-                state.transition_to(TestState::profile);
                 mock_transport_worker.add_work_item(Response{200, 0, {}, user_profile_json().dump()},
                                                     std::move(completion));
             }
             else if (request.url.find("/location") != std::string::npos) {
                 CHECK(request.method == HttpMethod::get);
-                state.transition_to(TestState::location);
                 mock_transport_worker.add_work_item(
                     Response{200,
                              0,
@@ -5954,37 +5828,36 @@ TEST_CASE("app: app cannot get deallocated during log in", "[sync][app]") {
     auto transporter = std::make_shared<transport>(mock_transport_worker, state);
 
     {
-        TestSyncManager sync_manager(get_config(transporter));
-        auto app = sync_manager.app();
-
-        app->log_in_with_credentials(AppCredentials::anonymous(),
-                                     [promise = std::move(cur_user_promise)](std::shared_ptr<SyncUser> user,
-                                                                             util::Optional<AppError> error) mutable {
-                                         REQUIRE_FALSE(error);
-                                         promise.emplace_value(std::move(user));
-                                     });
+        OfflineAppSession oas({transporter});
+        oas.app()->log_in_with_credentials(
+            AppCredentials::anonymous(), [promise = std::move(cur_user_promise)](
+                                             std::shared_ptr<SyncUser> user, util::Optional<AppError> error) mutable {
+                REQUIRE_FALSE(error);
+                promise.emplace_value(std::move(user));
+            });
     }
 
-    // At this point the test does not hold any reference to `app`.
-    state.transition_to(TestState::app_deallocated);
+    // At this point the test does not hold any reference to `app`, but the
+    // app is keeping itself alive
+    state.transition_to(TestState::app_released);
     auto cur_user = std::move(cur_user_future).get();
     CHECK(cur_user);
-
-    mock_transport_worker.mark_complete();
 }
-#endif
 
 TEST_CASE("app: user logs out while profile is fetched", "[sync][app][user]") {
     AsyncMockNetworkTransport mock_transport_worker;
-    enum class TestState { unknown, location, login, profile };
+    enum class TestState { unknown, location, login, logout, create, profile };
     TestingStateMachine<TestState> state(TestState::unknown);
     struct transport : public GenericNetworkTransport {
-        transport(AsyncMockNetworkTransport& worker, TestingStateMachine<TestState>& state,
-                  std::shared_ptr<SyncUser>& logged_in_user)
+        transport(AsyncMockNetworkTransport& worker, TestingStateMachine<TestState>& state)
             : mock_transport_worker(worker)
             , state(state)
-            , logged_in_user(logged_in_user)
         {
+        }
+        void set_app(App* app)
+        {
+            REQUIRE(state.get() == TestState::unknown);
+            m_app = app;
         }
 
         void send_request_to_server(const Request& request,
@@ -5996,7 +5869,10 @@ TEST_CASE("app: user logs out while profile is fetched", "[sync][app][user]") {
                     Response{200, 0, {}, user_json(encode_fake_jwt("access token")).dump()}, std::move(completion));
             }
             else if (request.url.find("/profile") != std::string::npos) {
-                logged_in_user->log_out();
+                REQUIRE(m_app);
+                auto user = m_app->current_user();
+                REQUIRE(user);
+                user->log_out();
                 state.transition_to(TestState::profile);
                 mock_transport_worker.add_work_item(Response{200, 0, {}, user_profile_json().dump()},
                                                     std::move(completion));
@@ -6012,46 +5888,53 @@ TEST_CASE("app: user logs out while profile is fetched", "[sync][app][user]") {
                              "\"http://localhost:9090\",\"ws_hostname\":\"ws://localhost:9090\"}"},
                     std::move(completion));
             }
+            else if (request.url.find("/session") != std::string::npos) {
+                CHECK(request.method == HttpMethod::del);
+                state.transition_to(TestState::logout);
+                mock_transport_worker.add_work_item(Response{200, 0, {}, ""}, std::move(completion));
+            }
+            else {
+                FAIL("Unexpected request in test transport " + request.url);
+            }
         }
 
         AsyncMockNetworkTransport& mock_transport_worker;
         TestingStateMachine<TestState>& state;
-        std::shared_ptr<SyncUser>& logged_in_user;
+        App* m_app;
     };
 
-    std::shared_ptr<SyncUser> logged_in_user;
-    auto transporter = std::make_shared<transport>(mock_transport_worker, state, logged_in_user);
+    auto transporter = std::make_shared<transport>(mock_transport_worker, state);
+    OfflineAppSession oas({transporter});
+    auto app = oas.app();
+    transporter->set_app(app.get());
 
-    TestSyncManager sync_manager(get_config(transporter));
-    auto app = sync_manager.app();
-
-    logged_in_user = app->sync_manager()->get_user("userid", good_access_token, good_access_token, dummy_device_id);
     auto custom_credentials = AppCredentials::facebook("a_token");
     auto [cur_user_promise, cur_user_future] = util::make_promise_future<std::shared_ptr<SyncUser>>();
 
-    app->link_user(logged_in_user, custom_credentials,
-                   [promise = std::move(cur_user_promise)](std::shared_ptr<SyncUser> user,
-                                                           util::Optional<AppError> error) mutable {
-                       REQUIRE_FALSE(error);
-                       promise.emplace_value(std::move(user));
-                   });
+    app->log_in_with_credentials(custom_credentials,
+                                 [promise = std::move(cur_user_promise)](std::shared_ptr<SyncUser> user,
+                                                                         util::Optional<AppError> error) mutable {
+                                     REQUIRE_FALSE(error);
+                                     promise.emplace_value(std::move(user));
+                                 });
 
     auto cur_user = std::move(cur_user_future).get();
     CHECK(state.get() == TestState::profile);
     CHECK(cur_user);
-    CHECK(cur_user == logged_in_user);
-
-    mock_transport_worker.mark_complete();
+    CHECK(cur_user->state() == SyncUser::State::LoggedOut);
+    REQUIRE(app->all_users().size() == 1);
+    CHECK(app->all_users()[0] == cur_user);
 }
 
 TEST_CASE("app: shared instances", "[sync][app]") {
+    test_util::TestDirGuard test_dir(util::make_temp_dir(), false);
+
     App::Config base_config;
     set_app_config_defaults(base_config, instance_of<UnitTestTransport>);
 
     SyncClientConfig sync_config;
     sync_config.metadata_mode = SyncClientConfig::MetadataMode::NoMetadata;
-    sync_config.base_file_path = util::make_temp_dir() + random_string(10);
-    util::try_make_dir(sync_config.base_file_path);
+    sync_config.base_file_path = test_dir;
 
     auto config1 = base_config;
     config1.app_id = "app1";

--- a/test/object-store/sync/client_reset.cpp
+++ b/test/object-store/sync/client_reset.cpp
@@ -326,7 +326,7 @@ TEST_CASE("sync: client reset", "[sync][pbs][client reset][baas]") {
             recovery_path = recovery_path_it->second;
             REQUIRE(util::File::exists(orig_path));
             REQUIRE(!util::File::exists(recovery_path));
-            bool did_reset_files = test_app_session.app()->sync_manager()->immediately_run_file_actions(orig_path);
+            bool did_reset_files = test_app_session.sync_manager()->immediately_run_file_actions(orig_path);
             REQUIRE(did_reset_files);
             REQUIRE(!util::File::exists(orig_path));
             REQUIRE(util::File::exists(recovery_path));
@@ -953,7 +953,7 @@ TEST_CASE("sync: client reset", "[sync][pbs][client reset][baas]") {
                 auto realm = Realm::get_shared_realm(temp_config);
                 wait_for_upload(*realm);
 
-                session = test_app_session.app()->sync_manager()->get_existing_session(temp_config.path);
+                session = test_app_session.sync_manager()->get_existing_session(temp_config.path);
                 REQUIRE(session);
             }
             sync::SessionErrorInfo synthetic(Status{ErrorCodes::SyncClientResetRequired, "A fake client reset error"},
@@ -1005,7 +1005,7 @@ TEST_CASE("sync: client reset", "[sync][pbs][client reset][baas]") {
                     },
                     std::chrono::seconds(20));
             }
-            auto session = test_app_session.app()->sync_manager()->get_existing_session(local_config.path);
+            auto session = test_app_session.sync_manager()->get_existing_session(local_config.path);
             if (session) {
                 session->shutdown_and_wait();
             }

--- a/test/object-store/sync/client_reset.cpp
+++ b/test/object-store/sync/client_reset.cpp
@@ -1946,9 +1946,8 @@ TEMPLATE_TEST_CASE("client reset types", "[sync][pbs][client reset]", cf::MixedV
     if (!util::EventLoop::has_implementation())
         return;
 
-    TestSyncManager init_sync_manager;
-    SyncTestFile config(init_sync_manager.app(), "default");
-    config.cache = false;
+    OfflineAppSession oas;
+    SyncTestFile config(oas, "default");
     config.automatic_change_notifications = false;
     ClientResyncMode test_mode = GENERATE(ClientResyncMode::DiscardLocal, ClientResyncMode::Recover);
     CAPTURE(test_mode);
@@ -1967,7 +1966,7 @@ TEMPLATE_TEST_CASE("client reset types", "[sync][pbs][client reset]", cf::MixedV
           {"set", PropertyType::Set | TestType::property_type}}},
     };
 
-    SyncTestFile config2(init_sync_manager.app(), "default");
+    SyncTestFile config2(oas.app()->current_user(), "default");
     config2.schema = config.schema;
 
     Results results;
@@ -2623,16 +2622,15 @@ TEMPLATE_TEST_CASE("client reset collections of links", "[sync][pbs][client rese
          }},
     };
 
-    TestSyncManager init_sync_manager;
-    SyncTestFile config(init_sync_manager.app(), "default");
-    config.cache = false;
+    OfflineAppSession oas;
+    SyncTestFile config(oas, "default");
     config.automatic_change_notifications = false;
     config.schema = schema;
     ClientResyncMode test_mode = GENERATE(ClientResyncMode::DiscardLocal, ClientResyncMode::Recover);
     CAPTURE(test_mode);
     config.sync_config->client_resync_mode = test_mode;
 
-    SyncTestFile config2(init_sync_manager.app(), "default");
+    SyncTestFile config2(oas.app()->current_user(), "default");
     config2.schema = schema;
 
     std::unique_ptr<reset_utils::TestClientReset> test_reset =
@@ -3140,9 +3138,8 @@ TEST_CASE("client reset with embedded object", "[sync][pbs][client reset][embedd
     if (!util::EventLoop::has_implementation())
         return;
 
-    TestSyncManager init_sync_manager;
-    SyncTestFile config(init_sync_manager.app(), "default");
-    config.cache = false;
+    OfflineAppSession oas;
+    SyncTestFile config(oas, "default");
     config.automatic_change_notifications = false;
     ClientResyncMode test_mode = GENERATE(ClientResyncMode::DiscardLocal, ClientResyncMode::Recover);
     CAPTURE(test_mode);
@@ -3488,7 +3485,7 @@ TEST_CASE("client reset with embedded object", "[sync][pbs][client reset][embedd
         }
     };
 
-    SyncTestFile config2(init_sync_manager.app(), "default");
+    SyncTestFile config2(oas.app()->current_user(), "default");
     config2.schema = config.schema;
 
     std::unique_ptr<reset_utils::TestClientReset> test_reset =
@@ -4280,7 +4277,7 @@ TEST_CASE("client reset with embedded object", "[sync][pbs][client reset][embedd
         reset_embedded_object({local}, {remote}, expected_recovered);
     }
     SECTION("server adds embedded object classes") {
-        SyncTestFile config2(init_sync_manager.app(), "default");
+        SyncTestFile config2(oas.app()->current_user(), "default");
         config2.schema = config.schema;
         config.schema = Schema{shared_class};
         test_reset = reset_utils::make_fake_local_client_reset(config, config2);
@@ -4305,7 +4302,7 @@ TEST_CASE("client reset with embedded object", "[sync][pbs][client reset][embedd
             ->run();
     }
     SECTION("client adds embedded object classes") {
-        SyncTestFile config2(init_sync_manager.app(), "default");
+        SyncTestFile config2(oas.app()->current_user(), "default");
         config2.schema = Schema{shared_class};
         test_reset = reset_utils::make_fake_local_client_reset(config, config2);
         TopLevelContent local_content;

--- a/test/object-store/sync/flx_sync.cpp
+++ b/test/object-store/sync/flx_sync.cpp
@@ -2218,7 +2218,6 @@ TEST_CASE("flx: interrupted bootstrap restarts/recovers on reconnect", "[sync][f
     std::vector<ObjectId> obj_ids_at_end = fill_large_array_schema(harness);
     SyncTestFile interrupted_realm_config(harness.app()->current_user(), harness.schema(),
                                           SyncConfig::FLXSyncEnabled{});
-    interrupted_realm_config.cache = false;
 
     {
         auto [interrupted_promise, interrupted] = util::make_promise_future<void>();
@@ -2742,7 +2741,6 @@ TEST_CASE("flx: bootstrap batching prevents orphan documents", "[sync][flx][boot
     std::vector<ObjectId> obj_ids_at_end = fill_large_array_schema(harness);
     SyncTestFile interrupted_realm_config(harness.app()->current_user(), harness.schema(),
                                           SyncConfig::FLXSyncEnabled{});
-    interrupted_realm_config.cache = false;
 
     auto check_interrupted_state = [&](const DBRef& realm) {
         auto tr = realm->start_read();
@@ -4053,7 +4051,6 @@ TEST_CASE("flx: compensating write errors get re-sent across sessions", "[sync][
 
     create_user_and_log_in(harness.app());
     SyncTestFile config(harness.app()->current_user(), harness.schema(), SyncConfig::FLXSyncEnabled{});
-    config.cache = false;
 
     {
         auto error_received_pf = util::make_promise_future<void>();
@@ -4630,7 +4627,6 @@ TEST_CASE("flx sync: resend pending subscriptions when reconnecting", "[sync][fl
     std::vector<ObjectId> obj_ids_at_end = fill_large_array_schema(harness);
     SyncTestFile interrupted_realm_config(harness.app()->current_user(), harness.schema(),
                                           SyncConfig::FLXSyncEnabled{});
-    interrupted_realm_config.cache = false;
 
     {
         auto pf = util::make_promise_future<void>();

--- a/test/object-store/sync/metadata.cpp
+++ b/test/object-store/sync/metadata.cpp
@@ -37,15 +37,11 @@ using namespace realm::util;
 using File = realm::util::File;
 using SyncAction = SyncFileActionMetadata::Action;
 
-static const std::string base_path = util::make_temp_dir() + "realm_objectstore_sync_metadata";
+static const std::string base_path = util::make_temp_dir() + "realm_objectstore_sync_metadata.test-dir";
 static const std::string metadata_path = base_path + "/metadata.realm";
 
 TEST_CASE("sync_metadata: user metadata", "[sync][metadata]") {
-    util::try_make_dir(base_path);
-    auto close = util::make_scope_exit([=]() noexcept {
-        util::try_remove_dir_recursive(base_path);
-    });
-
+    test_util::TestDirGuard test_dir(base_path);
     SyncMetadataManager manager(metadata_path, false);
 
     SECTION("can be properly constructed") {
@@ -131,11 +127,7 @@ TEST_CASE("sync_metadata: user metadata", "[sync][metadata]") {
 }
 
 TEST_CASE("sync_metadata: user metadata APIs", "[sync][metadata]") {
-    util::try_make_dir(base_path);
-    auto close = util::make_scope_exit([=]() noexcept {
-        util::try_remove_dir_recursive(base_path);
-    });
-
+    test_util::TestDirGuard test_dir(base_path);
     SyncMetadataManager manager(metadata_path, false);
     const std::string provider_type = "https://realm.example.org";
 
@@ -163,11 +155,7 @@ TEST_CASE("sync_metadata: user metadata APIs", "[sync][metadata]") {
 }
 
 TEST_CASE("sync_metadata: file action metadata", "[sync][metadata]") {
-    util::try_make_dir(base_path);
-    auto close = util::make_scope_exit([=]() noexcept {
-        util::try_remove_dir_recursive(base_path);
-    });
-
+    test_util::TestDirGuard test_dir(base_path);
     SyncMetadataManager manager(metadata_path, false);
 
     const std::string local_uuid_1 = "asdfg";
@@ -207,10 +195,7 @@ TEST_CASE("sync_metadata: file action metadata", "[sync][metadata]") {
 }
 
 TEST_CASE("sync_metadata: file action metadata APIs", "[sync][metadata]") {
-    util::try_make_dir(base_path);
-    auto close = util::make_scope_exit([=]() noexcept {
-        util::try_remove_dir_recursive(base_path);
-    });
+    test_util::TestDirGuard test_dir(base_path);
 
     SyncMetadataManager manager(metadata_path, false);
     SECTION("properly list all pending actions, reflecting their deletion") {
@@ -233,11 +218,7 @@ TEST_CASE("sync_metadata: file action metadata APIs", "[sync][metadata]") {
 }
 
 TEST_CASE("sync_metadata: results", "[sync][metadata]") {
-    util::try_make_dir(base_path);
-    auto close = util::make_scope_exit([=]() noexcept {
-        util::try_remove_dir_recursive(base_path);
-    });
-
+    test_util::TestDirGuard test_dir(base_path);
     SyncMetadataManager manager(metadata_path, false);
     const auto identity1 = "testcase3a1";
     const auto identity2 = "testcase3a3";
@@ -271,10 +252,7 @@ TEST_CASE("sync_metadata: results", "[sync][metadata]") {
 }
 
 TEST_CASE("sync_metadata: persistence across metadata manager instances", "[sync][metadata]") {
-    util::try_make_dir(base_path);
-    auto close = util::make_scope_exit([=]() noexcept {
-        util::try_remove_dir_recursive(base_path);
-    });
+    test_util::TestDirGuard temp_dir(base_path);
 
     SECTION("works for the basic case") {
         const auto identity = "testcase4a";
@@ -297,11 +275,7 @@ TEST_CASE("sync_metadata: persistence across metadata manager instances", "[sync
 }
 
 TEST_CASE("sync_metadata: encryption", "[sync][metadata]") {
-    util::try_make_dir(base_path);
-    auto close = util::make_scope_exit([=]() noexcept {
-        util::try_remove_dir_recursive(base_path);
-    });
-
+    test_util::TestDirGuard test_dir(base_path);
     const auto identity0 = "identity0";
     SECTION("prohibits opening the metadata Realm with different keys") {
         SECTION("different keys") {
@@ -447,10 +421,7 @@ TEST_CASE("sync_metadata: encryption", "[sync][metadata]") {
 
 #ifndef SWIFT_PACKAGE // The SPM build currently doesn't copy resource files
 TEST_CASE("sync metadata: can open old metadata realms", "[sync][metadata]") {
-    util::try_make_dir(base_path);
-    auto close = util::make_scope_exit([=]() noexcept {
-        util::try_remove_dir_recursive(base_path);
-    });
+    test_util::TestDirGuard test_dir(base_path);
 
     const std::string provider_type = "https://realm.example.org";
     const auto identity = "metadata migration test";

--- a/test/object-store/sync/session/connection_change_notifications.cpp
+++ b/test/object-store/sync/session/connection_change_notifications.cpp
@@ -20,41 +20,15 @@
 #include <util/test_utils.hpp>
 #include <util/sync/session_util.hpp>
 
-#include <realm/object-store/feature_checks.hpp>
-#include <realm/object-store/object_schema.hpp>
-#include <realm/object-store/object_store.hpp>
-#include <realm/object-store/property.hpp>
-#include <realm/object-store/schema.hpp>
-
-#include <realm/util/scope_exit.hpp>
-#include <realm/util/time.hpp>
-
-#include <catch2/catch_all.hpp>
-
-#include <atomic>
-#include <chrono>
-#include <fstream>
-#ifndef _WIN32
-#include <unistd.h>
-#endif
-
 using namespace realm;
 using namespace realm::util;
-
-static const std::string dummy_device_id = "123400000000000000000000";
-
-static const std::string base_path = util::make_temp_dir() + "realm_objectstore_sync_connection_state_changes";
 
 TEST_CASE("sync: Connection state changes", "[sync][session][connection change]") {
     if (!EventLoop::has_implementation())
         return;
 
-    TestSyncManager::Config config;
-    config.base_path = base_path;
-    TestSyncManager init_sync_manager(config);
-    auto app = init_sync_manager.app();
-    auto user = app->sync_manager()->get_user("user", ENCODE_FAKE_JWT("not_a_real_token"),
-                                              ENCODE_FAKE_JWT("also_not_a_real_token"), dummy_device_id);
+    TestSyncManager tsm;
+    auto user = tsm.fake_user();
 
     SECTION("register connection change listener") {
         auto session = sync_session(

--- a/test/object-store/sync/session/session.cpp
+++ b/test/object-store/sync/session/session.cpp
@@ -41,25 +41,26 @@
 using namespace realm;
 using namespace realm::util;
 
-static const std::string dummy_device_id = "123400000000000000000000";
-
-static std::shared_ptr<SyncUser> get_user(const std::shared_ptr<app::App>& app)
-{
-    return app->sync_manager()->get_user("user_id", ENCODE_FAKE_JWT("fake_refresh_token"),
-                                         ENCODE_FAKE_JWT("fake_access_token"), dummy_device_id);
-}
-
 TEST_CASE("SyncSession: management by SyncUser", "[sync][session]") {
     if (!EventLoop::has_implementation())
         return;
 
-    TestSyncManager init_sync_manager;
-    auto& server = init_sync_manager.sync_server();
-    auto app = init_sync_manager.app();
+    using State = SyncUser::State;
+
+    TestSyncManager tsm;
+    auto& server = tsm.sync_server();
     const std::string realm_base_url = server.base_url();
 
+    auto check_for_sessions = [](SyncUser& user, size_t count, SyncSession::State state) {
+        auto sessions = user.all_sessions();
+        CHECK(sessions.size() == count);
+        for (auto& session : sessions) {
+            CHECK(session->state() == state);
+        }
+    };
+
     SECTION("a SyncUser can properly retrieve its owned sessions") {
-        auto user = get_user(app);
+        auto user = tsm.fake_user();
         auto session1 = sync_session(user, "/test1a-1");
         auto session2 = sync_session(user, "/test1a-2");
         EventLoop::main().run_until([&] {
@@ -67,7 +68,7 @@ TEST_CASE("SyncSession: management by SyncUser", "[sync][session]") {
         });
 
         // Check the sessions on the SyncUser.
-        REQUIRE(user->all_sessions().size() == 2);
+        check_for_sessions(*user, 2, SyncSession::State::Active);
         auto s1 = user->session_for_on_disk_path(session1->path());
         REQUIRE(s1 == session1);
         auto s2 = user->session_for_on_disk_path(session2->path());
@@ -75,64 +76,60 @@ TEST_CASE("SyncSession: management by SyncUser", "[sync][session]") {
     }
 
     SECTION("a SyncUser properly unbinds its sessions upon logging out") {
-        auto user = get_user(app);
+        auto user = tsm.fake_user();
         auto session1 = sync_session(user, "/test1b-1");
         auto session2 = sync_session(user, "/test1b-2");
         EventLoop::main().run_until([&] {
             return sessions_are_active(*session1, *session2);
         });
 
-        // Log the user out.
         user->log_out();
         // The sessions should log themselves out.
         EventLoop::main().run_until([&] {
             return sessions_are_inactive(*session1, *session2);
         });
-        CHECK(user->all_sessions().size() == 0);
+        check_for_sessions(*user, 0, SyncSession::State::Inactive);
     }
 
     SECTION("a SyncUser defers binding new sessions until it is logged in") {
-        auto user = get_user(app);
+        auto user = tsm.fake_user();
         user->log_out();
-        REQUIRE(user->state() == SyncUser::State::LoggedOut);
+        REQUIRE(user->state() == State::LoggedOut);
         auto session1 = sync_session(user, "/test1c-1");
         auto session2 = sync_session(user, "/test1c-2");
         // Run the runloop many iterations to see if the sessions spuriously bind.
         spin_runloop();
         REQUIRE(session1->state() == SyncSession::State::Inactive);
         REQUIRE(session2->state() == SyncSession::State::Inactive);
-        REQUIRE(user->all_sessions().size() == 0);
-        // Log the user back in via the sync manager.
-        user = get_user(app);
+        check_for_sessions(*user, 0, SyncSession::State::Inactive);
+        user->log_in(ENCODE_FAKE_JWT("fake_access_token"), ENCODE_FAKE_JWT("fake_refresh_token"));
         EventLoop::main().run_until([&] {
             return sessions_are_active(*session1, *session2);
         });
-        REQUIRE(user->all_sessions().size() == 2);
+        check_for_sessions(*user, 2, SyncSession::State::Active);
     }
 
     SECTION("a SyncUser properly rebinds existing sessions upon logging back in") {
-        auto user = get_user(app);
+        auto user = tsm.fake_user();
         auto session1 = sync_session(user, "/test1d-1");
         auto session2 = sync_session(user, "/test1d-2");
         // Make sure the sessions are bound.
         EventLoop::main().run_until([&] {
             return sessions_are_active(*session1, *session2);
         });
-        REQUIRE(user->all_sessions().size() == 2);
-        // Log the user out.
+        check_for_sessions(*user, 2, SyncSession::State::Active);
         user->log_out();
-        REQUIRE(user->state() == SyncUser::State::LoggedOut);
+        REQUIRE(user->state() == State::LoggedOut);
         // Run the runloop many iterations to see if the sessions spuriously rebind.
         spin_runloop();
         REQUIRE(session1->state() == SyncSession::State::Inactive);
         REQUIRE(session2->state() == SyncSession::State::Inactive);
-        REQUIRE(user->all_sessions().size() == 0);
-        // Log the user back in via the sync manager.
-        user = get_user(app);
+        check_for_sessions(*user, 0, SyncSession::State::Inactive);
+        user->log_in(ENCODE_FAKE_JWT("fake_access_token"), ENCODE_FAKE_JWT("fake_refresh_token"));
         EventLoop::main().run_until([&] {
             return sessions_are_active(*session1, *session2);
         });
-        REQUIRE(user->all_sessions().size() == 2);
+        check_for_sessions(*user, 2, SyncSession::State::Active);
     }
 
     SECTION("sessions that were destroyed can be properly recreated when requested again") {
@@ -140,7 +137,7 @@ TEST_CASE("SyncSession: management by SyncUser", "[sync][session]") {
         std::weak_ptr<SyncSession> weak_session;
         std::string on_disk_path;
         util::Optional<SyncConfig> config;
-        auto user = get_user(app);
+        auto user = tsm.fake_user();
         {
             // Create the session within a nested scope, so we can control its lifetime.
             auto session = sync_session(
@@ -166,7 +163,7 @@ TEST_CASE("SyncSession: management by SyncUser", "[sync][session]") {
     }
 
     SECTION("a user can create multiple sessions for the same URL") {
-        auto user = get_user(app);
+        auto user = tsm.fake_user();
         // Note that this should put the sessions at different paths.
         auto session1 = sync_session(user, "/test");
         auto session2 = sync_session(user, "/test");
@@ -180,9 +177,8 @@ TEST_CASE("sync: log-in", "[sync][session]") {
         return;
 
     // Disable file-related functionality and metadata functionality for testing purposes.
-    TestSyncManager init_sync_manager;
-    auto app = init_sync_manager.app();
-    auto user = get_user(app);
+    TestSyncManager tsm;
+    auto user = tsm.fake_user();
 
     SECTION("Can log in") {
         std::atomic<int> error_count(0);
@@ -200,14 +196,12 @@ TEST_CASE("sync: log-in", "[sync][session]") {
         CHECK(error_count == 0);
     }
 
-    // TODO: write a test that logs out a Realm with multiple sessions, then logs it back in?
     // TODO: write tests that check that a Session properly handles various types of errors reported via its callback.
 }
 
 TEST_CASE("SyncSession: close() API", "[sync][session]") {
-    TestSyncManager init_sync_manager;
-    auto app = init_sync_manager.app();
-    auto user = get_user(app);
+    TestSyncManager tsm;
+    auto user = tsm.fake_user();
 
     SECTION("Behaves properly when called on session in the 'active' or 'inactive' state") {
         auto session = sync_session(user, "/test-close-for-active");
@@ -233,9 +227,8 @@ TEST_CASE("SyncSession: close() API", "[sync][session]") {
 }
 
 TEST_CASE("SyncSession: pause()/resume() API", "[sync][session]") {
-    TestSyncManager init_sync_manager;
-    auto app = init_sync_manager.app();
-    auto user = get_user(app);
+    TestSyncManager tsm;
+    auto user = tsm.fake_user();
 
     auto session = sync_session(user, "/test-close-for-active");
     EventLoop::main().run_until([&] {
@@ -286,9 +279,8 @@ TEST_CASE("SyncSession: pause()/resume() API", "[sync][session]") {
 }
 
 TEST_CASE("SyncSession: shutdown_and_wait() API", "[sync][session]") {
-    TestSyncManager init_sync_manager;
-    auto app = init_sync_manager.app();
-    auto user = get_user(app);
+    TestSyncManager tsm;
+    auto user = tsm.fake_user();
 
     SECTION("Behaves properly when called on session in the 'active' or 'inactive' state") {
         auto session = sync_session(user, "/test-close-for-active");
@@ -309,10 +301,8 @@ TEST_CASE("SyncSession: shutdown_and_wait() API", "[sync][session]") {
 }
 
 TEST_CASE("SyncSession: internal pause_async API", "[sync][session]") {
-    TestSyncManager init_sync_manager;
-    auto app = init_sync_manager.app();
-    auto user = app->sync_manager()->get_user("close-api-tests-user", ENCODE_FAKE_JWT("fake_refresh_token"),
-                                              ENCODE_FAKE_JWT("fake_access_token"), dummy_device_id);
+    TestSyncManager tsm;
+    auto user = tsm.fake_user("close-api-tests-user");
 
     auto session = sync_session(
         user, "/test-close-for-active", [](auto, auto) {}, SyncSessionStopPolicy::AfterChangesUploaded);
@@ -332,9 +322,8 @@ TEST_CASE("SyncSession: internal pause_async API", "[sync][session]") {
 }
 
 TEST_CASE("SyncSession: update_configuration()", "[sync][session]") {
-    TestSyncManager init_sync_manager({}, {false});
-    auto app = init_sync_manager.app();
-    auto user = get_user(app);
+    TestSyncManager tsm({}, {false});
+    auto user = tsm.fake_user();
     auto session = sync_session(user, "/update_configuration");
 
     SECTION("updates reported configuration") {
@@ -366,8 +355,7 @@ TEST_CASE("SyncSession: update_configuration()", "[sync][session]") {
 }
 
 TEST_CASE("sync: error handling", "[sync][session]") {
-    TestSyncManager init_sync_manager;
-    auto app = init_sync_manager.app();
+    TestSyncManager tsm;
 
     std::string on_disk_path;
     std::optional<SyncError> error;
@@ -378,9 +366,9 @@ TEST_CASE("sync: error handling", "[sync][session]") {
     };
 
     SECTION("reports DNS error") {
-        app->sync_manager()->set_sync_route("ws://invalid.com:9090");
+        tsm.sync_manager()->set_sync_route("ws://invalid.com:9090");
 
-        auto user = get_user(app);
+        auto user = tsm.fake_user();
         auto session = sync_session(user, "/test", store_sync_error);
         timed_wait_for(
             [&] {
@@ -398,14 +386,14 @@ TEST_CASE("sync: error handling", "[sync][session]") {
 #if !(defined(SWIFT_PACKAGE) || REALM_MOBILE)
     SECTION("reports TLS error as handshake failed") {
         TestSyncManager ssl_sync_manager({}, {StartImmediately{true}, EnableSSL{true}});
-        auto app = ssl_sync_manager.app();
-
-        auto user = get_user(app);
+        auto user = ssl_sync_manager.fake_user();
         auto session = sync_session(user, "/test", store_sync_error);
-        timed_wait_for([&] {
-            std::lock_guard lock(mutex);
-            return error.has_value();
-        });
+        timed_wait_for(
+            [&] {
+                std::lock_guard lock(mutex);
+                return error.has_value();
+            },
+            std::chrono::seconds(35));
         REQUIRE(error);
         CHECK(error->status.code() == ErrorCodes::TlsHandshakeFailed);
 #if REALM_HAVE_SECURE_TRANSPORT
@@ -423,7 +411,7 @@ TEST_CASE("sync: error handling", "[sync][session]") {
     using ProtocolErrorInfo = realm::sync::ProtocolErrorInfo;
 
     SECTION("Doesn't treat unknown system errors as being fatal") {
-        auto user = get_user(app);
+        auto user = tsm.fake_user();
         auto session = sync_session(user, "/test", store_sync_error);
         EventLoop::main().run_until([&] {
             return sessions_are_active(*session);
@@ -439,7 +427,8 @@ TEST_CASE("sync: error handling", "[sync][session]") {
     }
 
     SECTION("Properly handles a client reset error") {
-        auto user = get_user(app);
+        auto user = tsm.fake_user();
+
         auto session = sync_session(user, "/test", store_sync_error);
         std::string on_disk_path = session->path();
         EventLoop::main().run_until([&] {
@@ -467,7 +456,9 @@ TEST_CASE("sync: error handling", "[sync][session]") {
         std::string recovery_path = error->user_info[SyncError::c_recovery_file_path_key];
         auto idx = recovery_path.find("recovered_realm");
         CHECK(idx != std::string::npos);
-        idx = recovery_path.find(app->sync_manager()->recovery_directory_path());
+        idx = recovery_path.find(tsm.sync_manager()->recovery_directory_path());
+        CHECK(idx != std::string::npos);
+        idx = recovery_path.find(tsm.app()->config().app_id);
         CHECK(idx != std::string::npos);
         if (just_before.tm_year == just_after.tm_year) {
             idx = recovery_path.find(util::format_local_time(just_after_raw, "%Y"));
@@ -489,9 +480,9 @@ TEST_CASE("sync: stop policy behavior", "[sync][session]") {
         return;
 
     // Server is initially stopped so we can control when the session exits the dying state.
-    TestSyncManager init_sync_manager({}, {false});
-    auto& server = init_sync_manager.sync_server();
-    auto sync_manager = init_sync_manager.app()->sync_manager();
+    TestSyncManager tsm({}, {false});
+    auto& server = tsm.sync_server();
+    auto sync_manager = tsm.sync_manager();
     auto schema = Schema{
         {"object",
          {
@@ -502,7 +493,7 @@ TEST_CASE("sync: stop policy behavior", "[sync][session]") {
 
     std::atomic<bool> error_handler_invoked(false);
     Realm::Config config;
-    auto user = get_user(init_sync_manager.app());
+    auto user = tsm.fake_user();
 
     auto create_session = [&](SyncSessionStopPolicy stop_policy) {
         auto session = sync_session(
@@ -595,9 +586,8 @@ TEST_CASE("session restart", "[sync][session]") {
     if (!EventLoop::has_implementation())
         return;
 
-    TestSyncManager init_sync_manager({}, {false});
-    auto& server = init_sync_manager.sync_server();
-    auto app = init_sync_manager.app();
+    TestSyncManager tsm({}, {false});
+    auto& server = tsm.sync_server();
     Realm::Config config;
     auto schema = Schema{
         {"object",
@@ -607,7 +597,7 @@ TEST_CASE("session restart", "[sync][session]") {
          }},
     };
 
-    auto user = get_user(app);
+    auto user = tsm.fake_user();
     auto session = sync_session(
         user, "/test-restart", [&](auto, auto) {}, SyncSessionStopPolicy::AfterChangesUploaded, nullptr, schema,
         &config);
@@ -638,11 +628,12 @@ TEST_CASE("sync: non-synced metadata table doesn't result in non-additive schema
         return;
 
     // Disable file-related functionality and metadata functionality for testing purposes.
-    TestSyncManager init_sync_manager;
-
+    TestSyncManager tsm;
+    auto user = tsm.fake_user();
+    ;
     // Create a synced Realm containing a class with two properties.
     {
-        SyncTestFile config1(init_sync_manager.app(), "schema-version-test");
+        SyncTestFile config1(user, "schema-version-test");
         config1.schema_version = 1;
         config1.schema = Schema{
             {"object",
@@ -657,7 +648,7 @@ TEST_CASE("sync: non-synced metadata table doesn't result in non-additive schema
 
     // Download the existing Realm into a second local file without specifying a schema,
     // mirroring how `openAsync` works.
-    SyncTestFile config2(init_sync_manager.app(), "schema-version-test");
+    SyncTestFile config2(user, "schema-version-test");
     config2.schema_version = 1;
     {
         auto realm2 = Realm::get_shared_realm(config2);
@@ -668,7 +659,7 @@ TEST_CASE("sync: non-synced metadata table doesn't result in non-additive schema
     // only a single property. This should not result in us trying to remove `property2`,
     // and will throw an exception if it does.
     {
-        SyncTestFile config3(init_sync_manager.app(), "schema-version-test");
+        SyncTestFile config3(user, "schema-version-test");
         config3.path = config2.path;
         config3.schema_version = 1;
         config3.schema = Schema{

--- a/test/object-store/sync/session/session.cpp
+++ b/test/object-store/sync/session/session.cpp
@@ -458,8 +458,6 @@ TEST_CASE("sync: error handling", "[sync][session]") {
         CHECK(idx != std::string::npos);
         idx = recovery_path.find(tsm.sync_manager()->recovery_directory_path());
         CHECK(idx != std::string::npos);
-        idx = recovery_path.find(tsm.app()->config().app_id);
-        CHECK(idx != std::string::npos);
         if (just_before.tm_year == just_after.tm_year) {
             idx = recovery_path.find(util::format_local_time(just_after_raw, "%Y"));
             CHECK(idx != std::string::npos);

--- a/test/object-store/sync/session/wait_for_completion.cpp
+++ b/test/object-store/sync/session/wait_for_completion.cpp
@@ -137,7 +137,6 @@ TEST_CASE("SyncSession: wait_for_upload_completion() API", "[sync][pbs][session]
 
     SECTION("works properly when called on a logged-out session") {
         server.start();
-        const auto user_id = "user-async-wait-upload-3";
         auto user = tsm.fake_user();
         auto session = sync_session(user, "/user-async-wait-upload-3", [](auto, auto) {});
         EventLoop::main().run_until([&] {

--- a/test/object-store/sync/session/wait_for_completion.cpp
+++ b/test/object-store/sync/session/wait_for_completion.cpp
@@ -32,20 +32,14 @@ TEST_CASE("SyncSession: wait_for_download_completion() API", "[sync][pbs][sessio
     if (!EventLoop::has_implementation())
         return;
 
-    const std::string dummy_device_id = "123400000000000000000000";
-
-    // Disable file-related functionality and metadata functionality for testing purposes.
-    TestSyncManager::Config config;
-    config.metadata_mode = SyncManager::MetadataMode::NoMetadata;
-    TestSyncManager init_sync_manager(config, {false});
-    auto& server = init_sync_manager.sync_server();
-    auto sync_manager = init_sync_manager.app()->sync_manager();
+    TestSyncManager tsm({}, {false});
+    auto& server = tsm.sync_server();
+    auto sync_manager = tsm.sync_manager();
     std::atomic<bool> handler_called(false);
 
     SECTION("works properly when called after the session is bound") {
         server.start();
-        auto user = sync_manager->get_user("user-async-wait-download-1", ENCODE_FAKE_JWT("not_a_real_token"),
-                                           ENCODE_FAKE_JWT("not_a_real_token"), dummy_device_id);
+        auto user = tsm.fake_user();
         auto session = sync_session(user, "/async-wait-download-1", [](auto, auto) {});
         EventLoop::main().run_until([&] {
             return sessions_are_active(*session);
@@ -61,9 +55,7 @@ TEST_CASE("SyncSession: wait_for_download_completion() API", "[sync][pbs][sessio
 
     SECTION("works properly when called on a logged-out session") {
         server.start();
-        const auto user_id = "user-async-wait-download-3";
-        auto user = sync_manager->get_user(user_id, ENCODE_FAKE_JWT("not_a_real_token"),
-                                           ENCODE_FAKE_JWT("not_a_real_token"), dummy_device_id);
+        auto user = tsm.fake_user();
         auto session = sync_session(user, "/user-async-wait-download-3", [](auto, auto) {});
         EventLoop::main().run_until([&] {
             return sessions_are_active(*session);
@@ -80,8 +72,8 @@ TEST_CASE("SyncSession: wait_for_download_completion() API", "[sync][pbs][sessio
         spin_runloop();
         REQUIRE(handler_called == false);
         // Log the user back in
-        user = sync_manager->get_user(user_id, ENCODE_FAKE_JWT("not_a_real_token"),
-                                      ENCODE_FAKE_JWT("not_a_real_token"), dummy_device_id);
+        user = sync_manager->get_user(user->identity(), ENCODE_FAKE_JWT("not_a_real_token"),
+                                      ENCODE_FAKE_JWT("not_a_real_token"), "");
         EventLoop::main().run_until([&] {
             return sessions_are_active(*session);
         });
@@ -92,8 +84,7 @@ TEST_CASE("SyncSession: wait_for_download_completion() API", "[sync][pbs][sessio
     }
 
     SECTION("aborts properly when queued and the session errors out") {
-        auto user = sync_manager->get_user("user-async-wait-download-4", ENCODE_FAKE_JWT("not_a_real_token"),
-                                           ENCODE_FAKE_JWT("not_a_real_token"), dummy_device_id);
+        auto user = tsm.fake_user();
         std::atomic<int> error_count(0);
         std::shared_ptr<SyncSession> session = sync_session(user, "/async-wait-download-4", [&](auto, auto) {
             ++error_count;
@@ -120,22 +111,17 @@ TEST_CASE("SyncSession: wait_for_upload_completion() API", "[sync][pbs][session]
     if (!EventLoop::has_implementation())
         return;
 
-    const std::string dummy_device_id = "123400000000000000000000";
-
-    // Disable file-related functionality and metadata functionality for testing purposes.
     TestSyncManager::Config config;
-    config.metadata_mode = SyncManager::MetadataMode::NoMetadata;
     config.should_teardown_test_directory = false;
     SyncServer::Config server_config = {false};
-    TestSyncManager init_sync_manager(config, server_config);
-    auto& server = init_sync_manager.sync_server();
-    auto sync_manager = init_sync_manager.app()->sync_manager();
+    TestSyncManager tsm(config, server_config);
+    auto& server = tsm.sync_server();
+    auto sync_manager = tsm.sync_manager();
     std::atomic<bool> handler_called(false);
 
     SECTION("works properly when called after the session is bound") {
         server.start();
-        auto user = sync_manager->get_user("user-async-wait-upload-1", ENCODE_FAKE_JWT("not_a_real_token"),
-                                           ENCODE_FAKE_JWT("not_a_real_token"), dummy_device_id);
+        auto user = tsm.fake_user();
         auto session = sync_session(user, "/async-wait-upload-1", [](auto, auto) {});
         EventLoop::main().run_until([&] {
             return sessions_are_active(*session);
@@ -152,8 +138,7 @@ TEST_CASE("SyncSession: wait_for_upload_completion() API", "[sync][pbs][session]
     SECTION("works properly when called on a logged-out session") {
         server.start();
         const auto user_id = "user-async-wait-upload-3";
-        auto user = sync_manager->get_user(user_id, ENCODE_FAKE_JWT("not_a_real_token"),
-                                           ENCODE_FAKE_JWT("not_a_real_token"), dummy_device_id);
+        auto user = tsm.fake_user();
         auto session = sync_session(user, "/user-async-wait-upload-3", [](auto, auto) {});
         EventLoop::main().run_until([&] {
             return sessions_are_active(*session);
@@ -170,8 +155,8 @@ TEST_CASE("SyncSession: wait_for_upload_completion() API", "[sync][pbs][session]
         spin_runloop();
         REQUIRE(handler_called == false);
         // Log the user back in
-        user = sync_manager->get_user(user_id, ENCODE_FAKE_JWT("not_a_real_token"),
-                                      ENCODE_FAKE_JWT("not_a_real_token"), dummy_device_id);
+        user = sync_manager->get_user(user->identity(), ENCODE_FAKE_JWT("not_a_real_token"),
+                                      ENCODE_FAKE_JWT("not_a_real_token"), "");
         EventLoop::main().run_until([&] {
             return sessions_are_active(*session);
         });

--- a/test/object-store/sync/sync_manager.cpp
+++ b/test/object-store/sync/sync_manager.cpp
@@ -35,7 +35,7 @@ using namespace realm;
 using namespace realm::util;
 using File = realm::util::File;
 
-static const auto base_path = fs::path{util::make_temp_dir()}.make_preferred() / "realm_objectstore_sync_manager";
+static const auto base_path = fs::path{util::make_temp_dir()}.make_preferred() / "realm_objectstore_sync_manager.test-dir";
 static const std::string dummy_device_id = "123400000000000000000000";
 
 namespace {
@@ -462,8 +462,9 @@ TEST_CASE("sync_manager: persistent user state management", "[sync][sync manager
 }
 
 TEST_CASE("sync_manager: file actions", "[sync][sync manager]") {
+    test_util::TestDirGuard guard(base_path.string());
+
     using Action = SyncFileActionMetadata::Action;
-    reset_test_directory(base_path.string());
 
     auto file_manager = SyncFileManager(base_path.string(), "bar_app_id");
     // Open the metadata separately, so we can investigate it ourselves.

--- a/test/object-store/sync/user.cpp
+++ b/test/object-store/sync/user.cpp
@@ -180,9 +180,11 @@ TEST_CASE("sync_user: logout", "[sync][user]") {
 }
 
 TEST_CASE("sync_user: user persistence", "[sync][user]") {
-    TestSyncManager tsm(SyncManager::MetadataMode::NoEncryption);
+    TestSyncManager::Config tsm_config;
+    tsm_config.metadata_mode = SyncManager::MetadataMode::NoEncryption;
+    TestSyncManager tsm(tsm_config);
     auto sync_manager = tsm.sync_manager();
-    auto file_manager = SyncFileManager(tsm.base_file_path(), tsm.app()->config().app_id);
+    auto file_manager = SyncFileManager(tsm.base_file_path(), "app_id");
     // Open the metadata separately, so we can investigate it ourselves.
     SyncMetadataManager manager(file_manager.metadata_path(), false);
 

--- a/test/object-store/sync/user.cpp
+++ b/test/object-store/sync/user.cpp
@@ -36,7 +36,7 @@ static const std::string dummy_device_id = "123400000000000000000000";
 
 TEST_CASE("sync_user: SyncManager `get_user()` API", "[sync][user]") {
     TestSyncManager init_sync_manager;
-    auto sync_manager = init_sync_manager.app()->sync_manager();
+    auto sync_manager = init_sync_manager.sync_manager();
     const std::string identity = "sync_test_identity";
     const std::string refresh_token = ENCODE_FAKE_JWT("1234567890-fake-refresh-token");
     const std::string access_token = ENCODE_FAKE_JWT("1234567890-fake-access-token");
@@ -86,7 +86,7 @@ TEST_CASE("sync_user: SyncManager `get_user()` API", "[sync][user]") {
 
 TEST_CASE("sync_user: update state and tokens", "[sync][user]") {
     TestSyncManager init_sync_manager;
-    auto sync_manager = init_sync_manager.app()->sync_manager();
+    auto sync_manager = init_sync_manager.sync_manager();
     const std::string identity = "sync_test_identity";
     const std::string refresh_token = ENCODE_FAKE_JWT("fake-refresh-token-1");
     const std::string access_token = ENCODE_FAKE_JWT("fake-access-token-1");
@@ -113,8 +113,8 @@ TEST_CASE("sync_user: update state and tokens", "[sync][user]") {
 }
 
 TEST_CASE("sync_user: SyncManager get_existing_logged_in_user() API", "[sync][user]") {
-    TestSyncManager init_sync_manager(SyncManager::MetadataMode::NoMetadata);
-    auto sync_manager = init_sync_manager.app()->sync_manager();
+    TestSyncManager init_sync_manager;
+    auto sync_manager = init_sync_manager.sync_manager();
     const std::string identity = "sync_test_identity";
     const std::string refresh_token = ENCODE_FAKE_JWT("1234567890-fake-refresh-token");
     const std::string access_token = ENCODE_FAKE_JWT("1234567890-fake-access-token");
@@ -165,8 +165,8 @@ TEST_CASE("sync_user: SyncManager get_existing_logged_in_user() API", "[sync][us
 }
 
 TEST_CASE("sync_user: logout", "[sync][user]") {
-    TestSyncManager init_sync_manager(SyncManager::MetadataMode::NoMetadata);
-    auto sync_manager = init_sync_manager.app()->sync_manager();
+    TestSyncManager init_sync_manager;
+    auto sync_manager = init_sync_manager.sync_manager();
     const std::string identity = "sync_test_identity";
     const std::string refresh_token = ENCODE_FAKE_JWT("1234567890-fake-refresh-token");
     const std::string access_token = ENCODE_FAKE_JWT("1234567890-fake-access-token");
@@ -181,7 +181,7 @@ TEST_CASE("sync_user: logout", "[sync][user]") {
 
 TEST_CASE("sync_user: user persistence", "[sync][user]") {
     TestSyncManager tsm(SyncManager::MetadataMode::NoEncryption);
-    auto sync_manager = tsm.app()->sync_manager();
+    auto sync_manager = tsm.sync_manager();
     auto file_manager = SyncFileManager(tsm.base_file_path(), tsm.app()->config().app_id);
     // Open the metadata separately, so we can investigate it ourselves.
     SyncMetadataManager manager(file_manager.metadata_path(), false);

--- a/test/object-store/thread_safe_reference.cpp
+++ b/test/object-store/thread_safe_reference.cpp
@@ -70,10 +70,8 @@ TEST_CASE("thread safe reference") {
 
     TestFile config;
     config.automatic_change_notifications = false;
-    config.cache = false;
-    config.in_memory = true;
-    config.encryption_key = std::vector<char>();
     config.schema = schema;
+    config.in_memory = true;
     auto r = Realm::get_shared_realm(config);
 
     const auto int_obj_col = r->schema().find("int object")->persisted_properties[0].column_key;

--- a/test/object-store/util/sync/sync_test_utils.cpp
+++ b/test/object-store/util/sync/sync_test_utils.cpp
@@ -200,7 +200,7 @@ void wait_for_sessions_to_close(const TestAppSession& test_app_session)
 {
     timed_sleeping_wait_for(
         [&]() -> bool {
-            return !test_app_session.app()->sync_manager()->has_existing_sessions();
+            return !test_app_session.sync_manager()->has_existing_sessions();
         },
         std::chrono::minutes(5), std::chrono::milliseconds(100));
 }
@@ -547,7 +547,7 @@ struct BaasClientReset : public TestClientReset {
     {
         m_did_run = true;
         const AppSession& app_session = m_test_app_session.app_session();
-        auto sync_manager = m_test_app_session.app()->sync_manager();
+        auto sync_manager = m_test_app_session.sync_manager();
         std::string partition_value = m_local_config.sync_config->partition_value;
         REALM_ASSERT(partition_value.size() > 2 && *partition_value.begin() == '"' &&
                      *(partition_value.end() - 1) == '"');

--- a/test/object-store/util/sync/sync_test_utils.hpp
+++ b/test/object-store/util/sync/sync_test_utils.hpp
@@ -135,14 +135,6 @@ const std::shared_ptr<app::GenericNetworkTransport> instance_of = std::make_shar
 
 std::ostream& operator<<(std::ostream& os, util::Optional<app::AppError> error);
 
-template <typename Transport>
-TestSyncManager::Config get_config(Transport&& transport)
-{
-    TestSyncManager::Config config;
-    config.transport = transport;
-    return config;
-}
-
 void subscribe_to_all_and_bootstrap(Realm& realm);
 
 #if REALM_ENABLE_AUTH_TESTS

--- a/test/object-store/util/test_file.hpp
+++ b/test/object-store/util/test_file.hpp
@@ -20,23 +20,21 @@
 #define REALM_TEST_UTIL_TEST_FILE_HPP
 
 #include <realm/object-store/shared_realm.hpp>
+#include <realm/util/logger.hpp>
 #include <realm/util/tagged_bool.hpp>
 
-#include <realm/util/logger.hpp>
-#include <realm/util/optional.hpp>
+#if REALM_ENABLE_SYNC
+#include "test_utils.hpp"
+#include "unit_test_transport.hpp"
+
+#include <realm/object-store/sync/app.hpp>
+#include <realm/object-store/sync/sync_manager.hpp>
+#include <realm/sync/client.hpp>
+#include <realm/sync/config.hpp>
+#include <realm/sync/noinst/server/server.hpp>
+#endif // REALM_ENABLE_SYNC
 
 #include <thread>
-
-#if REALM_ENABLE_SYNC
-#include <realm/sync/config.hpp>
-#include <realm/object-store/sync/sync_manager.hpp>
-#include <realm/object-store/sync/app.hpp>
-#include "test_utils.hpp"
-
-#include <realm/sync/client.hpp>
-#include <realm/sync/noinst/server/server.hpp>
-
-#endif // REALM_ENABLE_SYNC
 
 #ifndef TEST_TIMEOUT_EXTRA
 #define TEST_TIMEOUT_EXTRA 0
@@ -162,6 +160,7 @@ private:
     }
 };
 
+class OfflineAppSession;
 struct SyncTestFile : TestFile {
     template <typename ErrorHandler>
     SyncTestFile(const realm::SyncConfig& sync_config, realm::SyncSessionStopPolicy stop_policy,
@@ -173,8 +172,8 @@ struct SyncTestFile : TestFile {
         schema_mode = realm::SchemaMode::AdditiveExplicit;
     }
 
-    SyncTestFile(std::shared_ptr<realm::app::App> app = nullptr, std::string name = "",
-                 std::string user_name = "test");
+    SyncTestFile(TestSyncManager&, std::string name = "", std::string user_name = "test");
+    SyncTestFile(OfflineAppSession&, std::string name = "");
     SyncTestFile(std::shared_ptr<realm::SyncUser> user, realm::bson::Bson partition,
                  realm::util::Optional<realm::Schema> schema = realm::util::none);
     SyncTestFile(std::shared_ptr<realm::SyncUser> user, realm::bson::Bson partition,
@@ -182,6 +181,82 @@ struct SyncTestFile : TestFile {
                  std::function<realm::SyncSessionErrorHandler>&& error_handler);
     SyncTestFile(std::shared_ptr<realm::app::App> app, realm::bson::Bson partition, realm::Schema schema);
     SyncTestFile(std::shared_ptr<realm::SyncUser> user, realm::Schema schema, realm::SyncConfig::FLXSyncEnabled);
+};
+
+class TestSyncManager {
+public:
+    struct Config {
+        Config() {}
+        std::string base_path;
+        realm::SyncManager::MetadataMode metadata_mode = realm::SyncManager::MetadataMode::NoMetadata;
+        bool should_teardown_test_directory = true;
+        realm::util::Logger::Level log_level = realm::util::Logger::Level::TEST_LOGGING_LEVEL;
+        bool start_sync_client = true;
+    };
+
+    TestSyncManager(const Config& = Config(), const SyncServer::Config& = {});
+    ~TestSyncManager();
+
+    std::string base_file_path() const
+    {
+        return m_base_file_path;
+    }
+    SyncServer& sync_server()
+    {
+        return m_sync_server;
+    }
+    const std::shared_ptr<realm::SyncManager>& sync_manager()
+    {
+        return m_sync_manager;
+    }
+
+    std::shared_ptr<realm::SyncUser> fake_user(const std::string& name = "test");
+
+private:
+    std::shared_ptr<realm::SyncManager> m_sync_manager;
+    SyncServer m_sync_server;
+    std::string m_base_file_path;
+    bool m_should_teardown_test_directory = true;
+};
+
+class OfflineAppSession {
+public:
+    struct Config {
+        Config(std::shared_ptr<realm::app::GenericNetworkTransport> = std::make_shared<UnitTestTransport>());
+        std::shared_ptr<realm::app::GenericNetworkTransport> transport;
+        bool delete_storage = true;
+        std::optional<std::string> storage_path;
+        realm::SyncManager::MetadataMode metadata_mode = realm::SyncManager::MetadataMode::NoMetadata;
+        std::optional<std::string> base_url;
+        std::shared_ptr<realm::sync::SyncSocketProvider> socket_provider;
+        std::optional<std::string> app_id;
+    };
+    OfflineAppSession(Config = {});
+    ~OfflineAppSession();
+
+    std::shared_ptr<realm::app::App> app() const noexcept
+    {
+        return m_app;
+    }
+    std::shared_ptr<realm::SyncUser> make_user() const;
+    realm::app::GenericNetworkTransport* transport()
+    {
+        return m_transport.get();
+    }
+    std::string base_file_path() const
+    {
+        return m_base_file_path;
+    }
+    const std::shared_ptr<realm::SyncManager>& sync_manager()
+    {
+        return m_app->sync_manager();
+    }
+
+private:
+    std::shared_ptr<realm::app::App> m_app;
+    std::string m_base_file_path;
+    std::shared_ptr<realm::app::GenericNetworkTransport> m_transport;
+    bool m_delete_storage = true;
 };
 
 #if REALM_ENABLE_AUTH_TESTS
@@ -222,80 +297,6 @@ private:
     std::shared_ptr<realm::app::GenericNetworkTransport> m_transport;
 };
 #endif
-
-class TestSyncManager {
-public:
-    struct Config {
-        Config() {}
-        realm::app::App::Config app_config;
-        std::string base_path;
-        realm::SyncManager::MetadataMode metadata_mode = realm::SyncManager::MetadataMode::NoMetadata;
-        bool should_teardown_test_directory = true;
-        realm::util::Logger::Level log_level = realm::util::Logger::Level::TEST_LOGGING_LEVEL;
-        bool override_sync_route = true;
-        std::shared_ptr<realm::app::GenericNetworkTransport> transport;
-        bool start_sync_client = true;
-    };
-
-    TestSyncManager(realm::SyncManager::MetadataMode mode);
-    TestSyncManager(const Config& = Config(), const SyncServer::Config& = {});
-    ~TestSyncManager();
-
-    std::shared_ptr<realm::app::App> app() const noexcept
-    {
-        return m_app;
-    }
-    std::string base_file_path() const
-    {
-        return m_base_file_path;
-    }
-    SyncServer& sync_server()
-    {
-        return m_sync_server;
-    }
-    const std::shared_ptr<realm::SyncManager>& sync_manager()
-    {
-        return m_app->sync_manager();
-    }
-
-    std::shared_ptr<realm::SyncUser> fake_user(const std::string& name = "test");
-
-    // Capture the token refresh callback so that we can invoke it later with
-    // the desired result
-    realm::util::UniqueFunction<void(const realm::app::Response&)> network_callback;
-
-    struct Transport : realm::app::GenericNetworkTransport {
-        Transport(realm::util::UniqueFunction<void(const realm::app::Response&)>& network_callback)
-            : network_callback(network_callback)
-        {
-        }
-
-        void
-        send_request_to_server(const realm::app::Request&,
-                               realm::util::UniqueFunction<void(const realm::app::Response&)>&& completion) override
-        {
-            network_callback = std::move(completion);
-        }
-
-        realm::util::UniqueFunction<void(const realm::app::Response&)>& network_callback;
-    };
-    const std::shared_ptr<realm::app::GenericNetworkTransport> transport;
-
-private:
-    std::shared_ptr<realm::app::App> m_app;
-    SyncServer m_sync_server;
-    std::string m_base_file_path;
-    bool m_should_teardown_test_directory = true;
-};
-
-inline TestSyncManager::TestSyncManager(realm::SyncManager::MetadataMode mode)
-    : TestSyncManager([=] {
-        Config config;
-        config.metadata_mode = mode;
-        return config;
-    }())
-{
-}
 
 bool wait_for_upload(realm::Realm& realm, std::chrono::seconds timeout = std::chrono::seconds(60));
 bool wait_for_download(realm::Realm& realm, std::chrono::seconds timeout = std::chrono::seconds(60));

--- a/test/object-store/util/test_file.hpp
+++ b/test/object-store/util/test_file.hpp
@@ -206,6 +206,10 @@ public:
     {
         return m_transport.get();
     }
+    const std::shared_ptr<realm::SyncManager>& sync_manager() const
+    {
+        return m_app->sync_manager();
+    }
 
     std::vector<realm::bson::BsonDocument> get_documents(realm::SyncUser& user, const std::string& object_type,
                                                          size_t expected_count) const;
@@ -248,6 +252,10 @@ public:
     SyncServer& sync_server()
     {
         return m_sync_server;
+    }
+    const std::shared_ptr<realm::SyncManager>& sync_manager()
+    {
+        return m_app->sync_manager();
     }
 
     std::shared_ptr<realm::SyncUser> fake_user(const std::string& name = "test");

--- a/test/object-store/util/test_utils.cpp
+++ b/test/object-store/util/test_utils.cpp
@@ -95,12 +95,6 @@ bool create_dummy_realm(std::string path, std::shared_ptr<Realm>* out)
     }
 }
 
-void reset_test_directory(const std::string& base_path)
-{
-    util::try_remove_dir_recursive(base_path);
-    util::make_dir(base_path);
-}
-
 std::vector<char> make_test_encryption_key(const char start)
 {
     std::vector<char> vector;

--- a/test/object-store/util/test_utils.hpp
+++ b/test/object-store/util/test_utils.hpp
@@ -180,7 +180,6 @@ std::ostream& operator<<(std::ostream&, const Exception&);
 class Realm;
 /// Open a Realm at a given path, creating its files.
 bool create_dummy_realm(std::string path, std::shared_ptr<Realm>* out = nullptr);
-void reset_test_directory(const std::string& base_path);
 std::vector<char> make_test_encryption_key(const char start = 0);
 void catch2_ensure_section_run_workaround(bool did_run_a_section, std::string section_name,
                                           util::FunctionRef<void()> func);

--- a/test/object-store/util/test_utils.hpp
+++ b/test/object-store/util/test_utils.hpp
@@ -47,21 +47,24 @@ public:
 
     void transition_to(E new_state)
     {
-        std::lock_guard lock{m_mutex};
-        m_cur_state = new_state;
+        {
+            std::lock_guard lock{m_mutex};
+            m_cur_state = new_state;
+        }
         m_cv.notify_one();
     }
 
     template <typename Func>
     void transition_with(Func&& func)
     {
-        std::lock_guard lock{m_mutex};
-        std::optional<E> new_state = func(m_cur_state);
-        if (!new_state) {
-            return;
+        {
+            std::lock_guard lock{m_mutex};
+            std::optional<E> new_state = func(m_cur_state);
+            if (!new_state) {
+                return;
+            }
+            m_cur_state = *new_state;
         }
-
-        m_cur_state = *new_state;
         m_cv.notify_one();
     }
 

--- a/test/object-store/util/unit_test_transport.hpp
+++ b/test/object-store/util/unit_test_transport.hpp
@@ -16,6 +16,9 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
+#ifndef REALM_TEST_UTIL_TRANSPORT_HPP
+#define REALM_TEST_UTIL_TRANSPORT_HPP
+
 #include <realm/object-store/sync/generic_network_transport.hpp>
 
 #include <external/json/json.hpp>
@@ -94,3 +97,5 @@ private:
     void handle_token_refresh(const realm::app::Request& request,
                               realm::util::UniqueFunction<void(const realm::app::Response&)>&& completion);
 };
+
+#endif // REALM_TEST_UTIL_TRANSPORT_HPP


### PR DESCRIPTION
Another pile of changes extracted from #7300 with the hopes of making it more reviewable.

The primary change here is that TestSyncManager no longer has an App, and a new type OfflineAppSession replaces it for things testing App using a mock transport. Our test types are now:

* TestSyncManager: initializes a SyncManager and SyncServer for testing sync functionality. Does not use any App Services[^1] or BaaS.
* OfflineAppSession: initializes an App using a mock network transport. Does not support sync, and is used for unit tests of App Services functionality
* TestAppSession: initializes an App using a real network transport that talks to BaaS. Used for integration tests and sync tests which can't be tested against the old server.

This removes the ability to reconfigure SyncManager after calling reset_for_testing(). This was something that was originally needed because SyncManager was a singleton, but that hasn't been the case ever since v10 and tests can now just create a new SyncManager. No one appears to have been relying on this. reset_for_testing() has been renamed to tear_down_for_testing() to reflect the change in functionality.


[^1]: Or won't post-app services split, anyway. Currently the actual implementation is still fairly coupled.
