### PR TITLE
RCORE-1490 Sync collections in Mixed and nested collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,10 @@
 # NEXT RELEASE
 
 ### Enhancements
-* <New feature description> (PR [#????](https://github.com/realm/realm-core/pull/????))
-* None.
+* Add support to synchronize collections embedded in Mixed properties and other collections (except sets) ([PR #7353](https://github.com/realm/realm-core/pull/7353)).
 
 ### Fixed
-* <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Fixed conflict resolution bug which may result in an crash when the AddInteger instruction on Mixed properties is merged against updates to a non-integer type ([PR #7353](https://github.com/realm/realm-core/pull/7353)).
 
 ### Breaking changes
 * None.

--- a/src/realm/dictionary.cpp
+++ b/src/realm/dictionary.cpp
@@ -707,7 +707,6 @@ bool Dictionary::try_erase(Mixed key)
     return true;
 }
 
-
 void Dictionary::erase(Mixed key)
 {
     if (!try_erase(key)) {

--- a/src/realm/dictionary.hpp
+++ b/src/realm/dictionary.hpp
@@ -227,6 +227,8 @@ public:
     void to_json(std::ostream&, JSONOutputMode, util::FunctionRef<void(const Mixed&)>) const override;
 
 private:
+    using Base::set_collection;
+
     template <typename T, typename Op>
     friend class CollectionColumnAggregate;
     friend class DictionaryLinkValues;

--- a/src/realm/obj.cpp
+++ b/src/realm/obj.cpp
@@ -1660,7 +1660,7 @@ Obj& Obj::set(ColKey col_key, T value, bool is_default)
 
     if (type != ColumnTypeTraits<T>::column_id)
         throw InvalidArgument(ErrorCodes::TypeMismatch,
-                              util::format("Property not a %1", ColumnTypeTraits<int64_t>::column_id));
+                              util::format("Property not a %1", ColumnTypeTraits<T>::column_id));
     if (value_is_null(value) && !attrs.test(col_attr_Nullable))
         throw NotNullable(Group::table_name_to_class_name(m_table->get_name()), m_table->get_column_name(col_key));
 

--- a/src/realm/object-store/c_api/list.cpp
+++ b/src/realm/object-store/c_api/list.cpp
@@ -112,7 +112,6 @@ RLM_API realm_dictionary_t* realm_list_set_dictionary(realm_list_t* list, size_t
     return wrap_err([&]() {
         list->set_collection(index, CollectionType::Dictionary);
         return new realm_dictionary_t{list->get_dictionary(index)};
-        ;
     });
 }
 

--- a/src/realm/object_converter.cpp
+++ b/src/realm/object_converter.cpp
@@ -327,10 +327,10 @@ void InterRealmValueConverter::copy_value(const Obj& src_obj, Obj& dst_obj, bool
 }
 
 //
-// Handle collections in mixed. A collection can have N nested levels (expect for Sets). And these levels can be
+// Handle collections in mixed. A collection can have N nested levels (except for Sets). And these levels can be
 // nested in arbitrary way (eg a List within a Dictionary or viceversa). In order to try to merge server changes with
-// client changes, the algorithm needs to go throw each single element in the collection, check its type and perform
-// the most appropriate action in order to miminize the number of notificiations triggered.
+// client changes, the algorithm needs to go through each single element in the collection, check its type and perform
+// the most appropriate action in order to miminize the number of notifications triggered.
 //
 void InterRealmValueConverter::handle_list_in_mixed(const Lst<Mixed>& src_list, Lst<Mixed>& dst_list) const
 {

--- a/src/realm/sync/instruction_applier.cpp
+++ b/src/realm/sync/instruction_applier.cpp
@@ -888,26 +888,27 @@ void InstructionApplier::operator()(const Instruction::Clear& instr)
         }
         Status on_list_index(LstBase& list, uint32_t index) override
         {
+            REALM_ASSERT(dynamic_cast<Lst<Mixed>*>(&list));
             auto& mixed_list = static_cast<Lst<Mixed>&>(list);
-            if (index < mixed_list.size()) {
-                auto val = mixed_list.get(index);
-
-                if (val.is_type(type_Dictionary)) {
-                    Dictionary d(mixed_list, mixed_list.get_key(index));
-                    d.clear();
-                    return Status::Pending;
-                }
-                if (val.is_type(type_List)) {
-                    Lst<Mixed> l(mixed_list, mixed_list.get_key(index));
-                    l.clear();
-                    return Status::Pending;
-                }
+            if (index >= mixed_list.size()) {
+                m_applier->bad_transaction_log("Clear: Index out of bounds (%1 > %2)", index,
+                                               mixed_list.size()); // Throws
+                return Status::DidNotResolve;
             }
-            else {
-                m_applier->bad_transaction_log("Clear: Index out of bounds (%1 > %2)", index, mixed_list.size());
+            auto val = mixed_list.get(index);
+            if (val.is_type(type_Dictionary)) {
+                Dictionary d(mixed_list, mixed_list.get_key(index));
+                d.clear();
+                return Status::Pending;
             }
-
-            return PathResolver::on_list_index(list, index);
+            if (val.is_type(type_List)) {
+                Lst<Mixed> l(mixed_list, mixed_list.get_key(index));
+                l.clear();
+                return Status::Pending;
+            }
+            m_applier->bad_transaction_log("Clear: Item (%1) at index %2 is not a collection", val.get_type(),
+                                           index); // Throws
+            return Status::DidNotResolve;
         }
         void on_dictionary(Dictionary& dict) override
         {
@@ -926,7 +927,9 @@ void InstructionApplier::operator()(const Instruction::Clear& instr)
                 l.clear();
                 return Status::Pending;
             }
-            return PathResolver::on_dictionary_key(dict, key);
+            m_applier->bad_transaction_log("Clear: Item (%1) at key '%2' is not a collection", val.get_type(),
+                                           key); // Throws
+            return Status::DidNotResolve;
         }
         void on_set(SetBase& set) override
         {

--- a/src/realm/sync/instruction_replication.cpp
+++ b/src/realm/sync/instruction_replication.cpp
@@ -81,18 +81,12 @@ Instruction::Payload SyncReplication::as_payload(Mixed value)
         }
     }
     if (type == type_Dictionary) {
-        if (!SYNC_SUPPORTS_NESTED_COLLECTIONS)
-            throw IllegalOperation("Cannot sync nested dictionary");
         return Instruction::Payload(Instruction::Payload::Dictionary());
     }
     else if (type == type_List) {
-        if (!SYNC_SUPPORTS_NESTED_COLLECTIONS)
-            throw IllegalOperation("Cannot sync nested list");
         return Instruction::Payload(Instruction::Payload::List());
     }
     else if (type == type_Set) {
-        if (!SYNC_SUPPORTS_NESTED_COLLECTIONS)
-            throw IllegalOperation("Cannot sync nested set");
         return Instruction::Payload(Instruction::Payload::Set());
     }
     return Instruction::Payload{};
@@ -810,11 +804,11 @@ void SyncReplication::populate_path_instr(Instruction::PathInstruction& instr, c
     }
 }
 
-void SyncReplication::populate_path_instr(Instruction::PathInstruction& instr, const CollectionBase& list)
+void SyncReplication::populate_path_instr(Instruction::PathInstruction& instr, const CollectionBase& collection)
 {
-    ConstTableRef source_table = list.get_table();
-    ObjKey source_obj = list.get_owner_key();
-    populate_path_instr(instr, *source_table, source_obj, list.get_short_path());
+    ConstTableRef source_table = collection.get_table();
+    ObjKey source_obj = collection.get_owner_key();
+    populate_path_instr(instr, *source_table, source_obj, collection.get_short_path());
 }
 
 void SyncReplication::populate_path_instr(Instruction::PathInstruction& instr, const CollectionBase& list,

--- a/src/realm/sync/instruction_replication.hpp
+++ b/src/realm/sync/instruction_replication.hpp
@@ -198,8 +198,6 @@ private:
     bool m_was_short_circuited;
 };
 
-constexpr bool SYNC_SUPPORTS_NESTED_COLLECTIONS = false;
-
 } // namespace sync
 } // namespace realm
 

--- a/src/realm/sync/instructions.hpp
+++ b/src/realm/sync/instructions.hpp
@@ -176,7 +176,7 @@ struct Payload {
     struct List {};
     /// Create an empty dictionary in-place (does not clear an existing dictionary).
     struct Dictionary {};
-    /// Create an empty set in-place (does not clear an existing dictionary).
+    /// Create an empty set in-place (does not clear an existing set).
     struct Set {};
     /// Sentinel value for an erased dictionary element.
     struct Erased {};

--- a/src/realm/sync/transform.cpp
+++ b/src/realm/sync/transform.cpp
@@ -1038,39 +1038,6 @@ struct MergeUtils {
     // shorter path than the right, and the entire left path is the initial
     // sequence of the right.
 
-    bool is_prefix_of(const Instruction::AddTable& left, const Instruction::TableInstruction& right) const noexcept
-    {
-        return same_table(left, right);
-    }
-
-    bool is_prefix_of(const Instruction::EraseTable& left, const Instruction::TableInstruction& right) const noexcept
-    {
-        return same_table(left, right);
-    }
-
-    bool is_prefix_of(const Instruction::AddColumn&, const Instruction::TableInstruction&) const noexcept
-    {
-        // Right side is a schema instruction.
-        return false;
-    }
-
-    bool is_prefix_of(const Instruction::EraseColumn&, const Instruction::TableInstruction&) const noexcept
-    {
-        // Right side is a schema instruction.
-        return false;
-    }
-
-    bool is_prefix_of(const Instruction::AddColumn& left, const Instruction::ObjectInstruction& right) const noexcept
-    {
-        return same_column(left, right);
-    }
-
-    bool is_prefix_of(const Instruction::EraseColumn& left,
-                      const Instruction::ObjectInstruction& right) const noexcept
-    {
-        return same_column(left, right);
-    }
-
     bool is_prefix_of(const Instruction::ObjectInstruction&, const Instruction::TableInstruction&) const noexcept
     {
         // Right side is a schema instruction.
@@ -1083,25 +1050,31 @@ struct MergeUtils {
         return same_object(left, right);
     }
 
-    bool is_prefix_of(const Instruction::PathInstruction&, const Instruction::TableInstruction&) const noexcept
+    // Returns the next path element if the first path is a parent of the second path.
+    // Example:
+    //  * is_prefix_of(field1.123.field2, field1.123.field2.456) = 456
+    //  * is_prefix_of(field1.123.field2, field1.123.field3.456) = {}
+
+    std::optional<Instruction::Path::Element> is_prefix_of(const Instruction::PathInstruction&,
+                                                           const Instruction::TableInstruction&) const noexcept
     {
         // Path instructions can never be full prefixes of table-level instructions. Note that this also covers
         // ObjectInstructions.
-        return false;
+        return {};
     }
 
-    bool is_prefix_of(const Instruction::PathInstruction& left,
-                      const Instruction::PathInstruction& right) const noexcept
+    std::optional<Instruction::Path::Element> is_prefix_of(const Instruction::PathInstruction& left,
+                                                           const Instruction::PathInstruction& right) const noexcept
     {
         if (left.path.size() < right.path.size() && same_field(left, right)) {
             for (size_t i = 0; i < left.path.size(); ++i) {
                 if (!same_path_element(left.path[i], right.path[i])) {
-                    return false;
+                    return {};
                 }
             }
-            return true;
+            return right.path[left.path.size()];
         }
-        return false;
+        return {};
     }
 
     // True if the left side is an instruction that touches a container within
@@ -1382,7 +1355,7 @@ DEFINE_MERGE_NOOP(Instruction::SetErase, Instruction::AddTable);
 
 DEFINE_NESTED_MERGE(Instruction::EraseTable)
 {
-    if (is_prefix_of(outer, inner)) {
+    if (same_table(outer, inner)) {
         inner_side.discard();
     }
 }
@@ -1499,15 +1472,28 @@ DEFINE_NESTED_MERGE(Instruction::Update)
 {
     using Type = Instruction::Payload::Type;
 
-    if (outer.value.type == Type::ObjectValue || outer.value.type == Type::Dictionary) {
-        // Creating an embedded object or a dictionary is an idempotent
-        // operation, and should not eliminate updates to the subtree.
+    if (outer.value.type == Type::ObjectValue) {
+        // Creating an embedded object is an idempotent operation, and should
+        // not eliminate updates to the subtree.
         return;
     }
 
     // Setting a value higher up in the hierarchy overwrites any modification to
     // the inner value, regardless of when this happened.
-    if (is_prefix_of(outer, inner)) {
+    if (auto next_element = is_prefix_of(outer, inner)) {
+        // REALM_ASSERT(next_element);
+        //  If this is a collection in mixed, we will allow the inner instruction
+        //  to pass so long as it references the proper type (list or dictionary).
+        if (outer.value.type == Type::List) {
+            if (mpark::holds_alternative<uint32_t>(*next_element)) {
+                return;
+            }
+        }
+        else if (outer.value.type == Type::Dictionary) {
+            if (mpark::holds_alternative<InternString>(*next_element)) {
+                return;
+            }
+        }
         inner_side.discard();
     }
 }
@@ -1537,17 +1523,27 @@ DEFINE_MERGE(Instruction::Update, Instruction::Update)
         }
 
         if (left.value.type != right.value.type) {
-            // Embedded object / dictionary creation should always lose to an
-            // Update(value), because these structures are nested, and we need to
-            // discard any update inside the structure.
-            if (left.value.type == Type::Dictionary || left.value.type == Type::ObjectValue) {
+            // Embedded object creation should always lose to an Update(value),
+            // because these structures are nested, and we need to discard any
+            // update inside the structure.
+            if (left.value.type == Type::ObjectValue) {
                 left_side.discard();
                 return;
             }
-            else if (right.value.type == Type::Dictionary || right.value.type == Type::ObjectValue) {
+            else if (right.value.type == Type::ObjectValue) {
                 right_side.discard();
                 return;
             }
+        }
+
+        // Updates to List or Dictionary are idempotent. If both sides are setting to the same value,
+        // let them both pass through. It is important that the instruction application rules reflect this.
+        // If it is not two lists or dictionaries, then the normal last-writer-wins rules will take effect below.
+        if (left.value.type == Type::List && right.value.type == Type::List) {
+            return;
+        }
+        else if (left.value.type == Type::Dictionary && right.value.type == Type::Dictionary) {
+            return;
         }
 
         // CONFLICT: Two updates of the same element.
@@ -1697,7 +1693,13 @@ DEFINE_MERGE_NOOP(Instruction::SetErase, Instruction::Update);
 
 /// AddInteger rules
 
-DEFINE_NESTED_MERGE_NOOP(Instruction::AddInteger);
+DEFINE_NESTED_MERGE(Instruction::AddInteger)
+{
+    if (is_prefix_of(outer, inner)) {
+        inner_side.discard();
+    }
+}
+
 DEFINE_MERGE_NOOP(Instruction::AddInteger, Instruction::AddInteger);
 DEFINE_MERGE_NOOP(Instruction::AddColumn, Instruction::AddInteger);
 DEFINE_MERGE_NOOP(Instruction::EraseColumn, Instruction::AddInteger);

--- a/src/realm/sync/transform.cpp
+++ b/src/realm/sync/transform.cpp
@@ -1481,7 +1481,6 @@ DEFINE_NESTED_MERGE(Instruction::Update)
     // Setting a value higher up in the hierarchy overwrites any modification to
     // the inner value, regardless of when this happened.
     if (auto next_element = is_prefix_of(outer, inner)) {
-        // REALM_ASSERT(next_element);
         //  If this is a collection in mixed, we will allow the inner instruction
         //  to pass so long as it references the proper type (list or dictionary).
         if (outer.value.type == Type::List) {
@@ -1699,8 +1698,22 @@ DEFINE_MERGE(Instruction::ArrayErase, Instruction::Update)
     }
 }
 
+DEFINE_MERGE(Instruction::Clear, Instruction::Update)
+{
+    // The two instructions are at the same level of nesting.
+
+    using Type = Instruction::Payload::Type;
+
+    // TODO: We could make it so a Clear instruction does not win against setting a property or
+    // collection item to a different collection.
+    if (same_path(left, right)) {
+        if (right.value.type != Type::List && right.value.type != Type::Dictionary) {
+            left_side.discard();
+        }
+    }
+}
+
 // Handled by nested rule
-DEFINE_MERGE_NOOP(Instruction::Clear, Instruction::Update);
 DEFINE_MERGE_NOOP(Instruction::SetInsert, Instruction::Update);
 DEFINE_MERGE_NOOP(Instruction::SetErase, Instruction::Update);
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -201,6 +201,7 @@ if(REALM_ENABLE_SYNC)
         test_sync_subscriptions.cpp
         test_sync_pending_bootstraps.cpp
         test_sync_error_backoff.cpp
+        test_transform_collections_mixed.cpp
         test_transform.cpp
         test_util_buffer_stream.cpp
         test_util_circular_buffer.cpp

--- a/test/test_all.cpp
+++ b/test/test_all.cpp
@@ -128,6 +128,7 @@ const char* file_order[] = {
 
     "large_tests*.cpp",
     "test_crypto.cpp",
+    "test_transform_collections_mixed.cpp",
     "test_transform.cpp",
     "test_array.cpp",
     "test_lang_bind_helper_sync.cpp",

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -6107,7 +6107,7 @@ TEST(Sync_Dictionary)
     }
 }
 
-TEST_IF(Sync_CollectionInMixed, sync::SYNC_SUPPORTS_NESTED_COLLECTIONS)
+TEST(Sync_CollectionInMixed)
 {
     TEST_CLIENT_DB(db_1);
     TEST_CLIENT_DB(db_2);
@@ -6266,7 +6266,7 @@ TEST_IF(Sync_CollectionInMixed, sync::SYNC_SUPPORTS_NESTED_COLLECTIONS)
     }
 }
 
-TEST_IF(Sync_CollectionInCollection, SYNC_SUPPORTS_NESTED_COLLECTIONS)
+TEST(Sync_CollectionInCollection)
 {
     TEST_CLIENT_DB(db_1);
     TEST_CLIENT_DB(db_2);

--- a/test/test_transform.cpp
+++ b/test/test_transform.cpp
@@ -2616,4 +2616,162 @@ TEST(Transform_ArrayClearVersusClearRegression)
     server->integrate_next_changeset_from(*client_2);
 }
 
+TEST(Transform_CreateDictionaryVsArrayInsert)
+{
+    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
+    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
+    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
+    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
+
+    // Create baseline
+    client_1->transaction([&](Peer& c) {
+        auto& tr = *c.group;
+        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
+        auto col_any = table->add_column(type_Mixed, "any");
+        auto obj = table->create_object_with_primary_key(1);
+        obj.set_collection(col_any, CollectionType::Dictionary);
+        auto dict = obj.get_dictionary_ptr(col_any);
+        dict->insert_collection("A", CollectionType::Dictionary);
+        auto dict2 = dict->get_dictionary("A");
+        dict2->insert_collection("B", CollectionType::List);
+    });
+
+    synchronize(server.get(), {client_1.get(), client_2.get()});
+
+    client_1->history.set_time(1);
+    client_2->history.set_time(2);
+
+    client_1->transaction([](Peer& p) {
+        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
+        auto col_any = p.table("class_Table")->get_column_key("any");
+        auto dict = obj.get_dictionary_ptr({col_any, "A"});
+        dict->insert_collection("B", CollectionType::Dictionary);
+    });
+
+    client_2->transaction([](Peer& p) {
+        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
+        auto col_any = p.table("class_Table")->get_column_key("any");
+        auto list = obj.get_list_ptr<Mixed>({col_any, "A", "B"});
+        list->add(1);
+    });
+
+    synchronize(server.get(), {client_1.get(), client_2.get()});
+
+    ReadTransaction read_server(server->shared_group);
+    ReadTransaction read_client_1(client_1->shared_group);
+    ReadTransaction read_client_2(client_2->shared_group);
+    CHECK(compare_groups(read_server, read_client_1));
+    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
+    auto table = read_server.get_table("class_Table");
+    auto col_any = table->get_column_key("any");
+    CHECK(table->get_object_with_primary_key(1).get_dictionary_ptr({col_any, "A", "B"})->is_empty());
+}
+
+TEST(Transform_CreateListVsArrayInsert)
+{
+    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
+    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
+    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
+    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
+
+    // Create baseline
+    client_1->transaction([&](Peer& c) {
+        auto& tr = *c.group;
+        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
+        auto col_any = table->add_column(type_Mixed, "any");
+        auto obj = table->create_object_with_primary_key(1);
+        obj.set_collection(col_any, CollectionType::Dictionary);
+        auto dict = obj.get_dictionary_ptr(col_any);
+        dict->insert_collection("A", CollectionType::Dictionary);
+        auto dict2 = dict->get_dictionary("A");
+        dict2->insert_collection("B", CollectionType::Dictionary);
+    });
+
+    synchronize(server.get(), {client_1.get(), client_2.get()});
+
+    client_1->history.set_time(1);
+    client_2->history.set_time(2);
+
+    client_1->transaction([](Peer& p) {
+        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
+        auto col_any = p.table("class_Table")->get_column_key("any");
+        auto dict = obj.get_dictionary_ptr({col_any, "A"});
+        dict->insert_collection("B", CollectionType::List);
+    });
+
+    client_2->transaction([](Peer& p) {
+        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
+        auto col_any = p.table("class_Table")->get_column_key("any");
+        auto dict = obj.get_dictionary_ptr({col_any, "A"});
+        dict->insert_collection("B", CollectionType::List);
+        auto list = dict->get_list("B");
+        list->insert_collection(0, CollectionType::Dictionary);
+        auto dict2 = list->get_dictionary(0);
+        dict2->insert("C", "some value");
+    });
+
+    synchronize(server.get(), {client_1.get(), client_2.get()});
+
+    ReadTransaction read_server(server->shared_group);
+    ReadTransaction read_client_1(client_1->shared_group);
+    ReadTransaction read_client_2(client_2->shared_group);
+    CHECK(compare_groups(read_server, read_client_1));
+    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
+    auto table = read_server.get_table("class_Table");
+    auto col_any = table->get_column_key("any");
+    CHECK_EQUAL(table->get_object_with_primary_key(1).get_dictionary_ptr({col_any, "A", "B", 0})->get("C"),
+                Mixed("some value"));
+}
+
+TEST(Transform_CreateListVsUpdateDictionary)
+{
+    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
+    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
+    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
+    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
+
+    // Create baseline
+    client_1->transaction([&](Peer& c) {
+        auto& tr = *c.group;
+        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
+        auto col_any = table->add_column(type_Mixed, "any");
+        auto obj = table->create_object_with_primary_key(1);
+        obj.set_collection(col_any, CollectionType::Dictionary);
+        auto dict = obj.get_dictionary_ptr(col_any);
+        dict->insert_collection("A", CollectionType::Dictionary);
+        auto dict2 = dict->get_dictionary("A");
+        dict2->insert_collection("B", CollectionType::Dictionary);
+    });
+
+    synchronize(server.get(), {client_1.get(), client_2.get()});
+
+    client_1->history.set_time(1);
+    client_2->history.set_time(2);
+
+    client_1->transaction([](Peer& p) {
+        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
+        auto col_any = p.table("class_Table")->get_column_key("any");
+        auto dict = obj.get_dictionary_ptr({col_any, "A"});
+        dict->insert_collection("B", CollectionType::List);
+    });
+
+    client_2->transaction([](Peer& p) {
+        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
+        auto col_any = p.table("class_Table")->get_column_key("any");
+        auto dict = obj.get_dictionary_ptr({col_any, "A", "B"});
+        dict->insert("C", "some value");
+    });
+
+    synchronize(server.get(), {client_1.get(), client_2.get()});
+
+    ReadTransaction read_server(server->shared_group);
+    ReadTransaction read_client_1(client_1->shared_group);
+    ReadTransaction read_client_2(client_2->shared_group);
+    CHECK(compare_groups(read_server, read_client_1));
+    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
+    auto table = read_server.get_table("class_Table");
+    auto col_any = table->get_column_key("any");
+    CHECK(table->get_object_with_primary_key(1).get_list_ptr<Mixed>({col_any, "A", "B"})->is_empty());
+}
+
 } // unnamed namespace

--- a/test/test_transform_collections_mixed.cpp
+++ b/test/test_transform_collections_mixed.cpp
@@ -4,33 +4,95 @@
 using namespace realm;
 using namespace realm::test_util;
 
+struct TransformTestHarness {
+    enum ConflictOrdering { ClientOneBeforeTwo, ClientTwoBeforeOne, SameTime };
+
+    template <typename Func>
+    explicit TransformTestHarness(unit_test::TestContext& test_context, ConflictOrdering ordering,
+                                  Func&& baseline_func)
+        : TransformTestHarness(test_context)
+    {
+        client_1->transaction([&](Peer& c) {
+            auto& tr = *c.group;
+            TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
+            auto col_any = table->add_column(type_Mixed, "any");
+            auto obj = table->create_object_with_primary_key(1);
+            baseline_func(obj, col_any);
+        });
+
+        synchronize(server.get(), {client_1.get(), client_2.get()});
+
+        switch (ordering) {
+            case SameTime:
+                break;
+            case ClientOneBeforeTwo:
+                client_1->history.set_time(1);
+                client_2->history.set_time(2);
+                break;
+            case ClientTwoBeforeOne:
+                client_2->history.set_time(1);
+                client_1->history.set_time(2);
+                break;
+        }
+    }
+
+    explicit TransformTestHarness(unit_test::TestContext& test_context)
+        : test_context(test_context)
+        , changeset_dump_dir_gen(get_changeset_dump_dir_generator(test_context))
+        , server(Peer::create_server(test_context, changeset_dump_dir_gen.get()))
+        , client_1(Peer::create_client(test_context, 2, changeset_dump_dir_gen.get()))
+        , client_2(Peer::create_client(test_context, 3, changeset_dump_dir_gen.get()))
+    {
+    }
+
+    template <typename Func>
+    void transaction(const std::unique_ptr<Peer>& p, Func&& func)
+    {
+        p->transaction([&](Peer& p) {
+            auto col_any = p.table("class_Table")->get_column_key("any");
+            auto obj = p.table("class_Table")->get_object_with_primary_key(1);
+            func(obj, col_any);
+        });
+    }
+
+    template <typename Func>
+    void check_merge_result(Func&& func)
+    {
+        synchronize(server.get(), {client_1.get(), client_2.get()});
+
+        auto read_server = server->shared_group->start_read();
+        auto read_client_1 = client_1->shared_group->start_read();
+        auto read_client_2 = client_2->shared_group->start_read();
+
+        CHECK(compare_groups(*read_server, *read_client_1));
+        CHECK(compare_groups(*read_server, *read_client_2, *test_context.logger));
+        auto table = read_server->get_table("class_Table");
+        auto col_any = table->get_column_key("any");
+        func(table->get_object_with_primary_key(Mixed{1}), col_any);
+    }
+
+    unit_test::TestContext& test_context;
+    std::unique_ptr<TestDirNameGenerator> changeset_dump_dir_gen;
+    std::unique_ptr<Peer> server;
+    std::unique_ptr<Peer> client_1;
+    std::unique_ptr<Peer> client_2;
+};
+
 // Test merging instructions at different level of nesting.
 
 TEST(Transform_CreateArrayVsArrayInsert)
 {
-    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
-    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
-    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
-    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
-
-    // Create baseline
-    client_1->transaction([](Peer& c) {
-        auto& tr = *c.group;
-        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
-        auto col_any = table->add_column(type_Mixed, "any");
-        auto obj = table->create_object_with_primary_key(1);
+    TransformTestHarness h(test_context, TransformTestHarness::SameTime, [](Obj obj, ColKey col_any) {
         obj.set_collection(col_any, CollectionType::Dictionary);
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    client_1->transaction([](Peer& p) {
+    h.client_1->transaction([](Peer& p) {
         auto obj = p.table("class_Table")->get_object_with_primary_key(1);
         auto col_any = p.table("class_Table")->get_column_key("any");
         obj.set_collection(col_any, CollectionType::List);
     });
 
-    client_2->transaction([](Peer& p) {
+    h.client_2->transaction([](Peer& p) {
         auto obj = p.table("class_Table")->get_object_with_primary_key(1);
         auto col_any = p.table("class_Table")->get_column_key("any");
         obj.set_collection(col_any, CollectionType::List);
@@ -38,33 +100,16 @@ TEST(Transform_CreateArrayVsArrayInsert)
         list.add(42);
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    ReadTransaction read_server(server->shared_group);
-    ReadTransaction read_client_1(client_1->shared_group);
-    ReadTransaction read_client_2(client_2->shared_group);
-    CHECK(compare_groups(read_server, read_client_1));
-    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
-    auto table = read_server.get_table("class_Table");
-    auto col_any = table->get_column_key("any");
-    auto list = table->get_object_with_primary_key(1).get_list_ptr<Mixed>(col_any);
-    CHECK_EQUAL(list->size(), 1);
-    CHECK_EQUAL(list->get(0), 42);
+    h.check_merge_result([&](Obj obj, ColKey col_any) {
+        auto list = obj.get_list_ptr<Mixed>(col_any);
+        CHECK_EQUAL(list->size(), 1);
+        CHECK_EQUAL(list->get(0), 42);
+    });
 }
 
 TEST(Transform_Nested_CreateArrayVsArrayInsert)
 {
-    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
-    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
-    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
-    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
-
-    // Create baseline
-    client_1->transaction([](Peer& c) {
-        auto& tr = *c.group;
-        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
-        auto col_any = table->add_column(type_Mixed, "any");
-        auto obj = table->create_object_with_primary_key(1);
+    TransformTestHarness h(test_context, TransformTestHarness::SameTime, [](Obj obj, ColKey col_any) {
         obj.set_collection(col_any, CollectionType::Dictionary);
         auto dict = obj.get_dictionary_ptr(col_any);
         dict->insert_collection("A", CollectionType::List);
@@ -74,97 +119,51 @@ TEST(Transform_Nested_CreateArrayVsArrayInsert)
         list2->insert(0, 42);
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    auto set_nested_list = [](Peer& p) {
-        auto col_any = p.table("class_Table")->get_column_key("any");
-        auto list = p.table("class_Table")->get_object_with_primary_key(1).get_list_ptr<Mixed>({col_any, "A", 0});
+    h.transaction(h.client_2, [&](Obj obj, ColKey col_any) {
+        auto list = obj.get_list_ptr<Mixed>({col_any, "A", 0});
         list->set_collection(0, CollectionType::List);
-    };
-
-    client_2->transaction([&](Peer& p) {
-        set_nested_list(p);
     });
 
-    synchronize(server.get(), {client_2.get()});
+    synchronize(h.server.get(), {h.client_2.get()});
 
-    client_1->transaction([&](Peer& p) {
-        set_nested_list(p);
+    h.transaction(h.client_1, [&](Obj obj, ColKey col_any) {
+        auto list = obj.get_list_ptr<Mixed>({col_any, "A", 0});
+        list->set_collection(0, CollectionType::List);
     });
 
-    client_2->transaction([](Peer& p) {
-        auto col_any = p.table("class_Table")->get_column_key("any");
-        auto list = p.table("class_Table")->get_object_with_primary_key(1).get_list_ptr<Mixed>({col_any, "A", 0, 0});
+    h.transaction(h.client_2, [&](Obj obj, ColKey col_any) {
+        auto list = obj.get_list_ptr<Mixed>({col_any, "A", 0, 0});
         list->add(42);
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    ReadTransaction read_server(server->shared_group);
-    ReadTransaction read_client_1(client_1->shared_group);
-    ReadTransaction read_client_2(client_2->shared_group);
-    CHECK(compare_groups(read_server, read_client_1));
-    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
-    auto table = read_server.get_table("class_Table");
-    auto col_any = table->get_column_key("any");
-    CHECK_EQUAL(table->get_object_with_primary_key(1).get_list_ptr<Mixed>({col_any, "A", 0, 0})->get(0), 42);
+    h.check_merge_result([&](Obj obj, ColKey col_any) {
+        CHECK_EQUAL(obj.get_list_ptr<Mixed>({col_any, "A", 0, 0})->get(0), 42);
+    });
 }
 
 TEST(Transform_CreateArrayVsDictionaryInsert)
 {
-    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
-    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
-    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
-    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
-
-    // Create baseline
-    client_1->transaction([](Peer& c) {
-        auto& tr = *c.group;
-        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
-        auto col_any = table->add_column(type_Mixed, "any");
-        auto obj = table->create_object_with_primary_key(1);
+    TransformTestHarness h(test_context, TransformTestHarness::SameTime, [](Obj obj, ColKey col_any) {
         obj.set_collection(col_any, CollectionType::Dictionary);
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    client_1->transaction([](Peer& p) {
-        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
-        auto col_any = p.table("class_Table")->get_column_key("any");
+    h.transaction(h.client_1, [&](Obj obj, ColKey col_any) {
         obj.set_collection(col_any, CollectionType::List);
     });
 
-    client_2->transaction([](Peer& p) {
-        auto col_any = p.table("class_Table")->get_column_key("any");
-        auto dict = p.table("class_Table")->get_object_with_primary_key(1).get_dictionary_ptr(col_any);
+    h.transaction(h.client_2, [&](Obj obj, ColKey col_any) {
+        auto dict = obj.get_dictionary_ptr(col_any);
         dict->insert("key", 42);
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    ReadTransaction read_server(server->shared_group);
-    ReadTransaction read_client_1(client_1->shared_group);
-    ReadTransaction read_client_2(client_2->shared_group);
-    CHECK(compare_groups(read_server, read_client_1));
-    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
-    auto table = read_server.get_table("class_Table");
-    auto col_any = table->get_column_key("any");
-    CHECK(table->get_object_with_primary_key(1).get_list_ptr<Mixed>(col_any)->is_empty());
+    h.check_merge_result([&](Obj obj, ColKey col_any) {
+        CHECK(obj.get_list_ptr<Mixed>(col_any)->is_empty());
+    });
 }
 
 TEST(Transform_Nested_CreateArrayVsDictionaryInsert)
 {
-    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
-    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
-    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
-    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
-
-    // Create baseline
-    client_1->transaction([](Peer& c) {
-        auto& tr = *c.group;
-        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
-        auto col_any = table->add_column(type_Mixed, "any");
-        auto obj = table->create_object_with_primary_key(1);
+    TransformTestHarness h(test_context, TransformTestHarness::SameTime, [](Obj obj, ColKey col_any) {
         obj.set_collection(col_any, CollectionType::Dictionary);
         auto dict = obj.get_dictionary_ptr(col_any);
         dict->insert_collection("A", CollectionType::List);
@@ -174,98 +173,50 @@ TEST(Transform_Nested_CreateArrayVsDictionaryInsert)
         dict2->insert_collection("B", CollectionType::Dictionary);
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    client_1->transaction([](Peer& p) {
-        auto col_any = p.table("class_Table")->get_column_key("any");
-        auto dict = p.table("class_Table")->get_object_with_primary_key(1).get_dictionary_ptr({col_any, "A", 0});
+    h.transaction(h.client_1, [&](Obj obj, ColKey col_any) {
+        auto dict = obj.get_dictionary_ptr({col_any, "A", 0});
         dict->insert_collection("B", CollectionType::List);
     });
 
-    client_2->transaction([](Peer& p) {
-        auto col_any = p.table("class_Table")->get_column_key("any");
-        auto dict = p.table("class_Table")->get_object_with_primary_key(1).get_dictionary_ptr({col_any, "A", 0, "B"});
+    h.transaction(h.client_2, [&](Obj obj, ColKey col_any) {
+        auto dict = obj.get_dictionary_ptr({col_any, "A", 0, "B"});
         dict->insert("key", 42);
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    ReadTransaction read_server(server->shared_group);
-    ReadTransaction read_client_1(client_1->shared_group);
-    ReadTransaction read_client_2(client_2->shared_group);
-    CHECK(compare_groups(read_server, read_client_1));
-    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
-    auto table = read_server.get_table("class_Table");
-    auto col_any = table->get_column_key("any");
-    CHECK(table->get_object_with_primary_key(1).get_list_ptr<Mixed>({col_any, "A", 0, "B"})->is_empty());
+    h.check_merge_result([&](Obj obj, ColKey col_any) {
+        CHECK(obj.get_list_ptr<Mixed>({col_any, "A", 0, "B"})->is_empty());
+    });
 }
 
 TEST(Transform_CreateDictionaryVsDictionaryInsert)
 {
-    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
-    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
-    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
-    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
-
-    // Create baseline
-    client_1->transaction([](Peer& c) {
-        auto& tr = *c.group;
-        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
-        auto col_any = table->add_column(type_Mixed, "any");
-        auto obj = table->create_object_with_primary_key(1);
+    TransformTestHarness h(test_context, TransformTestHarness::SameTime, [](Obj obj, ColKey col_any) {
         obj.set_collection(col_any, CollectionType::List);
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    auto set_nested_dictionary = [](Peer& p) {
-        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
-        auto col_any = p.table("class_Table")->get_column_key("any");
+    auto set_nested_dictionary = [](Obj obj, ColKey col_any) {
         obj.set_collection(col_any, CollectionType::Dictionary);
     };
 
-    client_2->transaction([&](Peer& p) {
-        set_nested_dictionary(p);
-    });
+    h.transaction(h.client_2, set_nested_dictionary);
 
-    synchronize(server.get(), {client_2.get()});
+    synchronize(h.server.get(), {h.client_2.get()});
 
-    client_1->transaction([&](Peer& p) {
-        set_nested_dictionary(p);
-    });
+    h.transaction(h.client_1, set_nested_dictionary);
 
-    client_2->transaction([](Peer& p) {
-        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
-        auto col_any = p.table("class_Table")->get_column_key("any");
+    h.transaction(h.client_2, [](Obj obj, ColKey col_any) {
         auto dict = obj.get_dictionary(col_any);
         dict.insert("key", 42);
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    ReadTransaction read_server(server->shared_group);
-    ReadTransaction read_client_1(client_1->shared_group);
-    ReadTransaction read_client_2(client_2->shared_group);
-    CHECK(compare_groups(read_server, read_client_1));
-    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
-    auto table = read_server.get_table("class_Table");
-    auto col_any = table->get_column_key("any");
-    CHECK_EQUAL(table->get_object_with_primary_key(1).get_dictionary(col_any).get("key"), 42);
+    h.check_merge_result([&](Obj obj, ColKey col_any) {
+        CHECK_EQUAL(obj.get_dictionary(col_any).get("key"), 42);
+    });
 }
 
 TEST(Transform_Nested_CreateDictionaryVsDictionaryInsert)
 {
-    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
-    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
-    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
-    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
-
-    // Create baseline
-    client_1->transaction([](Peer& c) {
-        auto& tr = *c.group;
-        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
-        auto col_any = table->add_column(type_Mixed, "any");
-        auto obj = table->create_object_with_primary_key(1);
+    TransformTestHarness h(test_context, TransformTestHarness::SameTime, [](Obj obj, ColKey col_any) {
         obj.set_collection(col_any, CollectionType::Dictionary);
         auto dict = obj.get_dictionary_ptr(col_any);
         dict->insert_collection("A", CollectionType::List);
@@ -275,98 +226,50 @@ TEST(Transform_Nested_CreateDictionaryVsDictionaryInsert)
         dict2->insert_collection("B", CollectionType::List);
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    auto set_nested_dictionary = [](Peer& p) {
-        auto col_any = p.table("class_Table")->get_column_key("any");
-        auto dict = p.table("class_Table")->get_object_with_primary_key(1).get_dictionary_ptr({col_any, "A", 0});
+    auto set_nested_dictionary = [](Obj obj, ColKey col_any) {
+        auto dict = obj.get_dictionary_ptr({col_any, "A", 0});
         dict->insert_collection("B", CollectionType::Dictionary);
     };
 
-    client_2->transaction([&](Peer& p) {
-        set_nested_dictionary(p);
-    });
+    h.transaction(h.client_2, set_nested_dictionary);
 
-    synchronize(server.get(), {client_2.get()});
+    synchronize(h.server.get(), {h.client_2.get()});
 
-    client_1->transaction([&](Peer& p) {
-        set_nested_dictionary(p);
-    });
+    h.transaction(h.client_1, set_nested_dictionary);
 
-    client_2->transaction([](Peer& p) {
-        auto col_any = p.table("class_Table")->get_column_key("any");
-        auto dict = p.table("class_Table")->get_object_with_primary_key(1).get_dictionary_ptr({col_any, "A", 0, "B"});
+    h.transaction(h.client_2, [](Obj obj, ColKey col_any) {
+        auto dict = obj.get_dictionary_ptr({col_any, "A", 0, "B"});
         dict->insert("key", 42);
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    ReadTransaction read_server(server->shared_group);
-    ReadTransaction read_client_1(client_1->shared_group);
-    ReadTransaction read_client_2(client_2->shared_group);
-    CHECK(compare_groups(read_server, read_client_1));
-    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
-    auto table = read_server.get_table("class_Table");
-    auto col_any = table->get_column_key("any");
-    CHECK_EQUAL(table->get_object_with_primary_key(1).get_dictionary_ptr({col_any, "A", 0, "B"})->get("key"), 42);
+    h.check_merge_result([&](Obj obj, ColKey col_any) {
+        CHECK_EQUAL(obj.get_dictionary_ptr({col_any, "A", 0, "B"})->get("key"), 42);
+    });
 }
 
 TEST(Transform_CreateDictionaryVsArrayInsert)
 {
-    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
-    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
-    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
-    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
-
-    // Create baseline
-    client_1->transaction([](Peer& c) {
-        auto& tr = *c.group;
-        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
-        auto col_any = table->add_column(type_Mixed, "any");
-        auto obj = table->create_object_with_primary_key(1);
+    TransformTestHarness h(test_context, TransformTestHarness::SameTime, [](Obj obj, ColKey col_any) {
         obj.set_collection(col_any, CollectionType::List);
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    client_1->transaction([](Peer& p) {
-        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
-        auto col_any = p.table("class_Table")->get_column_key("any");
+    h.transaction(h.client_1, [](Obj obj, ColKey col_any) {
         obj.set_collection(col_any, CollectionType::Dictionary);
     });
 
-    client_2->transaction([](Peer& p) {
-        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
-        auto col_any = p.table("class_Table")->get_column_key("any");
+    h.transaction(h.client_2, [](Obj obj, ColKey col_any) {
         auto list = obj.get_list<Mixed>(col_any);
         list.add(42);
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    ReadTransaction read_server(server->shared_group);
-    ReadTransaction read_client_1(client_1->shared_group);
-    ReadTransaction read_client_2(client_2->shared_group);
-    CHECK(compare_groups(read_server, read_client_1));
-    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
-    auto table = read_server.get_table("class_Table");
-    auto col_any = table->get_column_key("any");
-    CHECK(table->get_object_with_primary_key(1).get_dictionary(col_any).is_empty());
+    h.check_merge_result([&](Obj obj, ColKey col_any) {
+        CHECK(obj.get_dictionary(col_any).is_empty());
+    });
 }
 
 TEST(Transform_Nested_CreateDictionaryVsArrayInsert)
 {
-    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
-    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
-    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
-    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
-
-    // Create baseline
-    client_1->transaction([](Peer& c) {
-        auto& tr = *c.group;
-        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
-        auto col_any = table->add_column(type_Mixed, "any");
-        auto obj = table->create_object_with_primary_key(1);
+    TransformTestHarness h(test_context, TransformTestHarness::SameTime, [](Obj obj, ColKey col_any) {
         obj.set_collection(col_any, CollectionType::Dictionary);
         auto dict = obj.get_dictionary_ptr(col_any);
         dict->insert_collection("A", CollectionType::List);
@@ -376,106 +279,51 @@ TEST(Transform_Nested_CreateDictionaryVsArrayInsert)
         dict2->insert_collection("B", CollectionType::List);
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    client_1->transaction([](Peer& p) {
-        auto col_any = p.table("class_Table")->get_column_key("any");
-        auto dict = p.table("class_Table")->get_object_with_primary_key(1).get_dictionary_ptr({col_any, "A", 0});
+    h.transaction(h.client_1, [](Obj obj, ColKey col_any) {
+        auto dict = obj.get_dictionary_ptr({col_any, "A", 0});
         dict->insert_collection("B", CollectionType::Dictionary);
     });
 
-    client_2->transaction([](Peer& p) {
-        auto col_any = p.table("class_Table")->get_column_key("any");
-        auto list =
-            p.table("class_Table")->get_object_with_primary_key(1).get_list_ptr<Mixed>({col_any, "A", 0, "B"});
+    h.transaction(h.client_2, [](Obj obj, ColKey col_any) {
+        auto list = obj.get_list_ptr<Mixed>({col_any, "A", 0, "B"});
         list->add(42);
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    ReadTransaction read_server(server->shared_group);
-    ReadTransaction read_client_1(client_1->shared_group);
-    ReadTransaction read_client_2(client_2->shared_group);
-    CHECK(compare_groups(read_server, read_client_1));
-    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
-    auto table = read_server.get_table("class_Table");
-    auto col_any = table->get_column_key("any");
-    CHECK(table->get_object_with_primary_key(1).get_dictionary_ptr({col_any, "A", 0, "B"})->is_empty());
+    h.check_merge_result([&](Obj obj, ColKey col_any) {
+        CHECK(obj.get_dictionary_ptr({col_any, "A", 0, "B"})->is_empty());
+    });
 }
 
 TEST(Transform_ArrayInsertVsUpdateString)
 {
-    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
-    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
-    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
-    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
-
-    // Create baseline
-    client_1->transaction([](Peer& c) {
-        auto& tr = *c.group;
-        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
-        auto col_any = table->add_column(type_Mixed, "any");
-        auto obj = table->create_object_with_primary_key(1);
+    TransformTestHarness h(test_context, TransformTestHarness::ClientOneBeforeTwo, [](Obj obj, ColKey col_any) {
         obj.set_collection(col_any, CollectionType::List);
         auto list = obj.get_list<Mixed>(col_any);
         list.add(1);
         list.add(2);
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    client_1->history.set_time(1);
-    client_2->history.set_time(2);
-
-    client_1->transaction([](Peer& p) {
-        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
-        auto col_any = p.table("class_Table")->get_column_key("any");
+    h.transaction(h.client_1, [](Obj obj, ColKey col_any) {
         auto list = obj.get_list<Mixed>(col_any);
         list.add(3);
     });
 
-    client_2->transaction([](Peer& p) {
-        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
-        auto col_any = p.table("class_Table")->get_column_key("any");
+    h.transaction(h.client_2, [](Obj obj, ColKey col_any) {
         obj.set(col_any, Mixed{"value"});
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    ReadTransaction read_server(server->shared_group);
-    ReadTransaction read_client_1(client_1->shared_group);
-    ReadTransaction read_client_2(client_2->shared_group);
-    CHECK(compare_groups(read_server, read_client_1));
-    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
-    auto table = read_server.get_table("class_Table");
-    auto col_any = table->get_column_key("any");
-    CHECK_EQUAL(table->get_object_with_primary_key(1).get_any(col_any), "value");
+    h.check_merge_result([&](Obj obj, ColKey col_any) {
+        CHECK_EQUAL(obj.get_any(col_any), "value");
+    });
 }
 
 TEST(Transform_ClearArrayVsDictionaryInsert)
 {
-    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
-    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
-    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
-    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
-
-    // Create baseline
-    client_1->transaction([](Peer& c) {
-        auto& tr = *c.group;
-        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
-        auto col_any = table->add_column(type_Mixed, "any");
-        auto obj = table->create_object_with_primary_key(1);
+    TransformTestHarness h(test_context, TransformTestHarness::ClientOneBeforeTwo, [](Obj obj, ColKey col_any) {
         obj.set_collection(col_any, CollectionType::Dictionary);
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    client_1->history.set_time(1);
-    client_2->history.set_time(2);
-
-    client_1->transaction([](Peer& p) {
-        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
-        auto col_any = p.table("class_Table")->get_column_key("any");
+    h.transaction(h.client_1, [](Obj obj, ColKey col_any) {
         obj.set_collection(col_any, CollectionType::List);
         auto list = obj.get_list<Mixed>(col_any);
         list.add(1);
@@ -484,126 +332,57 @@ TEST(Transform_ClearArrayVsDictionaryInsert)
         list.add(3);
     });
 
-    client_2->transaction([](Peer& p) {
-        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
-        auto col_any = p.table("class_Table")->get_column_key("any");
+    h.transaction(h.client_2, [](Obj obj, ColKey col_any) {
         auto dict = obj.get_dictionary(col_any);
         dict.insert("key1", 42);
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    ReadTransaction read_server(server->shared_group);
-    ReadTransaction read_client_1(client_1->shared_group);
-    ReadTransaction read_client_2(client_2->shared_group);
-    CHECK(compare_groups(read_server, read_client_1));
-    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
-    auto table = read_server.get_table("class_Table");
-    auto col_any = table->get_column_key("any");
-    auto list = table->get_object_with_primary_key(1).get_list_ptr<Mixed>(col_any);
-    CHECK_EQUAL(list->size(), 1);
-    CHECK_EQUAL(list->get(0), 3);
+    h.check_merge_result([&](Obj obj, ColKey col_any) {
+        auto list = obj.get_list_ptr<Mixed>(col_any);
+        CHECK_EQUAL(list->size(), 1);
+        CHECK_EQUAL(list->get(0), 3);
+    });
 }
 
 // Test merging instructions at same level of nesting (both on Mixed properties and nested collections).
 
 TEST(Transform_CreateArrayBeforeUpdateInt)
 {
-    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
-    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
-    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
-    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
+    TransformTestHarness h(test_context, TransformTestHarness::ClientOneBeforeTwo, [](Obj, ColKey) {});
 
-    // Create baseline
-    client_1->transaction([](Peer& c) {
-        auto& tr = *c.group;
-        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
-        table->add_column(type_Mixed, "any");
-        table->create_object_with_primary_key(1);
-    });
-
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    client_1->history.set_time(1);
-    client_2->history.set_time(2);
-
-    client_1->transaction([](Peer& p) {
-        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
-        auto col_any = p.table("class_Table")->get_column_key("any");
+    h.transaction(h.client_1, [](Obj obj, ColKey col_any) {
         obj.set_collection(col_any, CollectionType::List);
     });
 
-    client_2->transaction([](Peer& p) {
-        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
-        obj.set_any("any", 42);
+    h.transaction(h.client_2, [](Obj obj, ColKey col_any) {
+        obj.set_any(col_any, 42);
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    ReadTransaction read_server(server->shared_group);
-    ReadTransaction read_client_1(client_1->shared_group);
-    ReadTransaction read_client_2(client_2->shared_group);
-    CHECK(compare_groups(read_server, read_client_1));
-    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
-    auto table = read_server.get_table("class_Table");
-    CHECK_EQUAL(table->get_object_with_primary_key(1).get_any("any"), 42);
+    h.check_merge_result([&](Obj obj, ColKey col_any) {
+        CHECK_EQUAL(obj.get_any(col_any), 42);
+    });
 }
 
 TEST(Transform_CreateArrayAfterUpdateInt)
 {
-    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
-    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
-    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
-    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
+    TransformTestHarness h(test_context, TransformTestHarness::ClientTwoBeforeOne, [](Obj, ColKey) {});
 
-    // Create baseline
-    client_1->transaction([](Peer& c) {
-        auto& tr = *c.group;
-        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
-        table->add_column(type_Mixed, "any");
-        table->create_object_with_primary_key(1);
-    });
-
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    client_2->history.set_time(1);
-    client_1->history.set_time(2);
-
-    client_1->transaction([](Peer& p) {
-        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
-        auto col_any = p.table("class_Table")->get_column_key("any");
+    h.transaction(h.client_1, [](Obj obj, ColKey col_any) {
         obj.set_collection(col_any, CollectionType::List);
     });
 
-    client_2->transaction([](Peer& p) {
-        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
-        obj.set_any("any", 42);
+    h.transaction(h.client_2, [](Obj obj, ColKey col_any) {
+        obj.set_any(col_any, 42);
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    ReadTransaction read_server(server->shared_group);
-    ReadTransaction read_client_1(client_1->shared_group);
-    ReadTransaction read_client_2(client_2->shared_group);
-    CHECK(compare_groups(read_server, read_client_1));
-    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
-    auto table = read_server.get_table("class_Table");
-    CHECK(table->get_object_with_primary_key(1).get_list<Mixed>("any").is_empty());
+    h.check_merge_result([&](Obj obj, ColKey col_any) {
+        CHECK(obj.get_list<Mixed>(col_any).is_empty());
+    });
 }
 
 TEST(Transform_Nested_CreateArrayBeforeUpdateInt)
 {
-    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
-    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
-    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
-    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
-
-    // Create baseline
-    client_1->transaction([](Peer& c) {
-        auto& tr = *c.group;
-        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
-        auto col_any = table->add_column(type_Mixed, "any");
-        auto obj = table->create_object_with_primary_key(1);
+    TransformTestHarness h(test_context, TransformTestHarness::ClientOneBeforeTwo, [](Obj obj, ColKey col_any) {
         obj.set_collection(col_any, CollectionType::Dictionary);
         auto dict = obj.get_dictionary_ptr(col_any);
         dict->insert_collection("A", CollectionType::List);
@@ -613,132 +392,58 @@ TEST(Transform_Nested_CreateArrayBeforeUpdateInt)
         dict2->insert("B", "some value");
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    client_1->history.set_time(1);
-    client_2->history.set_time(2);
-
-    client_1->transaction([](Peer& p) {
-        auto col_any = p.table("class_Table")->get_column_key("any");
-        auto dict = p.table("class_Table")->get_object_with_primary_key(1).get_dictionary_ptr({col_any, "A", 0});
+    h.transaction(h.client_1, [](Obj obj, ColKey col_any) {
+        auto dict = obj.get_dictionary_ptr({col_any, "A", 0});
         dict->insert_collection("B", CollectionType::List);
     });
 
-    client_2->transaction([](Peer& p) {
-        auto col_any = p.table("class_Table")->get_column_key("any");
-        auto dict = p.table("class_Table")->get_object_with_primary_key(1).get_dictionary_ptr({col_any, "A", 0});
+    h.transaction(h.client_2, [](Obj obj, ColKey col_any) {
+        auto dict = obj.get_dictionary_ptr({col_any, "A", 0});
         dict->insert("B", 42);
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    ReadTransaction read_server(server->shared_group);
-    ReadTransaction read_client_1(client_1->shared_group);
-    ReadTransaction read_client_2(client_2->shared_group);
-    CHECK(compare_groups(read_server, read_client_1));
-    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
-    auto table = read_server.get_table("class_Table");
-    auto col_any = table->get_column_key("any");
-    CHECK_EQUAL(table->get_object_with_primary_key(1).get_dictionary_ptr({col_any, "A", 0})->get("B"), 42);
+    h.check_merge_result([&](Obj obj, ColKey col_any) {
+        CHECK_EQUAL(obj.get_dictionary_ptr({col_any, "A", 0})->get("B"), 42);
+    });
 }
 
 TEST(Transform_CreateDictionaryBeforeUpdateInt)
 {
-    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
-    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
-    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
-    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
+    TransformTestHarness h(test_context, TransformTestHarness::ClientOneBeforeTwo, [](Obj, ColKey) {});
 
-    // Create baseline
-    client_1->transaction([](Peer& c) {
-        auto& tr = *c.group;
-        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
-        table->add_column(type_Mixed, "any");
-        table->create_object_with_primary_key(1);
-    });
-
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    client_1->history.set_time(1);
-    client_2->history.set_time(2);
-
-    client_1->transaction([](Peer& p) {
-        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
-        auto col_any = p.table("class_Table")->get_column_key("any");
+    h.transaction(h.client_1, [](Obj obj, ColKey col_any) {
         obj.set_collection(col_any, CollectionType::Dictionary);
     });
 
-    client_2->transaction([](Peer& p) {
-        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
-        obj.set_any("any", 42);
+    h.transaction(h.client_2, [](Obj obj, ColKey col_any) {
+        obj.set_any(col_any, 42);
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    ReadTransaction read_server(server->shared_group);
-    ReadTransaction read_client_1(client_1->shared_group);
-    ReadTransaction read_client_2(client_2->shared_group);
-    CHECK(compare_groups(read_server, read_client_1));
-    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
-    auto table = read_server.get_table("class_Table");
-    CHECK_EQUAL(table->get_object_with_primary_key(1).get_any("any"), 42);
+    h.check_merge_result([&](Obj obj, ColKey col_any) {
+        CHECK_EQUAL(obj.get_any(col_any), 42);
+    });
 }
 
 TEST(Transform_CreateDictionaryAfterUpdateInt)
 {
-    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
-    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
-    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
-    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
+    TransformTestHarness h(test_context, TransformTestHarness::ClientTwoBeforeOne, [](Obj, ColKey) {});
 
-    // Create baseline
-    client_1->transaction([](Peer& c) {
-        auto& tr = *c.group;
-        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
-        table->add_column(type_Mixed, "any");
-        table->create_object_with_primary_key(1);
-    });
-
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    client_2->history.set_time(1);
-    client_1->history.set_time(2);
-
-    client_1->transaction([](Peer& p) {
-        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
-        auto col_any = p.table("class_Table")->get_column_key("any");
+    h.transaction(h.client_1, [](Obj obj, ColKey col_any) {
         obj.set_collection(col_any, CollectionType::Dictionary);
     });
 
-    client_2->transaction([](Peer& p) {
-        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
-        obj.set_any("any", 42);
+    h.transaction(h.client_2, [](Obj obj, ColKey col_any) {
+        obj.set_any(col_any, 42);
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    ReadTransaction read_server(server->shared_group);
-    ReadTransaction read_client_1(client_1->shared_group);
-    ReadTransaction read_client_2(client_2->shared_group);
-    CHECK(compare_groups(read_server, read_client_1));
-    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
-    auto table = read_server.get_table("class_Table");
-    CHECK(table->get_object_with_primary_key(1).get_dictionary("any").is_empty());
+    h.check_merge_result([&](Obj obj, ColKey col_any) {
+        CHECK(obj.get_dictionary(col_any).is_empty());
+    });
 }
 
 TEST(Transform_Nested_CreateDictionaryAfterUpdateInt)
 {
-    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
-    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
-    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
-    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
-
-    // Create baseline
-    client_1->transaction([](Peer& c) {
-        auto& tr = *c.group;
-        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
-        auto col_any = table->add_column(type_Mixed, "any");
-        auto obj = table->create_object_with_primary_key(1);
+    TransformTestHarness h(test_context, TransformTestHarness::ClientTwoBeforeOne, [](Obj obj, ColKey col_any) {
         obj.set_collection(col_any, CollectionType::Dictionary);
         auto dict = obj.get_dictionary_ptr(col_any);
         dict->insert_collection("A", CollectionType::List);
@@ -748,103 +453,52 @@ TEST(Transform_Nested_CreateDictionaryAfterUpdateInt)
         dict2->insert("B", "some value");
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    client_2->history.set_time(1);
-    client_1->history.set_time(2);
-
-    client_1->transaction([](Peer& p) {
-        auto col_any = p.table("class_Table")->get_column_key("any");
-        auto dict = p.table("class_Table")->get_object_with_primary_key(1).get_dictionary_ptr({col_any, "A", 0});
+    h.transaction(h.client_1, [](Obj obj, ColKey col_any) {
+        auto dict = obj.get_dictionary_ptr({col_any, "A", 0});
         dict->insert_collection("B", CollectionType::Dictionary);
     });
 
-    client_2->transaction([](Peer& p) {
-        auto col_any = p.table("class_Table")->get_column_key("any");
-        auto dict = p.table("class_Table")->get_object_with_primary_key(1).get_dictionary_ptr({col_any, "A", 0});
+    h.transaction(h.client_2, [](Obj obj, ColKey col_any) {
+        auto dict = obj.get_dictionary_ptr({col_any, "A", 0});
         dict->insert("B", 42);
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    ReadTransaction read_server(server->shared_group);
-    ReadTransaction read_client_1(client_1->shared_group);
-    ReadTransaction read_client_2(client_2->shared_group);
-    CHECK(compare_groups(read_server, read_client_1));
-    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
-    auto table = read_server.get_table("class_Table");
-    auto col_any = table->get_column_key("any");
-    CHECK(table->get_object_with_primary_key(1).get_dictionary_ptr({col_any, "A", 0, "B"})->is_empty());
+    h.check_merge_result([&](Obj obj, ColKey col_any) {
+        CHECK(obj.get_dictionary_ptr({col_any, "A", 0, "B"})->is_empty());
+    });
 }
 
 TEST(Transform_MergeArrays)
 {
-    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
-    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
-    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
-    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
+    TransformTestHarness h(test_context, TransformTestHarness::ClientOneBeforeTwo, [](Obj, ColKey) {});
 
-    // Create baseline
-    client_1->transaction([](Peer& c) {
-        auto& tr = *c.group;
-        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
-        table->add_column(type_Mixed, "any");
-        auto obj = table->create_object_with_primary_key(1);
-    });
-
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    client_1->history.set_time(1);
-    client_2->history.set_time(2);
-
-    client_1->transaction([](Peer& p) {
-        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
-        auto col_any = p.table("class_Table")->get_column_key("any");
+    h.transaction(h.client_1, [](Obj obj, ColKey col_any) {
         obj.set_collection(col_any, CollectionType::List);
         auto list = obj.get_list<Mixed>(col_any);
         list.insert(0, "a");
         list.insert(1, "b");
     });
 
-    client_2->transaction([](Peer& p) {
-        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
-        auto col_any = p.table("class_Table")->get_column_key("any");
+    h.transaction(h.client_2, [](Obj obj, ColKey col_any) {
         obj.set_collection(col_any, CollectionType::List);
         auto list = obj.get_list<Mixed>(col_any);
         list.insert(0, "c");
         list.insert(1, "d");
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    ReadTransaction read_server(server->shared_group);
-    ReadTransaction read_client_1(client_1->shared_group);
-    ReadTransaction read_client_2(client_2->shared_group);
-    CHECK(compare_groups(read_server, read_client_1));
-    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
-    auto table = read_server.get_table("class_Table");
-    auto col_any = table->get_column_key("any");
-    auto list = table->get_object_with_primary_key(1).get_list_ptr<Mixed>(col_any);
-    CHECK_EQUAL(list->size(), 4);
-    CHECK_EQUAL(list->get(0), "a");
-    CHECK_EQUAL(list->get(1), "b");
-    CHECK_EQUAL(list->get(2), "c");
-    CHECK_EQUAL(list->get(3), "d");
+    h.check_merge_result([&](Obj obj, ColKey col_any) {
+        auto list = obj.get_list_ptr<Mixed>(col_any);
+        CHECK_EQUAL(list->size(), 4);
+        CHECK_EQUAL(list->get(0), "a");
+        CHECK_EQUAL(list->get(1), "b");
+        CHECK_EQUAL(list->get(2), "c");
+        CHECK_EQUAL(list->get(3), "d");
+    });
 }
 
 TEST(Transform_Nested_MergeArrays)
 {
-    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
-    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
-    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
-    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
-
-    // Create baseline
-    client_1->transaction([](Peer& c) {
-        auto& tr = *c.group;
-        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
-        auto col_any = table->add_column(type_Mixed, "any");
-        auto obj = table->create_object_with_primary_key(1);
+    TransformTestHarness h(test_context, TransformTestHarness::ClientOneBeforeTwo, [](Obj obj, ColKey col_any) {
         obj.set_collection(col_any, CollectionType::Dictionary);
         auto dict = obj.get_dictionary_ptr(col_any);
         dict->insert_collection("A", CollectionType::List);
@@ -854,113 +508,62 @@ TEST(Transform_Nested_MergeArrays)
         dict2->insert_collection("B", CollectionType::Dictionary);
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    client_1->history.set_time(1);
-    client_2->history.set_time(2);
-
-    client_1->transaction([](Peer& p) {
-        auto col_any = p.table("class_Table")->get_column_key("any");
-        auto dict = p.table("class_Table")->get_object_with_primary_key(1).get_dictionary_ptr({col_any, "A", 0});
+    h.transaction(h.client_1, [](Obj obj, ColKey col_any) {
+        auto dict = obj.get_dictionary_ptr({col_any, "A", 0});
         dict->insert_collection("B", CollectionType::List);
         auto list = dict->get_list("B");
         list->insert(0, "a");
         list->insert(1, "b");
     });
 
-    client_2->transaction([](Peer& p) {
-        auto col_any = p.table("class_Table")->get_column_key("any");
-        auto dict = p.table("class_Table")->get_object_with_primary_key(1).get_dictionary_ptr({col_any, "A", 0});
+    h.transaction(h.client_2, [](Obj obj, ColKey col_any) {
+        auto dict = obj.get_dictionary_ptr({col_any, "A", 0});
         dict->insert_collection("B", CollectionType::List);
         auto list = dict->get_list("B");
         list->insert(0, "c");
         list->insert(1, "d");
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    ReadTransaction read_server(server->shared_group);
-    ReadTransaction read_client_1(client_1->shared_group);
-    ReadTransaction read_client_2(client_2->shared_group);
-    CHECK(compare_groups(read_server, read_client_1));
-    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
-    auto table = read_server.get_table("class_Table");
-    auto col_any = table->get_column_key("any");
-    auto list = table->get_object_with_primary_key(1).get_list_ptr<Mixed>({col_any, "A", 0, "B"});
-    CHECK_EQUAL(list->size(), 4);
-    CHECK_EQUAL(list->get(0), "a");
-    CHECK_EQUAL(list->get(1), "b");
-    CHECK_EQUAL(list->get(2), "c");
-    CHECK_EQUAL(list->get(3), "d");
+    h.check_merge_result([&](Obj obj, ColKey col_any) {
+        auto list = obj.get_list_ptr<Mixed>({col_any, "A", 0, "B"});
+        CHECK_EQUAL(list->size(), 4);
+        CHECK_EQUAL(list->get(0), "a");
+        CHECK_EQUAL(list->get(1), "b");
+        CHECK_EQUAL(list->get(2), "c");
+        CHECK_EQUAL(list->get(3), "d");
+    });
 }
 
 TEST(Transform_MergeDictionaries)
 {
-    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
-    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
-    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
-    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
+    TransformTestHarness h(test_context, TransformTestHarness::ClientOneBeforeTwo, [](Obj, ColKey) {});
 
-    // Create baseline
-    client_1->transaction([](Peer& c) {
-        auto& tr = *c.group;
-        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
-        table->add_column(type_Mixed, "any");
-        auto obj = table->create_object_with_primary_key(1);
-    });
-
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    client_1->history.set_time(1);
-    client_2->history.set_time(2);
-
-    client_1->transaction([](Peer& p) {
-        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
-        auto col_any = p.table("class_Table")->get_column_key("any");
+    h.transaction(h.client_1, [](Obj obj, ColKey col_any) {
         obj.set_collection(col_any, CollectionType::Dictionary);
         auto list = obj.get_dictionary(col_any);
         list.insert("key1", "a");
         list.insert("key2", "b");
     });
 
-    client_2->transaction([](Peer& p) {
-        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
-        auto col_any = p.table("class_Table")->get_column_key("any");
+    h.transaction(h.client_2, [](Obj obj, ColKey col_any) {
         obj.set_collection(col_any, CollectionType::Dictionary);
         auto list = obj.get_dictionary(col_any);
         list.insert("key2", "y");
         list.insert("key3", "z");
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    ReadTransaction read_server(server->shared_group);
-    ReadTransaction read_client_1(client_1->shared_group);
-    ReadTransaction read_client_2(client_2->shared_group);
-    CHECK(compare_groups(read_server, read_client_1));
-    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
-    auto table = read_server.get_table("class_Table");
-    auto col_any = table->get_column_key("any");
-    auto dict = table->get_object_with_primary_key(1).get_dictionary(col_any);
-    CHECK_EQUAL(dict.size(), 3);
-    CHECK_EQUAL(dict.get("key1"), "a");
-    CHECK_EQUAL(dict.get("key2"), "y");
-    CHECK_EQUAL(dict.get("key3"), "z");
+    h.check_merge_result([&](Obj obj, ColKey col_any) {
+        auto dict = obj.get_dictionary(col_any);
+        CHECK_EQUAL(dict.size(), 3);
+        CHECK_EQUAL(dict.get("key1"), "a");
+        CHECK_EQUAL(dict.get("key2"), "y");
+        CHECK_EQUAL(dict.get("key3"), "z");
+    });
 }
 
 TEST(Transform_Nested_MergeDictionaries)
 {
-    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
-    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
-    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
-    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
-
-    // Create baseline
-    client_1->transaction([](Peer& c) {
-        auto& tr = *c.group;
-        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
-        auto col_any = table->add_column(type_Mixed, "any");
-        auto obj = table->create_object_with_primary_key(1);
+    TransformTestHarness h(test_context, TransformTestHarness::ClientOneBeforeTwo, [](Obj obj, ColKey col_any) {
         obj.set_collection(col_any, CollectionType::Dictionary);
         auto dict = obj.get_dictionary_ptr(col_any);
         dict->insert_collection("A", CollectionType::List);
@@ -970,164 +573,86 @@ TEST(Transform_Nested_MergeDictionaries)
         dict2->insert_collection("B", CollectionType::List);
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    client_1->history.set_time(1);
-    client_2->history.set_time(2);
-
-    client_1->transaction([](Peer& p) {
-        auto col_any = p.table("class_Table")->get_column_key("any");
-        auto dict = p.table("class_Table")->get_object_with_primary_key(1).get_dictionary_ptr({col_any, "A", 0});
+    h.transaction(h.client_1, [](Obj obj, ColKey col_any) {
+        auto dict = obj.get_dictionary_ptr({col_any, "A", 0});
         dict->insert_collection("B", CollectionType::Dictionary);
         auto dict2 = dict->get_dictionary("B");
         dict2->insert("key1", "a");
         dict2->insert("key2", "b");
     });
 
-    client_2->transaction([](Peer& p) {
-        auto col_any = p.table("class_Table")->get_column_key("any");
-        auto dict = p.table("class_Table")->get_object_with_primary_key(1).get_dictionary_ptr({col_any, "A", 0});
+    h.transaction(h.client_2, [](Obj obj, ColKey col_any) {
+        auto dict = obj.get_dictionary_ptr({col_any, "A", 0});
         dict->insert_collection("B", CollectionType::Dictionary);
         auto dict2 = dict->get_dictionary("B");
         dict2->insert("key2", "y");
         dict2->insert("key3", "z");
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    ReadTransaction read_server(server->shared_group);
-    ReadTransaction read_client_1(client_1->shared_group);
-    ReadTransaction read_client_2(client_2->shared_group);
-    CHECK(compare_groups(read_server, read_client_1));
-    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
-    auto table = read_server.get_table("class_Table");
-    auto col_any = table->get_column_key("any");
-    auto dict = table->get_object_with_primary_key(1).get_dictionary_ptr({col_any, "A", 0, "B"});
-    CHECK_EQUAL(dict->size(), 3);
-    CHECK_EQUAL(dict->get("key1"), "a");
-    CHECK_EQUAL(dict->get("key2"), "y");
-    CHECK_EQUAL(dict->get("key3"), "z");
+    h.check_merge_result([&](Obj obj, ColKey col_any) {
+        auto dict = obj.get_dictionary_ptr({col_any, "A", 0, "B"});
+        CHECK_EQUAL(dict->size(), 3);
+        CHECK_EQUAL(dict->get("key1"), "a");
+        CHECK_EQUAL(dict->get("key2"), "y");
+        CHECK_EQUAL(dict->get("key3"), "z");
+    });
 }
 
 TEST(Transform_CreateArrayAfterCreateDictionary)
 {
-    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
-    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
-    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
-    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
+    TransformTestHarness h(test_context, TransformTestHarness::ClientTwoBeforeOne, [](Obj, ColKey) {});
 
-    // Create baseline
-    client_1->transaction([](Peer& c) {
-        auto& tr = *c.group;
-        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
-        table->add_column(type_Mixed, "any");
-        auto obj = table->create_object_with_primary_key(1);
-    });
-
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    client_2->history.set_time(1);
-    client_1->history.set_time(2);
-
-    client_1->transaction([](Peer& p) {
-        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
-        auto col_any = p.table("class_Table")->get_column_key("any");
+    h.transaction(h.client_1, [](Obj obj, ColKey col_any) {
         obj.set_collection(col_any, CollectionType::List);
         auto list = obj.get_list<Mixed>(col_any);
         list.insert(0, "a");
         list.insert(1, "b");
     });
 
-    client_2->transaction([](Peer& p) {
-        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
-        auto col_any = p.table("class_Table")->get_column_key("any");
+    h.transaction(h.client_2, [](Obj obj, ColKey col_any) {
         obj.set_collection(col_any, CollectionType::Dictionary);
         auto dict = obj.get_dictionary(col_any);
         dict.insert("key1", "a");
         dict.insert("key2", "b");
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    ReadTransaction read_server(server->shared_group);
-    ReadTransaction read_client_1(client_1->shared_group);
-    ReadTransaction read_client_2(client_2->shared_group);
-    CHECK(compare_groups(read_server, read_client_1));
-    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
-    auto table = read_server.get_table("class_Table");
-    auto col_any = table->get_column_key("any");
-    auto list = table->get_object_with_primary_key(1).get_list_ptr<Mixed>(col_any);
-    CHECK_EQUAL(list->size(), 2);
-    CHECK_EQUAL(list->get(0), "a");
-    CHECK_EQUAL(list->get(1), "b");
+    h.check_merge_result([&](Obj obj, ColKey col_any) {
+        auto list = obj.get_list_ptr<Mixed>(col_any);
+        CHECK_EQUAL(list->size(), 2);
+        CHECK_EQUAL(list->get(0), "a");
+        CHECK_EQUAL(list->get(1), "b");
+    });
 }
 
 TEST(Transform_CreateArrayBeforeCreateDictionary)
 {
-    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
-    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
-    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
-    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
+    TransformTestHarness h(test_context, TransformTestHarness::ClientOneBeforeTwo, [](Obj, ColKey) {});
 
-    // Create baseline
-    client_1->transaction([](Peer& c) {
-        auto& tr = *c.group;
-        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
-        table->add_column(type_Mixed, "any");
-        auto obj = table->create_object_with_primary_key(1);
-    });
-
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    client_1->history.set_time(1);
-    client_2->history.set_time(2);
-
-    client_1->transaction([](Peer& p) {
-        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
-        auto col_any = p.table("class_Table")->get_column_key("any");
+    h.transaction(h.client_1, [](Obj obj, ColKey col_any) {
         obj.set_collection(col_any, CollectionType::List);
         auto list = obj.get_list<Mixed>(col_any);
         list.insert(0, "a");
         list.insert(1, "b");
     });
 
-    client_2->transaction([](Peer& p) {
-        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
-        auto col_any = p.table("class_Table")->get_column_key("any");
+    h.transaction(h.client_2, [](Obj obj, ColKey col_any) {
         obj.set_collection(col_any, CollectionType::Dictionary);
         auto dict = obj.get_dictionary(col_any);
         dict.insert("key1", "a");
         dict.insert("key2", "b");
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    ReadTransaction read_server(server->shared_group);
-    ReadTransaction read_client_1(client_1->shared_group);
-    ReadTransaction read_client_2(client_2->shared_group);
-    CHECK(compare_groups(read_server, read_client_1));
-    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
-    auto table = read_server.get_table("class_Table");
-    auto col_any = table->get_column_key("any");
-    auto dict = table->get_object_with_primary_key(1).get_dictionary_ptr(col_any);
-    CHECK_EQUAL(dict->size(), 2);
-    CHECK_EQUAL(dict->get("key1"), "a");
-    CHECK_EQUAL(dict->get("key2"), "b");
+    h.check_merge_result([&](Obj obj, ColKey col_any) {
+        auto dict = obj.get_dictionary_ptr(col_any);
+        CHECK_EQUAL(dict->size(), 2);
+        CHECK_EQUAL(dict->get("key1"), "a");
+        CHECK_EQUAL(dict->get("key2"), "b");
+    });
 }
 
 TEST(Transform_Nested_CreateArrayAfterCreateDictionary)
 {
-    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
-    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
-    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
-    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
-
-    // Create baseline
-    client_1->transaction([](Peer& c) {
-        auto& tr = *c.group;
-        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
-        auto col_any = table->add_column(type_Mixed, "any");
-        auto obj = table->create_object_with_primary_key(1);
+    TransformTestHarness h(test_context, TransformTestHarness::ClientTwoBeforeOne, [](Obj obj, ColKey col_any) {
         obj.set_collection(col_any, CollectionType::Dictionary);
         auto dict = obj.get_dictionary_ptr(col_any);
         dict->insert_collection("A", CollectionType::List);
@@ -1135,57 +660,33 @@ TEST(Transform_Nested_CreateArrayAfterCreateDictionary)
         list->insert_collection(0, CollectionType::Dictionary);
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    client_2->history.set_time(1);
-    client_1->history.set_time(2);
-
-    client_1->transaction([](Peer& p) {
-        auto col_any = p.table("class_Table")->get_column_key("any");
-        auto dict = p.table("class_Table")->get_object_with_primary_key(1).get_dictionary_ptr({col_any, "A", 0});
+    h.transaction(h.client_1, [](Obj obj, ColKey col_any) {
+        auto dict = obj.get_dictionary_ptr({col_any, "A", 0});
         dict->insert_collection("B", CollectionType::List);
         auto list = dict->get_list("B");
         list->insert(0, "a");
         list->insert(1, "b");
     });
 
-    client_2->transaction([](Peer& p) {
-        auto col_any = p.table("class_Table")->get_column_key("any");
-        auto dict = p.table("class_Table")->get_object_with_primary_key(1).get_dictionary_ptr({col_any, "A", 0});
+    h.transaction(h.client_2, [](Obj obj, ColKey col_any) {
+        auto dict = obj.get_dictionary_ptr({col_any, "A", 0});
         dict->insert_collection("B", CollectionType::Dictionary);
         auto dict2 = dict->get_dictionary("B");
         dict2->insert("key1", "a");
         dict2->insert("key2", "b");
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    ReadTransaction read_server(server->shared_group);
-    ReadTransaction read_client_1(client_1->shared_group);
-    ReadTransaction read_client_2(client_2->shared_group);
-    CHECK(compare_groups(read_server, read_client_1));
-    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
-    auto table = read_server.get_table("class_Table");
-    auto col_any = table->get_column_key("any");
-    auto list = table->get_object_with_primary_key(1).get_list_ptr<Mixed>({col_any, "A", 0, "B"});
-    CHECK_EQUAL(list->size(), 2);
-    CHECK_EQUAL(list->get(0), "a");
-    CHECK_EQUAL(list->get(1), "b");
+    h.check_merge_result([&](Obj obj, ColKey col_any) {
+        auto list = obj.get_list_ptr<Mixed>({col_any, "A", 0, "B"});
+        CHECK_EQUAL(list->size(), 2);
+        CHECK_EQUAL(list->get(0), "a");
+        CHECK_EQUAL(list->get(1), "b");
+    });
 }
 
 TEST(Transform_Nested_ClearArrayVsUpdateString)
 {
-    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
-    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
-    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
-    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
-
-    // Create baseline
-    client_1->transaction([](Peer& c) {
-        auto& tr = *c.group;
-        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
-        auto col_any = table->add_column(type_Mixed, "any");
-        auto obj = table->create_object_with_primary_key(1);
+    TransformTestHarness h(test_context, TransformTestHarness::ClientOneBeforeTwo, [](Obj obj, ColKey col_any) {
         obj.set_collection(col_any, CollectionType::Dictionary);
         auto dict = obj.get_dictionary_ptr(col_any);
         dict->insert_collection("A", CollectionType::List);
@@ -1194,65 +695,34 @@ TEST(Transform_Nested_ClearArrayVsUpdateString)
         list->add(2);
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    client_1->history.set_time(1);
-    client_2->history.set_time(2);
-
-    client_1->transaction([](Peer& p) {
-        auto col_any = p.table("class_Table")->get_column_key("any");
-        auto list = p.table("class_Table")->get_object_with_primary_key(1).get_list_ptr<Mixed>({col_any, "A"});
+    h.transaction(h.client_1, [](Obj obj, ColKey col_any) {
+        auto list = obj.get_list_ptr<Mixed>({col_any, "A"});
         list->clear();
         list->add(3);
     });
 
-    client_2->transaction([](Peer& p) {
-        auto col_any = p.table("class_Table")->get_column_key("any");
-        auto dict = p.table("class_Table")->get_object_with_primary_key(1).get_dictionary_ptr(col_any);
+    h.transaction(h.client_2, [](Obj obj, ColKey col_any) {
+        auto dict = obj.get_dictionary_ptr(col_any);
         dict->insert("A", "some value");
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    ReadTransaction read_server(server->shared_group);
-    ReadTransaction read_client_1(client_1->shared_group);
-    ReadTransaction read_client_2(client_2->shared_group);
-    CHECK(compare_groups(read_server, read_client_1));
-    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
-    auto table = read_server.get_table("class_Table");
-    auto col_any = table->get_column_key("any");
-    auto dict = table->get_object_with_primary_key(1).get_dictionary_ptr(col_any);
-    CHECK_EQUAL(dict->size(), 1);
-    CHECK_EQUAL(dict->get("A"), "some value");
+    h.check_merge_result([&](Obj obj, ColKey col_any) {
+        auto dict = obj.get_dictionary_ptr(col_any);
+        CHECK_EQUAL(dict->size(), 1);
+        CHECK_EQUAL(dict->get("A"), "some value");
+    });
 }
 
 TEST(Transform_ClearArrayVsCreateArray)
 {
-    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
-    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
-    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
-    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
-
-    // Create baseline
-    client_1->transaction([](Peer& c) {
-        auto& tr = *c.group;
-        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
-        auto col_any = table->add_column(type_Mixed, "any");
-        auto obj = table->create_object_with_primary_key(1);
+    TransformTestHarness h(test_context, TransformTestHarness::ClientOneBeforeTwo, [](Obj obj, ColKey col_any) {
         obj.set_collection(col_any, CollectionType::Dictionary);
         auto dict = obj.get_dictionary(col_any);
         dict.insert("key1", 1);
         dict.insert("key2", 2);
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    client_1->history.set_time(1);
-    client_2->history.set_time(2);
-
-    client_1->transaction([](Peer& p) {
-        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
-        auto col_any = p.table("class_Table")->get_column_key("any");
+    h.transaction(h.client_1, [](Obj obj, ColKey col_any) {
         obj.set_collection(col_any, CollectionType::List);
         auto list = obj.get_list<Mixed>(col_any);
         list.add(1);
@@ -1260,41 +730,22 @@ TEST(Transform_ClearArrayVsCreateArray)
         list.add(2);
     });
 
-    client_2->transaction([](Peer& p) {
-        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
-        auto col_any = p.table("class_Table")->get_column_key("any");
+    h.transaction(h.client_2, [](Obj obj, ColKey col_any) {
         obj.set_collection(col_any, CollectionType::List);
         auto list = obj.get_list<Mixed>(col_any);
         list.add(4);
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    ReadTransaction read_server(server->shared_group);
-    ReadTransaction read_client_1(client_1->shared_group);
-    ReadTransaction read_client_2(client_2->shared_group);
-    CHECK(compare_groups(read_server, read_client_1));
-    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
-    auto table = read_server.get_table("class_Table");
-    auto col_any = table->get_column_key("any");
-    auto list = table->get_object_with_primary_key(1).get_list_ptr<Mixed>(col_any);
-    CHECK_EQUAL(list->size(), 1);
-    CHECK_EQUAL(list->get(0), 2);
+    h.check_merge_result([&](Obj obj, ColKey col_any) {
+        auto list = obj.get_list_ptr<Mixed>(col_any);
+        CHECK_EQUAL(list->size(), 1);
+        CHECK_EQUAL(list->get(0), 2);
+    });
 }
 
 TEST(Transform_ClearArrayInsideArrayVsCreateArray)
 {
-    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
-    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
-    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
-    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
-
-    // Create baseline
-    client_1->transaction([](Peer& c) {
-        auto& tr = *c.group;
-        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
-        auto col_any = table->add_column(type_Mixed, "any");
-        auto obj = table->create_object_with_primary_key(1);
+    TransformTestHarness h(test_context, TransformTestHarness::ClientOneBeforeTwo, [](Obj obj, ColKey col_any) {
         obj.set_collection(col_any, CollectionType::List);
         auto list = obj.get_list<Mixed>(col_any);
         list.insert_collection(0, CollectionType::Dictionary);
@@ -1303,14 +754,7 @@ TEST(Transform_ClearArrayInsideArrayVsCreateArray)
         dict->insert("key2", 2);
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    client_1->history.set_time(1);
-    client_2->history.set_time(2);
-
-    client_1->transaction([](Peer& p) {
-        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
-        auto col_any = p.table("class_Table")->get_column_key("any");
+    h.transaction(h.client_1, [](Obj obj, ColKey col_any) {
         auto list = obj.get_list<Mixed>(col_any);
         list.set_collection(0, CollectionType::List);
         auto list2 = list.get_list(0);
@@ -1319,42 +763,23 @@ TEST(Transform_ClearArrayInsideArrayVsCreateArray)
         list2->add(2);
     });
 
-    client_2->transaction([](Peer& p) {
-        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
-        auto col_any = p.table("class_Table")->get_column_key("any");
+    h.transaction(h.client_2, [](Obj obj, ColKey col_any) {
         auto list = obj.get_list<Mixed>(col_any);
         list.set_collection(0, CollectionType::List);
         auto list2 = list.get_list(0);
         list2->add(4);
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    ReadTransaction read_server(server->shared_group);
-    ReadTransaction read_client_1(client_1->shared_group);
-    ReadTransaction read_client_2(client_2->shared_group);
-    CHECK(compare_groups(read_server, read_client_1));
-    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
-    auto table = read_server.get_table("class_Table");
-    auto col_any = table->get_column_key("any");
-    auto list = table->get_object_with_primary_key(1).get_list_ptr<Mixed>({col_any, 0});
-    CHECK_EQUAL(list->size(), 1);
-    CHECK_EQUAL(list->get(0), 2);
+    h.check_merge_result([&](Obj obj, ColKey col_any) {
+        auto list = obj.get_list_ptr<Mixed>({col_any, 0});
+        CHECK_EQUAL(list->size(), 1);
+        CHECK_EQUAL(list->get(0), 2);
+    });
 }
 
 TEST(Transform_ClearArrayInsideDictionaryVsCreateArray)
 {
-    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
-    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
-    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
-    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
-
-    // Create baseline
-    client_1->transaction([](Peer& c) {
-        auto& tr = *c.group;
-        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
-        auto col_any = table->add_column(type_Mixed, "any");
-        auto obj = table->create_object_with_primary_key(1);
+    TransformTestHarness h(test_context, TransformTestHarness::ClientOneBeforeTwo, [](Obj obj, ColKey col_any) {
         obj.set_collection(col_any, CollectionType::Dictionary);
         auto dict = obj.get_dictionary(col_any);
         dict.insert_collection("A", CollectionType::Dictionary);
@@ -1363,14 +788,7 @@ TEST(Transform_ClearArrayInsideDictionaryVsCreateArray)
         dict2->insert("key2", 2);
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    client_1->history.set_time(1);
-    client_2->history.set_time(2);
-
-    client_1->transaction([](Peer& p) {
-        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
-        auto col_any = p.table("class_Table")->get_column_key("any");
+    h.transaction(h.client_1, [](Obj obj, ColKey col_any) {
         auto dict = obj.get_dictionary(col_any);
         dict.insert_collection("A", CollectionType::List);
         auto list = dict.get_list("A");
@@ -1379,53 +797,27 @@ TEST(Transform_ClearArrayInsideDictionaryVsCreateArray)
         list->add(2);
     });
 
-    client_2->transaction([](Peer& p) {
-        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
-        auto col_any = p.table("class_Table")->get_column_key("any");
+    h.transaction(h.client_2, [](Obj obj, ColKey col_any) {
         auto dict = obj.get_dictionary(col_any);
         dict.insert_collection("A", CollectionType::List);
         auto list = dict.get_list("A");
         list->add(4);
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    ReadTransaction read_server(server->shared_group);
-    ReadTransaction read_client_1(client_1->shared_group);
-    ReadTransaction read_client_2(client_2->shared_group);
-    CHECK(compare_groups(read_server, read_client_1));
-    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
-    auto table = read_server.get_table("class_Table");
-    auto col_any = table->get_column_key("any");
-    auto list = table->get_object_with_primary_key(1).get_list_ptr<Mixed>({col_any, "A"});
-    CHECK_EQUAL(list->size(), 1);
-    CHECK_EQUAL(list->get(0), 2);
+    h.check_merge_result([&](Obj obj, ColKey col_any) {
+        auto list = obj.get_list_ptr<Mixed>({col_any, "A"});
+        CHECK_EQUAL(list->size(), 1);
+        CHECK_EQUAL(list->get(0), 2);
+    });
 }
 
 TEST(Transform_ClearArrayVsCreateDictionary)
 {
-    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
-    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
-    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
-    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
-
-    // Create baseline
-    client_1->transaction([](Peer& c) {
-        auto& tr = *c.group;
-        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
-        auto col_any = table->add_column(type_Mixed, "any");
-        auto obj = table->create_object_with_primary_key(1);
+    TransformTestHarness h(test_context, TransformTestHarness::ClientOneBeforeTwo, [](Obj obj, ColKey col_any) {
         obj.set_collection(col_any, CollectionType::List);
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    client_1->history.set_time(1);
-    client_2->history.set_time(2);
-
-    client_1->transaction([](Peer& p) {
-        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
-        auto col_any = p.table("class_Table")->get_column_key("any");
+    h.transaction(h.client_1, [](Obj obj, ColKey col_any) {
         auto list = obj.get_list<Mixed>(col_any);
         list.add(1);
         list.add(2);
@@ -1433,53 +825,27 @@ TEST(Transform_ClearArrayVsCreateDictionary)
         list.add(3);
     });
 
-    client_2->transaction([](Peer& p) {
-        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
-        auto col_any = p.table("class_Table")->get_column_key("any");
+    h.transaction(h.client_2, [](Obj obj, ColKey col_any) {
         obj.set_collection(col_any, CollectionType::Dictionary);
         auto dict = obj.get_dictionary(col_any);
         dict.insert("key1", 42);
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    ReadTransaction read_server(server->shared_group);
-    ReadTransaction read_client_1(client_1->shared_group);
-    ReadTransaction read_client_2(client_2->shared_group);
-    CHECK(compare_groups(read_server, read_client_1));
-    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
-    auto table = read_server.get_table("class_Table");
-    auto col_any = table->get_column_key("any");
-    auto dict = table->get_object_with_primary_key(1).get_dictionary(col_any);
-    CHECK(dict.is_empty());
+    h.check_merge_result([&](Obj obj, ColKey col_any) {
+        auto dict = obj.get_dictionary(col_any);
+        CHECK(dict.is_empty());
+    });
 }
 
 TEST(Transform_ClearArrayInsideArrayVsCreateDictionary)
 {
-    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
-    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
-    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
-    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
-
-    // Create baseline
-    client_1->transaction([](Peer& c) {
-        auto& tr = *c.group;
-        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
-        auto col_any = table->add_column(type_Mixed, "any");
-        auto obj = table->create_object_with_primary_key(1);
+    TransformTestHarness h(test_context, TransformTestHarness::ClientOneBeforeTwo, [](Obj obj, ColKey col_any) {
         obj.set_collection(col_any, CollectionType::List);
         auto list = obj.get_list<Mixed>(col_any);
         list.insert(0, 42);
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    client_1->history.set_time(1);
-    client_2->history.set_time(2);
-
-    client_1->transaction([](Peer& p) {
-        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
-        auto col_any = p.table("class_Table")->get_column_key("any");
+    h.transaction(h.client_1, [](Obj obj, ColKey col_any) {
         auto list = obj.get_list<Mixed>(col_any);
         list.set_collection(0, CollectionType::List);
         auto list2 = list.get_list(0);
@@ -1488,54 +854,28 @@ TEST(Transform_ClearArrayInsideArrayVsCreateDictionary)
         list2->add(2);
     });
 
-    client_2->transaction([](Peer& p) {
-        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
-        auto col_any = p.table("class_Table")->get_column_key("any");
+    h.transaction(h.client_2, [](Obj obj, ColKey col_any) {
         auto list = obj.get_list<Mixed>(col_any);
         list.set_collection(0, CollectionType::Dictionary);
         auto dict = list.get_dictionary(0);
         dict->insert("key1", "some value");
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    ReadTransaction read_server(server->shared_group);
-    ReadTransaction read_client_1(client_1->shared_group);
-    ReadTransaction read_client_2(client_2->shared_group);
-    CHECK(compare_groups(read_server, read_client_1));
-    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
-    auto table = read_server.get_table("class_Table");
-    auto col_any = table->get_column_key("any");
-    auto dict = table->get_object_with_primary_key(1).get_dictionary_ptr({col_any, 0});
-    CHECK(dict->is_empty());
+    h.check_merge_result([&](Obj obj, ColKey col_any) {
+        auto dict = obj.get_dictionary_ptr({col_any, 0});
+        CHECK(dict->is_empty());
+    });
 }
 
 TEST(Transform_ClearArrayInsideDictionaryVsCreateDictionary)
 {
-    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
-    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
-    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
-    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
-
-    // Create baseline
-    client_1->transaction([](Peer& c) {
-        auto& tr = *c.group;
-        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
-        auto col_any = table->add_column(type_Mixed, "any");
-        auto obj = table->create_object_with_primary_key(1);
+    TransformTestHarness h(test_context, TransformTestHarness::ClientOneBeforeTwo, [](Obj obj, ColKey col_any) {
         obj.set_collection(col_any, CollectionType::Dictionary);
         auto dict = obj.get_dictionary(col_any);
         dict.insert("A", "some value");
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    client_1->history.set_time(1);
-    client_2->history.set_time(2);
-
-    client_1->transaction([](Peer& p) {
-        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
-        auto col_any = p.table("class_Table")->get_column_key("any");
+    h.transaction(h.client_1, [](Obj obj, ColKey col_any) {
         auto dict = obj.get_dictionary(col_any);
         dict.insert_collection("A", CollectionType::List);
         auto list = dict.get_list("A");
@@ -1544,55 +884,29 @@ TEST(Transform_ClearArrayInsideDictionaryVsCreateDictionary)
         list->add(2);
     });
 
-    client_2->transaction([](Peer& p) {
-        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
-        auto col_any = p.table("class_Table")->get_column_key("any");
+    h.transaction(h.client_2, [](Obj obj, ColKey col_any) {
         auto dict = obj.get_dictionary(col_any);
         dict.insert_collection("A", CollectionType::Dictionary);
         auto dict2 = dict.get_dictionary("A");
         dict2->insert("key1", "some other value");
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    ReadTransaction read_server(server->shared_group);
-    ReadTransaction read_client_1(client_1->shared_group);
-    ReadTransaction read_client_2(client_2->shared_group);
-    CHECK(compare_groups(read_server, read_client_1));
-    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
-    auto table = read_server.get_table("class_Table");
-    auto col_any = table->get_column_key("any");
-    auto dict = table->get_object_with_primary_key(1).get_dictionary_ptr({col_any, "A"});
-    CHECK(dict->is_empty());
+    h.check_merge_result([&](Obj obj, ColKey col_any) {
+        auto dict = obj.get_dictionary_ptr({col_any, "A"});
+        CHECK(dict->is_empty());
+    });
 }
 
 TEST(Transform_ClearDictionaryVsCreateArray)
 {
-    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
-    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
-    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
-    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
-
-    // Create baseline
-    client_1->transaction([](Peer& c) {
-        auto& tr = *c.group;
-        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
-        auto col_any = table->add_column(type_Mixed, "any");
-        auto obj = table->create_object_with_primary_key(1);
+    TransformTestHarness h(test_context, TransformTestHarness::ClientOneBeforeTwo, [](Obj obj, ColKey col_any) {
         obj.set_collection(col_any, CollectionType::Dictionary);
         auto dict = obj.get_dictionary(col_any);
         dict.insert("key1", 1);
         dict.insert("key2", 2);
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    client_1->history.set_time(1);
-    client_2->history.set_time(2);
-
-    client_1->transaction([](Peer& p) {
-        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
-        auto col_any = p.table("class_Table")->get_column_key("any");
+    h.transaction(h.client_1, [](Obj obj, ColKey col_any) {
         obj.set_collection(col_any, CollectionType::Dictionary);
         auto dict = obj.get_dictionary(col_any);
         dict.insert("key3", 3);
@@ -1600,40 +914,21 @@ TEST(Transform_ClearDictionaryVsCreateArray)
         dict.insert("key4", 4);
     });
 
-    client_2->transaction([](Peer& p) {
-        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
-        auto col_any = p.table("class_Table")->get_column_key("any");
+    h.transaction(h.client_2, [](Obj obj, ColKey col_any) {
         obj.set_collection(col_any, CollectionType::List);
         auto list = obj.get_list<Mixed>(col_any);
         list.add(1);
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    ReadTransaction read_server(server->shared_group);
-    ReadTransaction read_client_1(client_1->shared_group);
-    ReadTransaction read_client_2(client_2->shared_group);
-    CHECK(compare_groups(read_server, read_client_1));
-    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
-    auto table = read_server.get_table("class_Table");
-    auto col_any = table->get_column_key("any");
-    auto list = table->get_object_with_primary_key(1).get_list_ptr<Mixed>(col_any);
-    CHECK(list->is_empty());
+    h.check_merge_result([&](Obj obj, ColKey col_any) {
+        auto list = obj.get_list_ptr<Mixed>(col_any);
+        CHECK(list->is_empty());
+    });
 }
 
 TEST(Transform_ClearDictionaryInsideArrayVsCreateArray)
 {
-    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
-    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
-    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
-    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
-
-    // Create baseline
-    client_1->transaction([](Peer& c) {
-        auto& tr = *c.group;
-        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
-        auto col_any = table->add_column(type_Mixed, "any");
-        auto obj = table->create_object_with_primary_key(1);
+    TransformTestHarness h(test_context, TransformTestHarness::ClientOneBeforeTwo, [](Obj obj, ColKey col_any) {
         obj.set_collection(col_any, CollectionType::List);
         auto list = obj.get_list<Mixed>(col_any);
         list.insert_collection(0, CollectionType::Dictionary);
@@ -1642,55 +937,29 @@ TEST(Transform_ClearDictionaryInsideArrayVsCreateArray)
         dict->insert("key2", 2);
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    client_1->history.set_time(1);
-    client_2->history.set_time(2);
-
-    client_1->transaction([](Peer& p) {
-        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
-        auto col_any = p.table("class_Table")->get_column_key("any");
+    h.transaction(h.client_1, [](Obj obj, ColKey col_any) {
         auto dict = obj.get_dictionary_ptr({col_any, 0});
         dict->insert("key3", 3);
         dict->clear();
         dict->insert("key4", 4);
     });
 
-    client_2->transaction([](Peer& p) {
-        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
-        auto col_any = p.table("class_Table")->get_column_key("any");
+    h.transaction(h.client_2, [](Obj obj, ColKey col_any) {
         auto list = obj.get_list<Mixed>(col_any);
         list.set_collection(0, CollectionType::List);
         auto list2 = list.get_list(0);
         list2->add(4);
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    ReadTransaction read_server(server->shared_group);
-    ReadTransaction read_client_1(client_1->shared_group);
-    ReadTransaction read_client_2(client_2->shared_group);
-    CHECK(compare_groups(read_server, read_client_1));
-    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
-    auto table = read_server.get_table("class_Table");
-    auto col_any = table->get_column_key("any");
-    auto list = table->get_object_with_primary_key(1).get_list_ptr<Mixed>({col_any, 0});
-    CHECK(list->is_empty());
+    h.check_merge_result([&](Obj obj, ColKey col_any) {
+        auto list = obj.get_list_ptr<Mixed>({col_any, 0});
+        CHECK(list->is_empty());
+    });
 }
 
 TEST(Transform_ClearDictionaryInsideDictionaryVsCreateArray)
 {
-    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
-    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
-    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
-    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
-
-    // Create baseline
-    client_1->transaction([](Peer& c) {
-        auto& tr = *c.group;
-        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
-        auto col_any = table->add_column(type_Mixed, "any");
-        auto obj = table->create_object_with_primary_key(1);
+    TransformTestHarness h(test_context, TransformTestHarness::ClientOneBeforeTwo, [](Obj obj, ColKey col_any) {
         obj.set_collection(col_any, CollectionType::Dictionary);
         auto dict = obj.get_dictionary(col_any);
         dict.insert_collection("A", CollectionType::Dictionary);
@@ -1699,66 +968,33 @@ TEST(Transform_ClearDictionaryInsideDictionaryVsCreateArray)
         dict2->insert("key2", 2);
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    client_1->history.set_time(1);
-    client_2->history.set_time(2);
-
-    client_1->transaction([](Peer& p) {
-        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
-        auto col_any = p.table("class_Table")->get_column_key("any");
+    h.transaction(h.client_1, [](Obj obj, ColKey col_any) {
         auto dict = obj.get_dictionary_ptr({col_any, "A"});
         dict->insert("key3", 3);
         dict->clear();
         dict->insert("key4", 4);
     });
 
-    client_2->transaction([](Peer& p) {
-        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
-        auto col_any = p.table("class_Table")->get_column_key("any");
+    h.transaction(h.client_2, [](Obj obj, ColKey col_any) {
         auto dict = obj.get_dictionary(col_any);
         dict.insert_collection("A", CollectionType::List);
         auto list = dict.get_list("A");
         list->add(4);
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    ReadTransaction read_server(server->shared_group);
-    ReadTransaction read_client_1(client_1->shared_group);
-    ReadTransaction read_client_2(client_2->shared_group);
-    CHECK(compare_groups(read_server, read_client_1));
-    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
-    auto table = read_server.get_table("class_Table");
-    auto col_any = table->get_column_key("any");
-    auto list = table->get_object_with_primary_key(1).get_list_ptr<Mixed>({col_any, "A"});
-    CHECK(list->is_empty());
+    h.check_merge_result([&](Obj obj, ColKey col_any) {
+        auto list = obj.get_list_ptr<Mixed>({col_any, "A"});
+        CHECK(list->is_empty());
+    });
 }
 
 TEST(Transform_ClearDictionaryVsCreateDictionary)
 {
-    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
-    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
-    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
-    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
-
-    // Create baseline
-    client_1->transaction([](Peer& c) {
-        auto& tr = *c.group;
-        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
-        auto col_any = table->add_column(type_Mixed, "any");
-        auto obj = table->create_object_with_primary_key(1);
+    TransformTestHarness h(test_context, TransformTestHarness::ClientOneBeforeTwo, [](Obj obj, ColKey col_any) {
         obj.set_collection(col_any, CollectionType::List);
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    client_1->history.set_time(1);
-    client_2->history.set_time(2);
-
-    client_1->transaction([](Peer& p) {
-        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
-        auto col_any = p.table("class_Table")->get_column_key("any");
+    h.transaction(h.client_1, [](Obj obj, ColKey col_any) {
         obj.set_collection(col_any, CollectionType::Dictionary);
         auto dict = obj.get_dictionary(col_any);
         dict.insert("key1", 1);
@@ -1766,54 +1002,28 @@ TEST(Transform_ClearDictionaryVsCreateDictionary)
         dict.insert("key2", 2);
     });
 
-    client_2->transaction([](Peer& p) {
-        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
-        auto col_any = p.table("class_Table")->get_column_key("any");
+    h.transaction(h.client_2, [](Obj obj, ColKey col_any) {
         obj.set_collection(col_any, CollectionType::Dictionary);
         auto dict = obj.get_dictionary(col_any);
         dict.insert("key3", 3);
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    ReadTransaction read_server(server->shared_group);
-    ReadTransaction read_client_1(client_1->shared_group);
-    ReadTransaction read_client_2(client_2->shared_group);
-    CHECK(compare_groups(read_server, read_client_1));
-    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
-    auto table = read_server.get_table("class_Table");
-    auto col_any = table->get_column_key("any");
-    auto dict = table->get_object_with_primary_key(1).get_dictionary(col_any);
-    CHECK_EQUAL(dict.size(), 1);
-    CHECK_EQUAL(dict.get("key2"), 2);
+    h.check_merge_result([&](Obj obj, ColKey col_any) {
+        auto dict = obj.get_dictionary(col_any);
+        CHECK_EQUAL(dict.size(), 1);
+        CHECK_EQUAL(dict.get("key2"), 2);
+    });
 }
 
 TEST(Transform_ClearDictionaryInsideArrayVsCreateDictionary)
 {
-    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
-    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
-    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
-    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
-
-    // Create baseline
-    client_1->transaction([](Peer& c) {
-        auto& tr = *c.group;
-        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
-        auto col_any = table->add_column(type_Mixed, "any");
-        auto obj = table->create_object_with_primary_key(1);
+    TransformTestHarness h(test_context, TransformTestHarness::ClientOneBeforeTwo, [](Obj obj, ColKey col_any) {
         obj.set_collection(col_any, CollectionType::List);
         auto list = obj.get_list<Mixed>(col_any);
         list.insert(0, 42);
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    client_1->history.set_time(1);
-    client_2->history.set_time(2);
-
-    client_1->transaction([](Peer& p) {
-        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
-        auto col_any = p.table("class_Table")->get_column_key("any");
+    h.transaction(h.client_1, [](Obj obj, ColKey col_any) {
         auto list = obj.get_list<Mixed>(col_any);
         list.insert_collection(0, CollectionType::Dictionary);
         auto dict = list.get_dictionary(0);
@@ -1822,55 +1032,29 @@ TEST(Transform_ClearDictionaryInsideArrayVsCreateDictionary)
         dict->insert("key2", 2);
     });
 
-    client_2->transaction([](Peer& p) {
-        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
-        auto col_any = p.table("class_Table")->get_column_key("any");
+    h.transaction(h.client_2, [](Obj obj, ColKey col_any) {
         auto list = obj.get_list<Mixed>(col_any);
         list.set_collection(0, CollectionType::Dictionary);
         auto dict = list.get_dictionary(0);
         dict->insert("key3", 3);
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    ReadTransaction read_server(server->shared_group);
-    ReadTransaction read_client_1(client_1->shared_group);
-    ReadTransaction read_client_2(client_2->shared_group);
-    CHECK(compare_groups(read_server, read_client_1));
-    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
-    auto table = read_server.get_table("class_Table");
-    auto col_any = table->get_column_key("any");
-    auto dict = table->get_object_with_primary_key(1).get_dictionary_ptr({col_any, 0});
-    CHECK_EQUAL(dict->size(), 1);
-    CHECK_EQUAL(dict->get("key2"), 2);
+    h.check_merge_result([&](Obj obj, ColKey col_any) {
+        auto dict = obj.get_dictionary_ptr({col_any, 0});
+        CHECK_EQUAL(dict->size(), 1);
+        CHECK_EQUAL(dict->get("key2"), 2);
+    });
 }
 
 TEST(Transform_ClearDictionaryInsideDictionaryVsCreateDictionary)
 {
-    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
-    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
-    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
-    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
-
-    // Create baseline
-    client_1->transaction([](Peer& c) {
-        auto& tr = *c.group;
-        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
-        auto col_any = table->add_column(type_Mixed, "any");
-        auto obj = table->create_object_with_primary_key(1);
+    TransformTestHarness h(test_context, TransformTestHarness::ClientOneBeforeTwo, [](Obj obj, ColKey col_any) {
         obj.set_collection(col_any, CollectionType::Dictionary);
         auto dict = obj.get_dictionary(col_any);
         dict.insert("A", "some value");
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    client_1->history.set_time(1);
-    client_2->history.set_time(2);
-
-    client_1->transaction([](Peer& p) {
-        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
-        auto col_any = p.table("class_Table")->get_column_key("any");
+    h.transaction(h.client_1, [](Obj obj, ColKey col_any) {
         auto dict = obj.get_dictionary(col_any);
         dict.insert_collection("A", CollectionType::Dictionary);
         auto dict2 = dict.get_dictionary("A");
@@ -1879,26 +1063,16 @@ TEST(Transform_ClearDictionaryInsideDictionaryVsCreateDictionary)
         dict2->insert("key2", 2);
     });
 
-    client_2->transaction([](Peer& p) {
-        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
-        auto col_any = p.table("class_Table")->get_column_key("any");
+    h.transaction(h.client_2, [](Obj obj, ColKey col_any) {
         auto dict = obj.get_dictionary(col_any);
         dict.insert_collection("A", CollectionType::Dictionary);
         auto dict2 = dict.get_dictionary("A");
         dict2->insert("key3", 3);
     });
 
-    synchronize(server.get(), {client_1.get(), client_2.get()});
-
-    ReadTransaction read_server(server->shared_group);
-    ReadTransaction read_client_1(client_1->shared_group);
-    ReadTransaction read_client_2(client_2->shared_group);
-    CHECK(compare_groups(read_server, read_client_1));
-    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
-    auto table = read_server.get_table("class_Table");
-    auto col_any = table->get_column_key("any");
-    auto dict = table->get_object_with_primary_key(1).get_dictionary_ptr({col_any, "A"});
-    CHECK_EQUAL(dict->size(), 1);
-    CHECK_EQUAL(dict->get("key2"), 2);
+    h.check_merge_result([&](Obj obj, ColKey col_any) {
+        auto dict = obj.get_dictionary_ptr({col_any, "A"});
+        CHECK_EQUAL(dict->size(), 1);
+        CHECK_EQUAL(dict->get("key2"), 2);
+    });
 }
-

--- a/test/test_transform_collections_mixed.cpp
+++ b/test/test_transform_collections_mixed.cpp
@@ -190,9 +190,8 @@ TEST(Transform_Nested_CreateListVsUpdateDictionary)
 
     client_2->transaction([](Peer& p) {
         auto col_any = p.table("class_Table")->get_column_key("any");
-        auto dict =
-            p.table("class_Table")->get_object_with_primary_key(1).get_dictionary_ptr({col_any, "A", 0, "B"});
-       dict->insert("key", 42);
+        auto dict = p.table("class_Table")->get_object_with_primary_key(1).get_dictionary_ptr({col_any, "A", 0, "B"});
+        dict->insert("key", 42);
     });
 
     synchronize(server.get(), {client_1.get(), client_2.get()});
@@ -828,7 +827,7 @@ TEST(Transform_MergeDictionaries)
     });
 
     client_2->transaction([&](Peer& p) {
-       auto obj = p.table("class_Table")->get_object_with_primary_key(1);
+        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
         auto col_any = p.table("class_Table")->get_column_key("any");
         obj.set_collection(col_any, CollectionType::Dictionary);
         auto list = obj.get_dictionary(col_any);

--- a/test/test_transform_collections_mixed.cpp
+++ b/test/test_transform_collections_mixed.cpp
@@ -1,0 +1,1078 @@
+#include "peer.hpp"
+#include "util/dump_changesets.hpp"
+
+using namespace realm;
+using namespace realm::test_util;
+
+TEST(Transform_CreateListVsCreateList)
+{
+    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
+    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
+    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
+    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
+
+    // Create baseline
+    client_1->transaction([&](Peer& c) {
+        auto& tr = *c.group;
+        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
+        auto col_any = table->add_column(type_Mixed, "any");
+        auto obj = table->create_object_with_primary_key(1);
+        obj.set_collection(col_any, CollectionType::Dictionary);
+    });
+
+    synchronize(server.get(), {client_1.get(), client_2.get()});
+
+    auto set_nested_list = [](Peer& p) {
+        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
+        auto col_any = p.table("class_Table")->get_column_key("any");
+        obj.set_collection(col_any, CollectionType::List);
+    };
+
+    client_2->transaction([&](Peer& p) {
+        set_nested_list(p);
+    });
+
+    synchronize(server.get(), {client_2.get()});
+
+    client_1->transaction([&](Peer& p) {
+        set_nested_list(p);
+    });
+
+    client_2->transaction([](Peer& p) {
+        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
+        auto col_any = p.table("class_Table")->get_column_key("any");
+        auto list = obj.get_list<Mixed>(col_any);
+        list.add(42);
+    });
+
+    synchronize(server.get(), {client_1.get(), client_2.get()});
+
+    ReadTransaction read_server(server->shared_group);
+    ReadTransaction read_client_1(client_1->shared_group);
+    ReadTransaction read_client_2(client_2->shared_group);
+    CHECK(compare_groups(read_server, read_client_1));
+    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
+    auto table = read_server.get_table("class_Table");
+    auto col_any = table->get_column_key("any");
+    CHECK_EQUAL(table->get_object_with_primary_key(1).get_list_ptr<Mixed>(col_any)->get(0), 42);
+}
+
+TEST(Transform_Nested_CreateListVsArrayInsert)
+{
+    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
+    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
+    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
+    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
+
+    // Create baseline
+    client_1->transaction([&](Peer& c) {
+        auto& tr = *c.group;
+        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
+        auto col_any = table->add_column(type_Mixed, "any");
+        auto obj = table->create_object_with_primary_key(1);
+        obj.set_collection(col_any, CollectionType::Dictionary);
+        auto dict = obj.get_dictionary_ptr(col_any);
+        dict->insert_collection("A", CollectionType::List);
+        auto list = dict->get_list("A");
+        list->insert_collection(0, CollectionType::Dictionary);
+        auto dict2 = list->get_dictionary(0);
+        dict2->insert_collection("B", CollectionType::Dictionary);
+    });
+
+    synchronize(server.get(), {client_1.get(), client_2.get()});
+
+    auto set_nested_list = [](Peer& p) {
+        auto col_any = p.table("class_Table")->get_column_key("any");
+        auto dict = p.table("class_Table")->get_object_with_primary_key(1).get_dictionary_ptr({col_any, "A", 0});
+        dict->insert_collection("B", CollectionType::List);
+    };
+
+    client_2->transaction([&](Peer& p) {
+        set_nested_list(p);
+    });
+
+    synchronize(server.get(), {client_2.get()});
+
+    client_1->transaction([&](Peer& p) {
+        set_nested_list(p);
+    });
+
+    client_2->transaction([](Peer& p) {
+        auto col_any = p.table("class_Table")->get_column_key("any");
+        auto list =
+            p.table("class_Table")->get_object_with_primary_key(1).get_list_ptr<Mixed>({col_any, "A", 0, "B"});
+        list->add(42);
+    });
+
+    synchronize(server.get(), {client_1.get(), client_2.get()});
+
+    ReadTransaction read_server(server->shared_group);
+    ReadTransaction read_client_1(client_1->shared_group);
+    ReadTransaction read_client_2(client_2->shared_group);
+    CHECK(compare_groups(read_server, read_client_1));
+    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
+    auto table = read_server.get_table("class_Table");
+    auto col_any = table->get_column_key("any");
+    CHECK_EQUAL(table->get_object_with_primary_key(1).get_list_ptr<Mixed>({col_any, "A", 0, "B"})->get(0), 42);
+}
+
+TEST(Transform_CreateListVsUpdateDictionary)
+{
+    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
+    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
+    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
+    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
+
+    // Create baseline
+    client_1->transaction([&](Peer& c) {
+        auto& tr = *c.group;
+        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
+        auto col_any = table->add_column(type_Mixed, "any");
+        auto obj = table->create_object_with_primary_key(1);
+        obj.set_collection(col_any, CollectionType::Dictionary);
+    });
+
+    synchronize(server.get(), {client_1.get(), client_2.get()});
+
+    client_1->transaction([&](Peer& p) {
+        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
+        auto col_any = p.table("class_Table")->get_column_key("any");
+        obj.set_collection(col_any, CollectionType::List);
+    });
+
+    client_2->transaction([](Peer& p) {
+        auto col_any = p.table("class_Table")->get_column_key("any");
+        auto dict = p.table("class_Table")->get_object_with_primary_key(1).get_dictionary_ptr(col_any);
+        dict->insert("key", 42);
+    });
+
+    synchronize(server.get(), {client_1.get(), client_2.get()});
+
+    ReadTransaction read_server(server->shared_group);
+    ReadTransaction read_client_1(client_1->shared_group);
+    ReadTransaction read_client_2(client_2->shared_group);
+    CHECK(compare_groups(read_server, read_client_1));
+    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
+    auto table = read_server.get_table("class_Table");
+    auto col_any = table->get_column_key("any");
+    CHECK(table->get_object_with_primary_key(1).get_list_ptr<Mixed>(col_any)->is_empty());
+}
+
+TEST(Transform_Nested_CreateListVsUpdateDictionary)
+{
+    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
+    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
+    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
+    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
+
+    // Create baseline
+    client_1->transaction([&](Peer& c) {
+        auto& tr = *c.group;
+        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
+        auto col_any = table->add_column(type_Mixed, "any");
+        auto obj = table->create_object_with_primary_key(1);
+        obj.set_collection(col_any, CollectionType::Dictionary);
+        auto dict = obj.get_dictionary_ptr(col_any);
+        dict->insert_collection("A", CollectionType::List);
+        auto list = dict->get_list("A");
+        list->insert_collection(0, CollectionType::Dictionary);
+        auto dict2 = list->get_dictionary(0);
+        dict2->insert_collection("B", CollectionType::Dictionary);
+    });
+
+    synchronize(server.get(), {client_1.get(), client_2.get()});
+
+    client_1->transaction([&](Peer& p) {
+        auto col_any = p.table("class_Table")->get_column_key("any");
+        auto dict = p.table("class_Table")->get_object_with_primary_key(1).get_dictionary_ptr({col_any, "A", 0});
+        dict->insert_collection("B", CollectionType::List);
+    });
+
+    client_2->transaction([](Peer& p) {
+        auto col_any = p.table("class_Table")->get_column_key("any");
+        auto dict =
+            p.table("class_Table")->get_object_with_primary_key(1).get_dictionary_ptr({col_any, "A", 0, "B"});
+       dict->insert("key", 42);
+    });
+
+    synchronize(server.get(), {client_1.get(), client_2.get()});
+
+    ReadTransaction read_server(server->shared_group);
+    ReadTransaction read_client_1(client_1->shared_group);
+    ReadTransaction read_client_2(client_2->shared_group);
+    CHECK(compare_groups(read_server, read_client_1));
+    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
+    auto table = read_server.get_table("class_Table");
+    auto col_any = table->get_column_key("any");
+    CHECK(table->get_object_with_primary_key(1).get_list_ptr<Mixed>({col_any, "A", 0, "B"})->is_empty());
+}
+
+TEST(Transform_CreateDictionaryVsUpdateDictionary)
+{
+    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
+    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
+    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
+    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
+
+    // Create baseline
+    client_1->transaction([&](Peer& c) {
+        auto& tr = *c.group;
+        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
+        auto col_any = table->add_column(type_Mixed, "any");
+        auto obj = table->create_object_with_primary_key(1);
+        obj.set_collection(col_any, CollectionType::List);
+    });
+
+    synchronize(server.get(), {client_1.get(), client_2.get()});
+
+    auto set_nested_dictionary = [](Peer& p) {
+        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
+        auto col_any = p.table("class_Table")->get_column_key("any");
+        obj.set_collection(col_any, CollectionType::Dictionary);
+    };
+
+    client_2->transaction([&](Peer& p) {
+        set_nested_dictionary(p);
+    });
+
+    synchronize(server.get(), {client_2.get()});
+
+    client_1->transaction([&](Peer& p) {
+        set_nested_dictionary(p);
+    });
+
+    client_2->transaction([](Peer& p) {
+        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
+        auto col_any = p.table("class_Table")->get_column_key("any");
+        auto dict = obj.get_dictionary(col_any);
+        dict.insert("key", 42);
+    });
+
+    synchronize(server.get(), {client_1.get(), client_2.get()});
+
+    ReadTransaction read_server(server->shared_group);
+    ReadTransaction read_client_1(client_1->shared_group);
+    ReadTransaction read_client_2(client_2->shared_group);
+    CHECK(compare_groups(read_server, read_client_1));
+    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
+    auto table = read_server.get_table("class_Table");
+    auto col_any = table->get_column_key("any");
+    CHECK_EQUAL(table->get_object_with_primary_key(1).get_dictionary(col_any).get("key"), 42);
+}
+
+TEST(Transform_Nested_CreateDictionaryVsUpdateDictionary)
+{
+    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
+    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
+    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
+    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
+
+    // Create baseline
+    client_1->transaction([&](Peer& c) {
+        auto& tr = *c.group;
+        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
+        auto col_any = table->add_column(type_Mixed, "any");
+        auto obj = table->create_object_with_primary_key(1);
+        obj.set_collection(col_any, CollectionType::Dictionary);
+        auto dict = obj.get_dictionary_ptr(col_any);
+        dict->insert_collection("A", CollectionType::List);
+        auto list = dict->get_list("A");
+        list->insert_collection(0, CollectionType::Dictionary);
+        auto dict2 = list->get_dictionary(0);
+        dict2->insert_collection("B", CollectionType::List);
+    });
+
+    synchronize(server.get(), {client_1.get(), client_2.get()});
+
+    auto set_nested_dictionary = [](Peer& p) {
+        auto col_any = p.table("class_Table")->get_column_key("any");
+        auto dict = p.table("class_Table")->get_object_with_primary_key(1).get_dictionary_ptr({col_any, "A", 0});
+        dict->insert_collection("B", CollectionType::Dictionary);
+    };
+
+    client_2->transaction([&](Peer& p) {
+        set_nested_dictionary(p);
+    });
+
+    synchronize(server.get(), {client_2.get()});
+
+    client_1->transaction([&](Peer& p) {
+        set_nested_dictionary(p);
+    });
+
+    client_2->transaction([](Peer& p) {
+        auto col_any = p.table("class_Table")->get_column_key("any");
+        auto dict = p.table("class_Table")->get_object_with_primary_key(1).get_dictionary_ptr({col_any, "A", 0, "B"});
+        dict->insert("key", 42);
+    });
+
+    synchronize(server.get(), {client_1.get(), client_2.get()});
+
+    ReadTransaction read_server(server->shared_group);
+    ReadTransaction read_client_1(client_1->shared_group);
+    ReadTransaction read_client_2(client_2->shared_group);
+    CHECK(compare_groups(read_server, read_client_1));
+    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
+    auto table = read_server.get_table("class_Table");
+    auto col_any = table->get_column_key("any");
+    CHECK_EQUAL(table->get_object_with_primary_key(1).get_dictionary_ptr({col_any, "A", 0, "B"})->get("key"), 42);
+}
+
+
+TEST(Transform_CreateDictionaryVsArrayInsert)
+{
+    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
+    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
+    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
+    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
+
+    // Create baseline
+    client_1->transaction([&](Peer& c) {
+        auto& tr = *c.group;
+        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
+        auto col_any = table->add_column(type_Mixed, "any");
+        auto obj = table->create_object_with_primary_key(1);
+        obj.set_collection(col_any, CollectionType::List);
+    });
+
+    synchronize(server.get(), {client_1.get(), client_2.get()});
+
+    client_1->transaction([&](Peer& p) {
+        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
+        auto col_any = p.table("class_Table")->get_column_key("any");
+        obj.set_collection(col_any, CollectionType::Dictionary);
+    });
+
+    client_2->transaction([](Peer& p) {
+        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
+        auto col_any = p.table("class_Table")->get_column_key("any");
+        auto list = obj.get_list<Mixed>(col_any);
+        list.add(42);
+    });
+
+    synchronize(server.get(), {client_1.get(), client_2.get()});
+
+    ReadTransaction read_server(server->shared_group);
+    ReadTransaction read_client_1(client_1->shared_group);
+    ReadTransaction read_client_2(client_2->shared_group);
+    CHECK(compare_groups(read_server, read_client_1));
+    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
+    auto table = read_server.get_table("class_Table");
+    auto col_any = table->get_column_key("any");
+    CHECK(table->get_object_with_primary_key(1).get_dictionary(col_any).is_empty());
+}
+
+TEST(Transform_Nested_CreateDictionaryVsArrayInsert)
+{
+    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
+    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
+    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
+    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
+
+    // Create baseline
+    client_1->transaction([&](Peer& c) {
+        auto& tr = *c.group;
+        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
+        auto col_any = table->add_column(type_Mixed, "any");
+        auto obj = table->create_object_with_primary_key(1);
+        obj.set_collection(col_any, CollectionType::Dictionary);
+        auto dict = obj.get_dictionary_ptr(col_any);
+        dict->insert_collection("A", CollectionType::List);
+        auto list = dict->get_list("A");
+        list->insert_collection(0, CollectionType::Dictionary);
+        auto dict2 = list->get_dictionary(0);
+        dict2->insert_collection("B", CollectionType::List);
+    });
+
+    synchronize(server.get(), {client_1.get(), client_2.get()});
+
+    client_1->transaction([&](Peer& p) {
+        auto col_any = p.table("class_Table")->get_column_key("any");
+        auto dict = p.table("class_Table")->get_object_with_primary_key(1).get_dictionary_ptr({col_any, "A", 0});
+        dict->insert_collection("B", CollectionType::Dictionary);
+    });
+
+    client_2->transaction([](Peer& p) {
+        auto col_any = p.table("class_Table")->get_column_key("any");
+        auto list =
+            p.table("class_Table")->get_object_with_primary_key(1).get_list_ptr<Mixed>({col_any, "A", 0, "B"});
+        list->add(42);
+    });
+
+    synchronize(server.get(), {client_1.get(), client_2.get()});
+
+    ReadTransaction read_server(server->shared_group);
+    ReadTransaction read_client_1(client_1->shared_group);
+    ReadTransaction read_client_2(client_2->shared_group);
+    CHECK(compare_groups(read_server, read_client_1));
+    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
+    auto table = read_server.get_table("class_Table");
+    auto col_any = table->get_column_key("any");
+    CHECK(table->get_object_with_primary_key(1).get_dictionary_ptr({col_any, "A", 0, "B"})->is_empty());
+}
+
+TEST(Transform_CreateListBeforeUpdateInt)
+{
+    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
+    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
+    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
+    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
+
+    // Create baseline
+    client_1->transaction([&](Peer& c) {
+        auto& tr = *c.group;
+        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
+        table->add_column(type_Mixed, "any");
+        table->create_object_with_primary_key(1);
+    });
+
+    synchronize(server.get(), {client_1.get(), client_2.get()});
+
+    client_1->history.set_time(1);
+    client_2->history.set_time(2);
+
+    client_1->transaction([&](Peer& p) {
+        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
+        auto col_any = p.table("class_Table")->get_column_key("any");
+        obj.set_collection(col_any, CollectionType::List);
+    });
+
+    client_2->transaction([&](Peer& p) {
+        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
+        obj.set_any("any", 42);
+    });
+
+    synchronize(server.get(), {client_1.get(), client_2.get()});
+
+    ReadTransaction read_server(server->shared_group);
+    ReadTransaction read_client_1(client_1->shared_group);
+    ReadTransaction read_client_2(client_2->shared_group);
+    CHECK(compare_groups(read_server, read_client_1));
+    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
+    auto table = read_server.get_table("class_Table");
+    CHECK_EQUAL(table->get_object_with_primary_key(1).get_any("any"), 42);
+}
+
+TEST(Transform_CreateListAfterUpdateInt)
+{
+    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
+    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
+    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
+    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
+
+    // Create baseline
+    client_1->transaction([&](Peer& c) {
+        auto& tr = *c.group;
+        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
+        table->add_column(type_Mixed, "any");
+        table->create_object_with_primary_key(1);
+    });
+
+    synchronize(server.get(), {client_1.get(), client_2.get()});
+
+    client_2->history.set_time(1);
+    client_1->history.set_time(2);
+
+    client_1->transaction([&](Peer& p) {
+        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
+        auto col_any = p.table("class_Table")->get_column_key("any");
+        obj.set_collection(col_any, CollectionType::List);
+    });
+
+    client_2->transaction([&](Peer& p) {
+        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
+        obj.set_any("any", 42);
+    });
+
+    synchronize(server.get(), {client_1.get(), client_2.get()});
+
+    ReadTransaction read_server(server->shared_group);
+    ReadTransaction read_client_1(client_1->shared_group);
+    ReadTransaction read_client_2(client_2->shared_group);
+    CHECK(compare_groups(read_server, read_client_1));
+    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
+    auto table = read_server.get_table("class_Table");
+    CHECK(table->get_object_with_primary_key(1).get_list<Mixed>("any").is_empty());
+}
+
+TEST(Transform_Nested_CreateListBeforeUpdateInt)
+{
+    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
+    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
+    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
+    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
+
+    // Create baseline
+    client_1->transaction([&](Peer& c) {
+        auto& tr = *c.group;
+        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
+        auto col_any = table->add_column(type_Mixed, "any");
+        auto obj = table->create_object_with_primary_key(1);
+        obj.set_collection(col_any, CollectionType::Dictionary);
+        auto dict = obj.get_dictionary_ptr(col_any);
+        dict->insert_collection("A", CollectionType::List);
+        auto list = dict->get_list("A");
+        list->insert_collection(0, CollectionType::Dictionary);
+        auto dict2 = list->get_dictionary(0);
+        dict2->insert("B", "some value");
+    });
+
+    synchronize(server.get(), {client_1.get(), client_2.get()});
+
+    client_1->history.set_time(1);
+    client_2->history.set_time(2);
+
+    client_1->transaction([&](Peer& p) {
+        auto col_any = p.table("class_Table")->get_column_key("any");
+        auto dict = p.table("class_Table")->get_object_with_primary_key(1).get_dictionary_ptr({col_any, "A", 0});
+        dict->insert_collection("B", CollectionType::List);
+    });
+
+    client_2->transaction([](Peer& p) {
+        auto col_any = p.table("class_Table")->get_column_key("any");
+        auto dict = p.table("class_Table")->get_object_with_primary_key(1).get_dictionary_ptr({col_any, "A", 0});
+        dict->insert("B", 42);
+    });
+
+    synchronize(server.get(), {client_1.get(), client_2.get()});
+
+    ReadTransaction read_server(server->shared_group);
+    ReadTransaction read_client_1(client_1->shared_group);
+    ReadTransaction read_client_2(client_2->shared_group);
+    CHECK(compare_groups(read_server, read_client_1));
+    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
+    auto table = read_server.get_table("class_Table");
+    auto col_any = table->get_column_key("any");
+    CHECK_EQUAL(table->get_object_with_primary_key(1).get_dictionary_ptr({col_any, "A", 0})->get("B"), 42);
+}
+
+TEST(Transform_CreateDictionaryBeforeUpdateInt)
+{
+    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
+    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
+    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
+    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
+
+    // Create baseline
+    client_1->transaction([&](Peer& c) {
+        auto& tr = *c.group;
+        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
+        table->add_column(type_Mixed, "any");
+        table->create_object_with_primary_key(1);
+    });
+
+    synchronize(server.get(), {client_1.get(), client_2.get()});
+
+    client_1->history.set_time(1);
+    client_2->history.set_time(2);
+
+    client_1->transaction([&](Peer& p) {
+        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
+        auto col_any = p.table("class_Table")->get_column_key("any");
+        obj.set_collection(col_any, CollectionType::Dictionary);
+    });
+
+    client_2->transaction([&](Peer& p) {
+        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
+        obj.set_any("any", 42);
+    });
+
+    synchronize(server.get(), {client_1.get(), client_2.get()});
+
+    ReadTransaction read_server(server->shared_group);
+    ReadTransaction read_client_1(client_1->shared_group);
+    ReadTransaction read_client_2(client_2->shared_group);
+    CHECK(compare_groups(read_server, read_client_1));
+    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
+    auto table = read_server.get_table("class_Table");
+    CHECK_EQUAL(table->get_object_with_primary_key(1).get_any("any"), 42);
+}
+
+TEST(Transform_CreateDictionaryAfterUpdateInt)
+{
+    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
+    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
+    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
+    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
+
+    // Create baseline
+    client_1->transaction([&](Peer& c) {
+        auto& tr = *c.group;
+        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
+        table->add_column(type_Mixed, "any");
+        table->create_object_with_primary_key(1);
+    });
+
+    synchronize(server.get(), {client_1.get(), client_2.get()});
+
+    client_2->history.set_time(1);
+    client_1->history.set_time(2);
+
+    client_1->transaction([&](Peer& p) {
+        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
+        auto col_any = p.table("class_Table")->get_column_key("any");
+        obj.set_collection(col_any, CollectionType::Dictionary);
+    });
+
+    client_2->transaction([&](Peer& p) {
+        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
+        obj.set_any("any", 42);
+    });
+
+    synchronize(server.get(), {client_1.get(), client_2.get()});
+
+    ReadTransaction read_server(server->shared_group);
+    ReadTransaction read_client_1(client_1->shared_group);
+    ReadTransaction read_client_2(client_2->shared_group);
+    CHECK(compare_groups(read_server, read_client_1));
+    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
+    auto table = read_server.get_table("class_Table");
+    CHECK(table->get_object_with_primary_key(1).get_dictionary("any").is_empty());
+}
+
+TEST(Transform_Nested_CreateDictionaryAfterUpdateInt)
+{
+    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
+    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
+    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
+    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
+
+    // Create baseline
+    client_1->transaction([&](Peer& c) {
+        auto& tr = *c.group;
+        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
+        auto col_any = table->add_column(type_Mixed, "any");
+        auto obj = table->create_object_with_primary_key(1);
+        obj.set_collection(col_any, CollectionType::Dictionary);
+        auto dict = obj.get_dictionary_ptr(col_any);
+        dict->insert_collection("A", CollectionType::List);
+        auto list = dict->get_list("A");
+        list->insert_collection(0, CollectionType::Dictionary);
+        auto dict2 = list->get_dictionary(0);
+        dict2->insert("B", "some value");
+    });
+
+    synchronize(server.get(), {client_1.get(), client_2.get()});
+
+    client_2->history.set_time(1);
+    client_1->history.set_time(2);
+
+    client_1->transaction([&](Peer& p) {
+        auto col_any = p.table("class_Table")->get_column_key("any");
+        auto dict = p.table("class_Table")->get_object_with_primary_key(1).get_dictionary_ptr({col_any, "A", 0});
+        dict->insert_collection("B", CollectionType::Dictionary);
+    });
+
+    client_2->transaction([](Peer& p) {
+        auto col_any = p.table("class_Table")->get_column_key("any");
+        auto dict = p.table("class_Table")->get_object_with_primary_key(1).get_dictionary_ptr({col_any, "A", 0});
+        dict->insert("B", 42);
+    });
+
+    synchronize(server.get(), {client_1.get(), client_2.get()});
+
+    ReadTransaction read_server(server->shared_group);
+    ReadTransaction read_client_1(client_1->shared_group);
+    ReadTransaction read_client_2(client_2->shared_group);
+    CHECK(compare_groups(read_server, read_client_1));
+    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
+    auto table = read_server.get_table("class_Table");
+    auto col_any = table->get_column_key("any");
+    CHECK(table->get_object_with_primary_key(1).get_dictionary_ptr({col_any, "A", 0, "B"})->is_empty());
+}
+
+TEST(Transform_MergeLists)
+{
+    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
+    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
+    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
+    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
+
+    // Create baseline
+    client_1->transaction([&](Peer& c) {
+        auto& tr = *c.group;
+        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
+        table->add_column(type_Mixed, "any");
+        auto obj = table->create_object_with_primary_key(1);
+    });
+
+    synchronize(server.get(), {client_1.get(), client_2.get()});
+
+    client_1->history.set_time(1);
+    client_2->history.set_time(2);
+
+    client_1->transaction([&](Peer& p) {
+        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
+        auto col_any = p.table("class_Table")->get_column_key("any");
+        obj.set_collection(col_any, CollectionType::List);
+        auto list = obj.get_list<Mixed>(col_any);
+        list.insert(0, "a");
+        list.insert(1, "b");
+    });
+
+    client_2->transaction([&](Peer& p) {
+        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
+        auto col_any = p.table("class_Table")->get_column_key("any");
+        obj.set_collection(col_any, CollectionType::List);
+        auto list = obj.get_list<Mixed>(col_any);
+        list.insert(0, "c");
+        list.insert(1, "d");
+    });
+
+    synchronize(server.get(), {client_1.get(), client_2.get()});
+
+    ReadTransaction read_server(server->shared_group);
+    ReadTransaction read_client_1(client_1->shared_group);
+    ReadTransaction read_client_2(client_2->shared_group);
+    CHECK(compare_groups(read_server, read_client_1));
+    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
+    auto table = read_server.get_table("class_Table");
+    auto col_any = table->get_column_key("any");
+    auto list = table->get_object_with_primary_key(1).get_list_ptr<Mixed>(col_any);
+    CHECK_EQUAL(list->size(), 4);
+    CHECK_EQUAL(list->get(0), "a");
+    CHECK_EQUAL(list->get(1), "b");
+    CHECK_EQUAL(list->get(2), "c");
+    CHECK_EQUAL(list->get(3), "d");
+}
+
+TEST(Transform_Nested_MergeLists)
+{
+    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
+    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
+    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
+    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
+
+    // Create baseline
+    client_1->transaction([&](Peer& c) {
+        auto& tr = *c.group;
+        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
+        auto col_any = table->add_column(type_Mixed, "any");
+        auto obj = table->create_object_with_primary_key(1);
+        obj.set_collection(col_any, CollectionType::Dictionary);
+        auto dict = obj.get_dictionary_ptr(col_any);
+        dict->insert_collection("A", CollectionType::List);
+        auto list = dict->get_list("A");
+        list->insert_collection(0, CollectionType::Dictionary);
+        auto dict2 = list->get_dictionary(0);
+        dict2->insert_collection("B", CollectionType::Dictionary);
+    });
+
+    synchronize(server.get(), {client_1.get(), client_2.get()});
+
+    client_1->history.set_time(1);
+    client_2->history.set_time(2);
+
+    client_1->transaction([&](Peer& p) {
+        auto col_any = p.table("class_Table")->get_column_key("any");
+        auto dict = p.table("class_Table")->get_object_with_primary_key(1).get_dictionary_ptr({col_any, "A", 0});
+        dict->insert_collection("B", CollectionType::List);
+        auto list = dict->get_list("B");
+        list->insert(0, "a");
+        list->insert(1, "b");
+    });
+
+    client_2->transaction([](Peer& p) {
+        auto col_any = p.table("class_Table")->get_column_key("any");
+        auto dict = p.table("class_Table")->get_object_with_primary_key(1).get_dictionary_ptr({col_any, "A", 0});
+        dict->insert_collection("B", CollectionType::List);
+        auto list = dict->get_list("B");
+        list->insert(0, "c");
+        list->insert(1, "d");
+    });
+
+    synchronize(server.get(), {client_1.get(), client_2.get()});
+
+    ReadTransaction read_server(server->shared_group);
+    ReadTransaction read_client_1(client_1->shared_group);
+    ReadTransaction read_client_2(client_2->shared_group);
+    CHECK(compare_groups(read_server, read_client_1));
+    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
+    auto table = read_server.get_table("class_Table");
+    auto col_any = table->get_column_key("any");
+    auto list = table->get_object_with_primary_key(1).get_list_ptr<Mixed>({col_any, "A", 0, "B"});
+    CHECK_EQUAL(list->size(), 4);
+    CHECK_EQUAL(list->get(0), "a");
+    CHECK_EQUAL(list->get(1), "b");
+    CHECK_EQUAL(list->get(2), "c");
+    CHECK_EQUAL(list->get(3), "d");
+}
+
+TEST(Transform_MergeDictionaries)
+{
+    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
+    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
+    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
+    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
+
+    // Create baseline
+    client_1->transaction([&](Peer& c) {
+        auto& tr = *c.group;
+        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
+        table->add_column(type_Mixed, "any");
+        auto obj = table->create_object_with_primary_key(1);
+    });
+
+    synchronize(server.get(), {client_1.get(), client_2.get()});
+
+    client_1->history.set_time(1);
+    client_2->history.set_time(2);
+
+    client_1->transaction([&](Peer& p) {
+        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
+        auto col_any = p.table("class_Table")->get_column_key("any");
+        obj.set_collection(col_any, CollectionType::Dictionary);
+        auto list = obj.get_dictionary(col_any);
+        list.insert("key1", "a");
+        list.insert("key2", "b");
+    });
+
+    client_2->transaction([&](Peer& p) {
+       auto obj = p.table("class_Table")->get_object_with_primary_key(1);
+        auto col_any = p.table("class_Table")->get_column_key("any");
+        obj.set_collection(col_any, CollectionType::Dictionary);
+        auto list = obj.get_dictionary(col_any);
+        list.insert("key2", "y");
+        list.insert("key3", "z");
+    });
+
+    synchronize(server.get(), {client_1.get(), client_2.get()});
+
+    ReadTransaction read_server(server->shared_group);
+    ReadTransaction read_client_1(client_1->shared_group);
+    ReadTransaction read_client_2(client_2->shared_group);
+    CHECK(compare_groups(read_server, read_client_1));
+    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
+    auto table = read_server.get_table("class_Table");
+    auto col_any = table->get_column_key("any");
+    auto dict = table->get_object_with_primary_key(1).get_dictionary(col_any);
+    CHECK_EQUAL(dict.size(), 3);
+    CHECK_EQUAL(dict.get("key1"), "a");
+    CHECK_EQUAL(dict.get("key2"), "y");
+    CHECK_EQUAL(dict.get("key3"), "z");
+}
+
+TEST(Transform_Nested_MergeDictionaries)
+{
+    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
+    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
+    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
+    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
+
+    // Create baseline
+    client_1->transaction([&](Peer& c) {
+        auto& tr = *c.group;
+        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
+        auto col_any = table->add_column(type_Mixed, "any");
+        auto obj = table->create_object_with_primary_key(1);
+        obj.set_collection(col_any, CollectionType::Dictionary);
+        auto dict = obj.get_dictionary_ptr(col_any);
+        dict->insert_collection("A", CollectionType::List);
+        auto list = dict->get_list("A");
+        list->insert_collection(0, CollectionType::Dictionary);
+        auto dict2 = list->get_dictionary(0);
+        dict2->insert_collection("B", CollectionType::List);
+    });
+
+    synchronize(server.get(), {client_1.get(), client_2.get()});
+
+    client_1->history.set_time(1);
+    client_2->history.set_time(2);
+
+    client_1->transaction([&](Peer& p) {
+        auto col_any = p.table("class_Table")->get_column_key("any");
+        auto dict = p.table("class_Table")->get_object_with_primary_key(1).get_dictionary_ptr({col_any, "A", 0});
+        dict->insert_collection("B", CollectionType::Dictionary);
+        auto dict2 = dict->get_dictionary("B");
+        dict2->insert("key1", "a");
+        dict2->insert("key2", "b");
+    });
+
+    client_2->transaction([](Peer& p) {
+        auto col_any = p.table("class_Table")->get_column_key("any");
+        auto dict = p.table("class_Table")->get_object_with_primary_key(1).get_dictionary_ptr({col_any, "A", 0});
+        dict->insert_collection("B", CollectionType::Dictionary);
+        auto dict2 = dict->get_dictionary("B");
+        dict2->insert("key2", "y");
+        dict2->insert("key3", "z");
+    });
+
+    synchronize(server.get(), {client_1.get(), client_2.get()});
+
+    ReadTransaction read_server(server->shared_group);
+    ReadTransaction read_client_1(client_1->shared_group);
+    ReadTransaction read_client_2(client_2->shared_group);
+    CHECK(compare_groups(read_server, read_client_1));
+    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
+    auto table = read_server.get_table("class_Table");
+    auto col_any = table->get_column_key("any");
+    auto dict = table->get_object_with_primary_key(1).get_dictionary_ptr({col_any, "A", 0, "B"});
+    CHECK_EQUAL(dict->size(), 3);
+    CHECK_EQUAL(dict->get("key1"), "a");
+    CHECK_EQUAL(dict->get("key2"), "y");
+    CHECK_EQUAL(dict->get("key3"), "z");
+}
+
+TEST(Transform_CreateListAfterCreateDictionary)
+{
+    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
+    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
+    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
+    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
+
+    // Create baseline
+    client_1->transaction([&](Peer& c) {
+        auto& tr = *c.group;
+        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
+        table->add_column(type_Mixed, "any");
+        auto obj = table->create_object_with_primary_key(1);
+    });
+
+    synchronize(server.get(), {client_1.get(), client_2.get()});
+
+    client_2->history.set_time(1);
+    client_1->history.set_time(2);
+
+    client_1->transaction([&](Peer& p) {
+        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
+        auto col_any = p.table("class_Table")->get_column_key("any");
+        obj.set_collection(col_any, CollectionType::List);
+        auto list = obj.get_list<Mixed>(col_any);
+        list.insert(0, "a");
+        list.insert(1, "b");
+    });
+
+    client_2->transaction([&](Peer& p) {
+        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
+        auto col_any = p.table("class_Table")->get_column_key("any");
+        obj.set_collection(col_any, CollectionType::Dictionary);
+        auto dict = obj.get_dictionary(col_any);
+        dict.insert("key1", "a");
+        dict.insert("key2", "b");
+    });
+
+    synchronize(server.get(), {client_1.get(), client_2.get()});
+
+    ReadTransaction read_server(server->shared_group);
+    ReadTransaction read_client_1(client_1->shared_group);
+    ReadTransaction read_client_2(client_2->shared_group);
+    CHECK(compare_groups(read_server, read_client_1));
+    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
+    auto table = read_server.get_table("class_Table");
+    auto col_any = table->get_column_key("any");
+    auto list = table->get_object_with_primary_key(1).get_list_ptr<Mixed>(col_any);
+    CHECK_EQUAL(list->size(), 2);
+    CHECK_EQUAL(list->get(0), "a");
+    CHECK_EQUAL(list->get(1), "b");
+}
+
+TEST(Transform_CreateListBeforeCreateDictionary)
+{
+    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
+    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
+    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
+    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
+
+    // Create baseline
+    client_1->transaction([&](Peer& c) {
+        auto& tr = *c.group;
+        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
+        table->add_column(type_Mixed, "any");
+        auto obj = table->create_object_with_primary_key(1);
+    });
+
+    synchronize(server.get(), {client_1.get(), client_2.get()});
+
+    client_1->history.set_time(1);
+    client_2->history.set_time(2);
+
+    client_1->transaction([&](Peer& p) {
+        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
+        auto col_any = p.table("class_Table")->get_column_key("any");
+        obj.set_collection(col_any, CollectionType::List);
+        auto list = obj.get_list<Mixed>(col_any);
+        list.insert(0, "a");
+        list.insert(1, "b");
+    });
+
+    client_2->transaction([&](Peer& p) {
+        auto obj = p.table("class_Table")->get_object_with_primary_key(1);
+        auto col_any = p.table("class_Table")->get_column_key("any");
+        obj.set_collection(col_any, CollectionType::Dictionary);
+        auto dict = obj.get_dictionary(col_any);
+        dict.insert("key1", "a");
+        dict.insert("key2", "b");
+    });
+
+    synchronize(server.get(), {client_1.get(), client_2.get()});
+
+    ReadTransaction read_server(server->shared_group);
+    ReadTransaction read_client_1(client_1->shared_group);
+    ReadTransaction read_client_2(client_2->shared_group);
+    CHECK(compare_groups(read_server, read_client_1));
+    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
+    auto table = read_server.get_table("class_Table");
+    auto col_any = table->get_column_key("any");
+    auto dict = table->get_object_with_primary_key(1).get_dictionary_ptr(col_any);
+    CHECK_EQUAL(dict->size(), 2);
+    CHECK_EQUAL(dict->get("key1"), "a");
+    CHECK_EQUAL(dict->get("key2"), "b");
+}
+
+TEST(Transform_Nested_CreateListAfterCreateDictionary)
+{
+    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
+    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
+    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
+    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
+
+    // Create baseline
+    client_1->transaction([&](Peer& c) {
+        auto& tr = *c.group;
+        TableRef table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
+        auto col_any = table->add_column(type_Mixed, "any");
+        auto obj = table->create_object_with_primary_key(1);
+        obj.set_collection(col_any, CollectionType::Dictionary);
+        auto dict = obj.get_dictionary_ptr(col_any);
+        dict->insert_collection("A", CollectionType::List);
+        auto list = dict->get_list("A");
+        list->insert_collection(0, CollectionType::Dictionary);
+    });
+
+    synchronize(server.get(), {client_1.get(), client_2.get()});
+
+    client_2->history.set_time(1);
+    client_1->history.set_time(2);
+
+    client_1->transaction([&](Peer& p) {
+        auto col_any = p.table("class_Table")->get_column_key("any");
+        auto dict = p.table("class_Table")->get_object_with_primary_key(1).get_dictionary_ptr({col_any, "A", 0});
+        dict->insert_collection("B", CollectionType::List);
+        auto list = dict->get_list("B");
+        list->insert(0, "a");
+        list->insert(1, "b");
+    });
+
+    client_2->transaction([](Peer& p) {
+        auto col_any = p.table("class_Table")->get_column_key("any");
+        auto dict = p.table("class_Table")->get_object_with_primary_key(1).get_dictionary_ptr({col_any, "A", 0});
+        dict->insert_collection("B", CollectionType::Dictionary);
+        auto dict2 = dict->get_dictionary("B");
+        dict2->insert("key1", "a");
+        dict2->insert("key2", "b");
+    });
+
+    synchronize(server.get(), {client_1.get(), client_2.get()});
+
+    ReadTransaction read_server(server->shared_group);
+    ReadTransaction read_client_1(client_1->shared_group);
+    ReadTransaction read_client_2(client_2->shared_group);
+    CHECK(compare_groups(read_server, read_client_1));
+    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
+    auto table = read_server.get_table("class_Table");
+    auto col_any = table->get_column_key("any");
+    auto list = table->get_object_with_primary_key(1).get_list_ptr<Mixed>({col_any, "A", 0, "B"});
+    CHECK_EQUAL(list->size(), 2);
+    CHECK_EQUAL(list->get(0), "a");
+    CHECK_EQUAL(list->get(1), "b");
+}


### PR DESCRIPTION
## What, How & Why?
Add support to sync collections of Mixed (i.e, List\<Dictionary\>).

This PR contains:

1. Updates to OT rules to account for collections of mixed
2. Set of tests to exercise the OT changes and the InstructionApplier
3. Bug fix (resulting in a crash) of AddInteger (with a higher timestamp) vs Update(other_type) OT rule for Mixed fields

Note: it's easier to review each commit individually.

<details>
<summary>Test Plan:</summary>

Same level of nesting (both on Mixed properties and nested collections):

* CreateArray vs AddInteger (only on Mixed properties)
* CreateDictionary vs AddInteger (only on Mixed properties)
* CreateArray vs UpdateInt
* CreateDictionary vs UpdateInt
* ArrayInsert vs ArrayInsert
* DictionaryInsert vs DictionaryInsert
* CreateArray vs CreateDictionary
* ClearArray vs UpdateString
* ClearArray vs CreateArray
* ClearArray vs CreateDictionary
* ClearDictionary vs CreateArray
* ClearDictionary vs CreateDictionary

Different level of nesting:

* CreateArray vs ArrayInsert
* CreateArray vs DictionaryInsert
* CreateDictionary vs DictionaryInsert
* CreateDictionary vs ArrayInsert
* ArrayInsert vs UpdateString
* ClearArray vs DictionaryInsert
</details>

## ☑️ ToDos
* [x] 📝 Changelog update
* [X] 🚦 Tests (or not relevant)
* ~~[ ] C-API, if public C++ API changed~~
* ~~[ ] `bindgen/spec.yml`, if public C++ API changed~~
