### PR TITLE
WIP in order to exploit subword parallel search for ArrayEncode::find()

### DIFF
--- a/src/realm/array_direct.hpp
+++ b/src/realm/array_direct.hpp
@@ -283,7 +283,6 @@ inline bool operator<(const bf_iterator& a, const bf_iterator& b)
     return a.field_position < b.field_position;
 }
 
-
 class bf_ref {
     bf_iterator it;
 
@@ -321,6 +320,11 @@ inline void write_bitfield(uint64_t* data_area, size_t field_position, size_t wi
     *it = value;
 }
 
+inline int64_t sign_extend_field_by_mask(size_t sign_mask, uint64_t value)
+{
+    uint64_t sign_extension = 0 - (value & sign_mask);
+    return value | sign_extension;
+}
 
 inline int64_t sign_extend_value(size_t width, uint64_t value)
 {

--- a/src/realm/array_encode.cpp
+++ b/src/realm/array_encode.cpp
@@ -95,7 +95,7 @@ bool ArrayEncode::always_encode(const Array& origin, Array& arr, bool packed) co
 bool ArrayEncode::encode(const Array& origin, Array& arr) const
 {
     // return false;
-    // return always_encode(origin, arr, true); // true packed, false flex
+    return always_encode(origin, arr, true); // true packed, false flex
 
     std::vector<int64_t> values;
     std::vector<size_t> indices;

--- a/src/realm/array_encode.hpp
+++ b/src/realm/array_encode.hpp
@@ -38,13 +38,10 @@ public:
     void init(const char* h);
 
     // init from mem B
-    size_t size() const;
-    size_t width() const;
-
-    inline NodeHeader::Encoding get_encoding() const
-    {
-        return m_encoding;
-    }
+    inline size_t size() const;
+    inline size_t width() const;
+    inline size_t width_mask() const;
+    inline NodeHeader::Encoding get_encoding() const;
 
     // get/set
     int64_t get(const Array&, size_t) const;
@@ -74,10 +71,36 @@ private:
     using Encoding = NodeHeader::Encoding;
     Encoding m_encoding{NodeHeader::Encoding::WTypBits}; // this is not ok .... probably
     size_t m_v_width = 0, m_v_size = 0, m_ndx_width = 0, m_ndx_size = 0;
+    size_t m_v_mask = 0;
 
     friend class ArrayPacked;
     friend class ArrayFlex;
 };
+
+
+inline size_t ArrayEncode::size() const
+{
+    using Encoding = NodeHeader::Encoding;
+    REALM_ASSERT_DEBUG(m_encoding == Encoding::Packed || m_encoding == Encoding::Flex);
+    return m_encoding == Encoding::Packed ? m_v_size : m_ndx_size;
+}
+
+inline size_t ArrayEncode::width() const
+{
+    using Encoding = NodeHeader::Encoding;
+    REALM_ASSERT_DEBUG(m_encoding == Encoding::Packed || m_encoding == Encoding::Flex);
+    return m_v_width;
+}
+
+inline size_t ArrayEncode::width_mask() const
+{
+    return m_v_mask;
+}
+
+inline NodeHeader::Encoding ArrayEncode::get_encoding() const
+{
+    return m_encoding;
+}
 
 } // namespace realm
 #endif // REALM_ARRAY_ENCODE_HPP

--- a/src/realm/array_flex.hpp
+++ b/src/realm/array_flex.hpp
@@ -36,14 +36,16 @@ public:
     std::vector<int64_t> fetch_all_values(const Array& h) const;
     // getters/setters
     int64_t get(const Array&, size_t) const;
-    int64_t get(const char*, size_t, size_t, size_t, size_t, size_t) const;
+    int64_t get(const char*, size_t, size_t, size_t, size_t, size_t, size_t) const;
     void get_chunk(const Array& h, size_t ndx, int64_t res[8]) const;
     void set_direct(const Array&, size_t, int64_t) const;
+    template <typename Cond>
+    bool find_all(const Array&, int64_t, size_t, size_t, size_t, QueryStateBase*) const;
+    int64_t sum(const Array&, size_t, size_t) const;
 
 private:
-    // header inspection
-    static bool get_encode_info(const char*, size_t&, size_t&, size_t&, size_t&);
-    static int64_t do_get(uint64_t*, size_t, size_t, size_t, size_t, size_t);
+    int64_t do_get(uint64_t*, size_t, size_t, size_t, size_t, size_t, size_t) const;
+    bool find_all_match(size_t start, size_t end, size_t baseindex, QueryStateBase* state) const;
 };
 } // namespace realm
 #endif // REALM_ARRAY_COMPRESS_HPP

--- a/src/realm/array_packed.hpp
+++ b/src/realm/array_packed.hpp
@@ -35,19 +35,19 @@ public:
     // encoding/decoding
     void init_array(char*, uint8_t, size_t, size_t) const;
     void copy_data(const Array&, Array&) const;
-    std::vector<int64_t> fetch_all_values(const Array&) const;
     // get or set
     int64_t get(const Array&, size_t) const;
-    int64_t get(const char*, size_t, size_t, size_t) const;
+    int64_t get(const char*, size_t, size_t, size_t, size_t) const;
     void get_chunk(const Array&, size_t, int64_t res[8]) const;
     void set_direct(const Array&, size_t, int64_t) const;
 
-    template <typename F>
-    std::vector<int64_t> find_all(const Array&, int64_t, size_t, size_t, F) const;
+    template <typename Cond>
+    bool find_all(const Array&, int64_t, size_t, size_t, size_t, QueryStateBase*) const;
+    int64_t sum(const Array&, size_t, size_t) const;
 
 private:
-    static void get_encode_info(const char*, size_t&, size_t&);
-    int64_t do_get(uint64_t*, size_t, size_t, size_t) const; // do not expose this!
+    int64_t do_get(uint64_t*, size_t, size_t, size_t, size_t) const;
+    bool find_all_match(size_t start, size_t end, size_t baseindex, QueryStateBase* state) const;
 };
 } // namespace realm
 

--- a/src/realm/array_unsigned.cpp
+++ b/src/realm/array_unsigned.cpp
@@ -46,7 +46,7 @@ inline uint8_t ArrayUnsigned::bit_width(uint64_t value)
 
 inline void ArrayUnsigned::_set(size_t ndx, uint8_t width, uint64_t value)
 {
-    //REALM_ASSERT_DEBUG(!is_encoded()); //why is this failing??
+    // REALM_ASSERT_DEBUG(!is_encoded()); //why is this failing??
     if (width == 8) {
         reinterpret_cast<uint8_t*>(m_data)[ndx] = uint8_t(value);
     }
@@ -63,7 +63,7 @@ inline void ArrayUnsigned::_set(size_t ndx, uint8_t width, uint64_t value)
 
 inline uint64_t ArrayUnsigned::_get(size_t ndx, uint8_t width) const
 {
-    //REALM_ASSERT_DEBUG(!is_encoded());
+    // REALM_ASSERT_DEBUG(!is_encoded());
     if (width == 8) {
         return reinterpret_cast<uint8_t*>(m_data)[ndx];
     }
@@ -175,7 +175,7 @@ size_t ArrayUnsigned::upper_bound(uint64_t value) const noexcept
 
 void ArrayUnsigned::insert(size_t ndx, uint64_t value)
 {
-    //REALM_ASSERT_DEBUG(!is_encoded());
+    // REALM_ASSERT_DEBUG(!is_encoded());
     REALM_ASSERT_DEBUG(m_width >= 8);
 
     bool do_expand = value > (uint64_t)m_ubound;
@@ -224,7 +224,7 @@ void ArrayUnsigned::insert(size_t ndx, uint64_t value)
 
 void ArrayUnsigned::erase(size_t ndx)
 {
-    //REALM_ASSERT_DEBUG(!is_encoded());
+    // REALM_ASSERT_DEBUG(!is_encoded());
     REALM_ASSERT_DEBUG(m_width >= 8);
 
     copy_on_write(); // Throws
@@ -249,7 +249,7 @@ uint64_t ArrayUnsigned::get(size_t index) const
 
 void ArrayUnsigned::set(size_t ndx, uint64_t value)
 {
-    //REALM_ASSERT_DEBUG(!is_encoded()); //todo this is failing
+    // REALM_ASSERT_DEBUG(!is_encoded()); //todo this is failing
     REALM_ASSERT_DEBUG(m_width >= 8);
     copy_on_write(); // Throws
 

--- a/src/realm/array_with_find.hpp
+++ b/src/realm/array_with_find.hpp
@@ -290,6 +290,7 @@ REALM_NOINLINE bool ArrayWithFind::find_all_will_match(size_t start2, size_t end
     return true;
 }
 
+
 // This is the main finding function for Array. Other finding functions are just
 // wrappers around this one. Search for 'value' using condition cond (Equal,
 // NotEqual, Less, etc) and call QueryStateBase::match() for each match. Break and

--- a/src/realm/parser/generated/query_flex.cpp
+++ b/src/realm/parser/generated/query_flex.cpp
@@ -101,6 +101,7 @@ typedef int16_t flex_int16_t;
 typedef uint16_t flex_uint16_t;
 typedef int32_t flex_int32_t;
 typedef uint32_t flex_uint32_t;
+typedef uint64_t flex_uint64_t;
 #else
 typedef signed char flex_int8_t;
 typedef short int flex_int16_t;
@@ -330,7 +331,7 @@ struct yy_buffer_state
 	/* Number of characters read into yy_ch_buf, not including EOB
 	 * characters.
 	 */
-	int yy_n_chars;
+	yy_size_t yy_n_chars;
 
 	/* Whether we "own" the buffer - i.e., we know we created it,
 	 * and can realloc() it to grow it, and should free() it to
@@ -428,7 +429,7 @@ static void yy_init_buffer ( YY_BUFFER_STATE b, FILE *file , yyscan_t yyscanner 
 
 YY_BUFFER_STATE yy_scan_buffer ( char *base, yy_size_t size , yyscan_t yyscanner );
 YY_BUFFER_STATE yy_scan_string ( const char *yy_str , yyscan_t yyscanner );
-YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, int len , yyscan_t yyscanner );
+YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, yy_size_t len , yyscan_t yyscanner );
 
 /* %endif */
 
@@ -495,7 +496,7 @@ static void yynoreturn yy_fatal_error ( const char* msg , yyscan_t yyscanner );
 #define YY_DO_BEFORE_ACTION \
 	yyg->yytext_ptr = yy_bp; \
 /* %% [2.0] code to fiddle yytext and yyleng for yymore() goes here \ */\
-	yyleng = (int) (yy_cp - yy_bp); \
+	yyleng = (yy_size_t) (yy_cp - yy_bp); \
 	yyg->yy_hold_char = *yy_cp; \
 	*yy_cp = '\0'; \
 /* %% [3.0] code to copy yytext_ptr to yytext[] goes here, if %array \ */\
@@ -1243,8 +1244,8 @@ struct yyguts_t
     size_t yy_buffer_stack_max; /**< capacity of stack. */
     YY_BUFFER_STATE * yy_buffer_stack; /**< Stack as an array. */
     char yy_hold_char;
-    int yy_n_chars;
-    int yyleng_r;
+    yy_size_t yy_n_chars;
+    yy_size_t yyleng_r;
     char *yy_c_buf_p;
     int yy_init;
     int yy_start;
@@ -1336,7 +1337,7 @@ void yyset_out  ( FILE * _out_str , yyscan_t yyscanner );
 
 
 
-			int yyget_leng ( yyscan_t yyscanner );
+			yy_size_t yyget_leng ( yyscan_t yyscanner );
 
 
 
@@ -1450,7 +1451,7 @@ static int input ( yyscan_t yyscanner );
 	if ( YY_CURRENT_BUFFER_LVALUE->yy_is_interactive ) \
 		{ \
 		int c = '*'; \
-		int n; \
+		yy_size_t n; \
 		for ( n = 0; n < max_size && \
 			     (c = getc( yyin )) != EOF && c != '\n'; ++n ) \
 			buf[n] = (char) c; \
@@ -2180,7 +2181,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 	else
 		{
-			int num_to_read =
+			yy_size_t num_to_read =
 			YY_CURRENT_BUFFER_LVALUE->yy_buf_size - number_to_move - 1;
 
 		while ( num_to_read <= 0 )
@@ -2194,7 +2195,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 			if ( b->yy_is_our_buffer )
 				{
-				int new_size = b->yy_buf_size * 2;
+				yy_size_t new_size = b->yy_buf_size * 2;
 
 				if ( new_size <= 0 )
 					b->yy_buf_size += b->yy_buf_size / 8;
@@ -2252,7 +2253,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 	if ((yyg->yy_n_chars + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
 		/* Extend the array by 50%, plus the number we really need. */
-		int new_size = yyg->yy_n_chars + number_to_move + (yyg->yy_n_chars >> 1);
+		yy_size_t new_size = yyg->yy_n_chars + number_to_move + (yyg->yy_n_chars >> 1);
 		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) yyrealloc(
 			(void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf, (yy_size_t) new_size , yyscanner );
 		if ( ! YY_CURRENT_BUFFER_LVALUE->yy_ch_buf )
@@ -2380,7 +2381,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 		else
 			{ /* need more input */
-			int offset = (int) (yyg->yy_c_buf_p - yyg->yytext_ptr);
+			yy_size_t offset = yyg->yy_c_buf_p - yyg->yytext_ptr;
 			++yyg->yy_c_buf_p;
 
 			switch ( yy_get_next_buffer( yyscanner ) )
@@ -2849,12 +2850,12 @@ YY_BUFFER_STATE yy_scan_string (const char * yystr , yyscan_t yyscanner)
  * @param yyscanner The scanner object.
  * @return the newly allocated buffer state object.
  */
-YY_BUFFER_STATE yy_scan_bytes  (const char * yybytes, int  _yybytes_len , yyscan_t yyscanner)
+YY_BUFFER_STATE yy_scan_bytes  (const char * yybytes, yy_size_t  _yybytes_len , yyscan_t yyscanner)
 {
 	YY_BUFFER_STATE b;
 	char *buf;
 	yy_size_t n;
-	int i;
+	yy_size_t i;
     
 	/* Get memory for full buffer, including space for trailing EOB's. */
 	n = (yy_size_t) (_yybytes_len + 2);
@@ -2913,7 +2914,7 @@ static void yynoreturn yy_fatal_error (const char* msg , yyscan_t yyscanner)
 	do \
 		{ \
 		/* Undo effects of setting up yytext. */ \
-        int yyless_macro_arg = (n); \
+        yy_size_t yyless_macro_arg = (n); \
         YY_LESS_LINENO(yyless_macro_arg);\
 		yytext[yyleng] = yyg->yy_hold_char; \
 		yyg->yy_c_buf_p = yytext + yyless_macro_arg; \
@@ -3001,7 +3002,7 @@ FILE *yyget_out  (yyscan_t yyscanner)
 /** Get the length of the current token.
  * @param yyscanner The scanner object.
  */
-int yyget_leng  (yyscan_t yyscanner)
+yy_size_t yyget_leng  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     return yyleng;

--- a/src/realm/parser/generated/query_flex.hpp
+++ b/src/realm/parser/generated/query_flex.hpp
@@ -100,6 +100,7 @@ typedef int16_t flex_int16_t;
 typedef uint16_t flex_uint16_t;
 typedef int32_t flex_int32_t;
 typedef uint32_t flex_uint32_t;
+typedef uint64_t flex_uint64_t;
 #else
 typedef signed char flex_int8_t;
 typedef short int flex_int16_t;
@@ -278,7 +279,7 @@ struct yy_buffer_state
 	/* Number of characters read into yy_ch_buf, not including EOB
 	 * characters.
 	 */
-	int yy_n_chars;
+	yy_size_t yy_n_chars;
 
 	/* Whether we "own" the buffer - i.e., we know we created it,
 	 * and can realloc() it to grow it, and should free() it to
@@ -339,7 +340,7 @@ void yypop_buffer_state ( yyscan_t yyscanner );
 
 YY_BUFFER_STATE yy_scan_buffer ( char *base, yy_size_t size , yyscan_t yyscanner );
 YY_BUFFER_STATE yy_scan_string ( const char *yy_str , yyscan_t yyscanner );
-YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, int len , yyscan_t yyscanner );
+YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, yy_size_t len , yyscan_t yyscanner );
 
 /* %endif */
 
@@ -459,7 +460,7 @@ void yyset_out  ( FILE * _out_str , yyscan_t yyscanner );
 
 
 
-			int yyget_leng ( yyscan_t yyscanner );
+			yy_size_t yyget_leng ( yyscan_t yyscanner );
 
 
 

--- a/test/test_array_integer.cpp
+++ b/test/test_array_integer.cpp
@@ -32,7 +32,7 @@
 using namespace realm;
 using namespace realm::test_util;
 
-// #define ARRAY_PERFORMANCE_TESTING
+#define ARRAY_PERFORMANCE_TESTING
 #if !defined(REALM_DEBUG) && defined(ARRAY_PERFORMANCE_TESTING)
 TEST(perf_array_encode_get_vs_array_get)
 {
@@ -129,7 +129,7 @@ TEST(perf_array_encode_get_vs_array_get)
     a_encoded.destroy();
 }
 
-TEST(Test_basic_find)
+ONLY(Test_basic_find)
 {
     using namespace std;
     using namespace std::chrono;
@@ -186,9 +186,9 @@ TEST(Test_basic_find)
         }
     }
     t2 = high_resolution_clock::now();
-    std::cout << "   Positive values - ArrayEncode::find_first(): " << duration_cast<milliseconds>(t2 - t1).count()
-              << " ms" << std::endl;
-    std::cout << "   Positive values - ArrayEncode::find_first(): "
+    std::cout << "   Positive values - ArrayEncode::find(): " << duration_cast<milliseconds>(t2 - t1).count() << " ms"
+              << std::endl;
+    std::cout << "   Positive values - ArrayEncode::find(): "
               << (double)duration_cast<nanoseconds>(t2 - t1).count() / n_values / n_runs << " ns/value" << std::endl;
 
     std::cout << std::endl;
@@ -204,6 +204,12 @@ TEST(Test_basic_find)
     std::shuffle(input_array.begin(), input_array.end(), g1);
     for (const auto& v : input_array)
         a.add(v);
+
+    a.try_encode(a_encoded);
+    CHECK(a_encoded.is_encoded());
+    CHECK(a_encoded.size() == a.size());
+
+    // std::cout << a_encoded.get_width() << std::endl;
 
     // verify that both find the same thing
     for (size_t j = 0; j < n_runs; ++j) {
@@ -222,14 +228,11 @@ TEST(Test_basic_find)
     }
     t2 = high_resolution_clock::now();
 
-    std::cout << "   Negative values - Array::find(): " << duration_cast<nanoseconds>(t2 - t1).count() << " ns"
+    std::cout << "   Negative values - Array::find(): " << duration_cast<milliseconds>(t2 - t1).count() << " ms"
               << std::endl;
     std::cout << "   Negative values - Array::find(): "
               << (double)duration_cast<nanoseconds>(t2 - t1).count() / n_values / n_runs << " ns/value" << std::endl;
 
-    a.try_encode(a_encoded);
-    CHECK(a_encoded.is_encoded());
-    CHECK(a_encoded.size() == a.size());
     t1 = high_resolution_clock::now();
     for (size_t j = 0; j < n_runs; ++j) {
         for (size_t i = 0; i < n_values; ++i) {
@@ -239,9 +242,9 @@ TEST(Test_basic_find)
         }
     }
     t2 = high_resolution_clock::now();
-    std::cout << "   Negative values - ArrayEncode::find_first(): " << duration_cast<nanoseconds>(t2 - t1).count()
-              << " ns" << std::endl;
-    std::cout << "   Negative values - ArrayEncode::find_first(): "
+    std::cout << "   Negative values - ArrayEncode::find(): " << duration_cast<milliseconds>(t2 - t1).count() << " ms"
+              << std::endl;
+    std::cout << "   Negative values - ArrayEncode::find(): "
               << (double)duration_cast<nanoseconds>(t2 - t1).count() / n_values / n_runs << " ns/value" << std::endl;
 
     a.destroy();

--- a/test/test_array_integer.cpp
+++ b/test/test_array_integer.cpp
@@ -32,428 +32,551 @@
 using namespace realm;
 using namespace realm::test_util;
 
+// #define ARRAY_PERFORMANCE_TESTING
+#if !defined(REALM_DEBUG) && defined(ARRAY_PERFORMANCE_TESTING)
 TEST(perf_array_encode_get_vs_array_get)
 {
-    //    using namespace std;
-    //    using namespace std::chrono;
-    //    size_t n_values = 10000000;
-    //    size_t n_runs = 10000;
-    //    std::cout << "   N values = " << n_values << std::endl;
-    //    std::cout << "   N runs = " << n_runs << std::endl;
-    //    ArrayInteger a(Allocator::get_default());
-    //    ArrayInteger a_encoded(Allocator::get_default());
-    //    a.create();
-    //    for (size_t i = 0; i < n_values; i++) {
-    //        a.add(i);
-    //    }
-    //    auto t1 = high_resolution_clock::now();
-    //    for (size_t j = 0; j < n_runs; ++j) {
-    //        for (size_t i = 0; i < n_values; ++i)
-    //            REALM_ASSERT(a.get(i) == (int64_t)i);
-    //    }
-    //    auto t2 = high_resolution_clock::now();
-    //
-    //    std::cout << "   Array::get(): " << duration_cast<nanoseconds>(t2 - t1).count() << " ns" << std::endl;
-    //    std::cout << "   Array::get(): " << (double)duration_cast<nanoseconds>(t2 - t1).count() / n_values / n_runs
-    //              << " ns/value" << std::endl;
-    //
-    //    a.try_encode(a_encoded);
-    //    CHECK(a_encoded.is_encoded());
-    //    t1 = high_resolution_clock::now();
-    //    for (size_t j = 0; j < n_runs; ++j) {
-    //        for (size_t i = 0; i < n_values; ++i)
-    //            REALM_ASSERT(a_encoded.get(i) == (int64_t)i);
-    //    }
-    //    t2 = high_resolution_clock::now();
-    //    std::cout << "   ArrayEncode::get(): " << duration_cast<nanoseconds>(t2 - t1).count() << " ns" << std::endl;
-    //    std::cout << "   ArrayEncode::get(): " << (double)duration_cast<nanoseconds>(t2 - t1).count() / n_values /
-    //    n_runs
-    //              << " ns/value" << std::endl;
+    using namespace std;
+    using namespace std::chrono;
+    size_t n_values = 1000;
+    size_t n_runs = 100;
+    std::cout << "   N values = " << n_values << std::endl;
+    std::cout << "   N runs = " << n_runs << std::endl;
+
+    std::vector<int64_t> input_array;
+    ArrayInteger a(Allocator::get_default());
+    ArrayInteger a_encoded(Allocator::get_default());
+    a.create();
+
+    for (size_t i = 0; i < n_values; i++)
+        input_array.push_back(i);
+    std::random_device rd;
+    std::mt19937 g(rd());
+    std::shuffle(input_array.begin(), input_array.end(), g);
+    for (const auto& v : input_array)
+        a.add(v);
+
+    auto t1 = high_resolution_clock::now();
+    for (size_t j = 0; j < n_runs; ++j) {
+        for (size_t i = 0; i < n_values; ++i)
+            REALM_ASSERT(a.get(i) == input_array[i]);
+    }
+    auto t2 = high_resolution_clock::now();
+
+    std::cout << "   Positive values - Array::get(): " << duration_cast<nanoseconds>(t2 - t1).count() << " ns"
+              << std::endl;
+    std::cout << "   Positive values - Array::get(): "
+              << (double)duration_cast<nanoseconds>(t2 - t1).count() / n_values / n_runs << " ns/value" << std::endl;
+
+    a.try_encode(a_encoded);
+    CHECK(a_encoded.is_encoded());
+    CHECK(a_encoded.size() == a.size());
+    t1 = high_resolution_clock::now();
+
+    for (size_t j = 0; j < n_runs; ++j) {
+        for (size_t i = 0; i < n_values; ++i) {
+            REALM_ASSERT(a_encoded.get(i) == a.get(i));
+        }
+    }
+    t2 = high_resolution_clock::now();
+    std::cout << "   Positive values - ArrayEncode::get(): " << duration_cast<nanoseconds>(t2 - t1).count() << " ns"
+              << std::endl;
+    std::cout << "   Positive values - ArrayEncode::get(): "
+              << (double)duration_cast<nanoseconds>(t2 - t1).count() / n_values / n_runs << " ns/value" << std::endl;
+
+    a.destroy();
+    a_encoded.destroy();
+    a.create();
+    input_array.clear();
+    for (size_t i = 0; i < n_values; i++)
+        input_array.push_back(-i);
+    std::random_device rd1;
+    std::mt19937 g1(rd1());
+    std::shuffle(input_array.begin(), input_array.end(), g1);
+    for (const auto& v : input_array)
+        a.add(v);
+
+    t1 = high_resolution_clock::now();
+    for (size_t j = 0; j < n_runs; ++j) {
+        for (size_t i = 0; i < n_values; ++i)
+            REALM_ASSERT(a.get(i) == input_array[i]);
+    }
+    t2 = high_resolution_clock::now();
+
+    std::cout << std::endl;
+
+    std::cout << "   Negative values - Array::get(): " << duration_cast<nanoseconds>(t2 - t1).count() << " ns"
+              << std::endl;
+    std::cout << "   Negative values - Array::get(): "
+              << (double)duration_cast<nanoseconds>(t2 - t1).count() / n_values / n_runs << " ns/value" << std::endl;
+
+    a.try_encode(a_encoded);
+    CHECK(a_encoded.is_encoded());
+    CHECK(a_encoded.size() == a.size());
+    t1 = high_resolution_clock::now();
+    for (size_t j = 0; j < n_runs; ++j) {
+        for (size_t i = 0; i < n_values; ++i) {
+            REALM_ASSERT(a_encoded.get(i) == a.get(i));
+        }
+    }
+    t2 = high_resolution_clock::now();
+    std::cout << "   Negative values - ArrayEncode::get(): " << duration_cast<nanoseconds>(t2 - t1).count() << " ns"
+              << std::endl;
+    std::cout << "   Negative values - ArrayEncode::get(): "
+              << (double)duration_cast<nanoseconds>(t2 - t1).count() / n_values / n_runs << " ns/value" << std::endl;
+
+    a.destroy();
+    a_encoded.destroy();
 }
 
 TEST(Test_basic_find)
 {
-    //    ArrayInteger a(Allocator::get_default());
-    //    ArrayInteger a_encoded(Allocator::get_default());
-    //    a.create();
-    //    for (size_t i = 1; i <= 15; ++i)
-    //        a.add(i);
-    //    a.try_encode(a_encoded);
-    //    CHECK(a_encoded.is_encoded());
-    //    for (size_t i = 1; i <= 15; ++i)
-    //        CHECK(a.find_first(i) == a_encoded.find_first(i));
-    //
-    //    a_encoded.destroy();
-    //    a.destroy();
-    //    a.create();
-    //    for (size_t i = 1; i <= 15; ++i)
-    //        a.add(-i);
-    //    a.try_encode(a_encoded);
-    //    CHECK(a_encoded.is_encoded());
-    //    for (size_t i = 1; i <= 15; ++i)
-    //        CHECK(a.find_first(-i) == a_encoded.find_first(-i));
-    //    a.destroy();
-    //    a_encoded.destroy();
-    //    a.create();
-    //
-    //    for (size_t i = 1; i <= 50; ++i)
-    //        a.add(i);
-    //    a.try_encode(a_encoded);
-    //    CHECK(a_encoded.is_encoded());
-    //    for (size_t i = 1; i <= 50; ++i)
-    //        CHECK(a.find_first(i) == a_encoded.find_first(i));
-    //    a.destroy();
-    //    a_encoded.destroy();
-    //    a.create();
-    //    for (size_t i = 1; i <= 50; ++i)
-    //        a.add(i);
-    //    for (size_t i = 1; i <= 50; ++i)
-    //        a.add(-i);
-    //    a.try_encode(a_encoded);
-    //    CHECK(a_encoded.is_encoded());
-    //    for (size_t i = 1; i <= 50; ++i) {
-    //        CHECK(a.find_first(i) == a_encoded.find_first(i));
-    //        CHECK(a.find_first(-i) == a_encoded.find_first(-i));
-    //    }
-    //    a.destroy();
-    //    a_encoded.destroy();
-    //    a.create();
-    //    for (size_t i = 32512; i <= 32767; ++i)
-    //        a.add(i);
-    //    a.try_encode(a_encoded);
-    //    CHECK(a_encoded.is_encoded());
-    //    for (size_t i = 32512; i <= 32767; ++i)
-    //        CHECK(a.find_first(i) == a_encoded.find_first(i));
-    //
-    // #if REALM_DEBUG
-    //    QueryStateFindFirst state;
-    //    a_encoded.find_encoded<Equal>(32764, 82, 256, 0, &state);
-    //    CHECK(state.m_state != realm::npos);
-    // #endif
+    using namespace std;
+    using namespace std::chrono;
+    size_t n_values = 1000;
+    size_t n_runs = 100;
+    std::cout << "   N values = " << n_values << std::endl;
+    std::cout << "   N runs = " << n_runs << std::endl;
+
+    std::vector<int64_t> input_array;
+    ArrayInteger a(Allocator::get_default());
+    ArrayInteger a_encoded(Allocator::get_default());
+    a.create();
+
+    for (size_t i = 0; i < n_values; i++)
+        input_array.push_back(i);
+    std::random_device rd;
+    std::mt19937 g(rd());
+    std::shuffle(input_array.begin(), input_array.end(), g);
+    for (const auto& v : input_array)
+        a.add(v);
+
+    auto t1 = high_resolution_clock::now();
+    for (size_t j = 0; j < n_runs; ++j) {
+        for (size_t i = 0; i < n_values; ++i) {
+            auto ndx = a.find_first(i);
+            REALM_ASSERT(ndx != realm::not_found);
+            REALM_ASSERT(a.get(ndx) == input_array[ndx]);
+        }
+    }
+    auto t2 = high_resolution_clock::now();
+
+    std::cout << "   Positive values - Array::find(): " << duration_cast<milliseconds>(t2 - t1).count() << " ms"
+              << std::endl;
+    std::cout << "   Positive values - Array::find(): "
+              << (double)duration_cast<nanoseconds>(t2 - t1).count() / n_values / n_runs << " ns/value" << std::endl;
+
+    a.try_encode(a_encoded);
+    CHECK(a_encoded.is_encoded());
+    CHECK(a_encoded.size() == a.size());
+
+    // verify that both find the same thing
+    for (size_t j = 0; j < n_runs; ++j) {
+        for (size_t i = 0; i < n_values; ++i) {
+            REALM_ASSERT(a.find_first(i) == a_encoded.find_first(i));
+        }
+    }
+
+    t1 = high_resolution_clock::now();
+    for (size_t j = 0; j < n_runs; ++j) {
+        for (size_t i = 0; i < n_values; ++i) {
+            auto ndx = a_encoded.find_first(i);
+            REALM_ASSERT(ndx != realm::not_found);
+            REALM_ASSERT(a_encoded.get(ndx) == a.get(ndx));
+        }
+    }
+    t2 = high_resolution_clock::now();
+    std::cout << "   Positive values - ArrayEncode::find_first(): " << duration_cast<milliseconds>(t2 - t1).count()
+              << " ms" << std::endl;
+    std::cout << "   Positive values - ArrayEncode::find_first(): "
+              << (double)duration_cast<nanoseconds>(t2 - t1).count() / n_values / n_runs << " ns/value" << std::endl;
+
+    std::cout << std::endl;
+
+    a.destroy();
+    a_encoded.destroy();
+    a.create();
+    input_array.clear();
+    for (size_t i = 0; i < n_values; i++)
+        input_array.push_back(-i);
+    std::random_device rd1;
+    std::mt19937 g1(rd1());
+    std::shuffle(input_array.begin(), input_array.end(), g1);
+    for (const auto& v : input_array)
+        a.add(v);
+
+    // verify that both find the same thing
+    for (size_t j = 0; j < n_runs; ++j) {
+        for (size_t i = 0; i < n_values; ++i) {
+            REALM_ASSERT(a.find_first(-i) == a_encoded.find_first(-i));
+        }
+    }
+
+    t1 = high_resolution_clock::now();
+    for (size_t j = 0; j < n_runs; ++j) {
+        for (size_t i = 0; i < n_values; ++i) {
+            auto ndx = a.find_first(-i);
+            REALM_ASSERT(ndx != realm::not_found);
+            REALM_ASSERT(a.get(ndx) == input_array[ndx]);
+        }
+    }
+    t2 = high_resolution_clock::now();
+
+    std::cout << "   Negative values - Array::find(): " << duration_cast<nanoseconds>(t2 - t1).count() << " ns"
+              << std::endl;
+    std::cout << "   Negative values - Array::find(): "
+              << (double)duration_cast<nanoseconds>(t2 - t1).count() / n_values / n_runs << " ns/value" << std::endl;
+
+    a.try_encode(a_encoded);
+    CHECK(a_encoded.is_encoded());
+    CHECK(a_encoded.size() == a.size());
+    t1 = high_resolution_clock::now();
+    for (size_t j = 0; j < n_runs; ++j) {
+        for (size_t i = 0; i < n_values; ++i) {
+            auto ndx = a_encoded.find_first(-i);
+            REALM_ASSERT(ndx != realm::not_found);
+            REALM_ASSERT(a_encoded.get(ndx) == a.get(ndx));
+        }
+    }
+    t2 = high_resolution_clock::now();
+    std::cout << "   Negative values - ArrayEncode::find_first(): " << duration_cast<nanoseconds>(t2 - t1).count()
+              << " ns" << std::endl;
+    std::cout << "   Negative values - ArrayEncode::find_first(): "
+              << (double)duration_cast<nanoseconds>(t2 - t1).count() / n_values / n_runs << " ns/value" << std::endl;
+
+    a.destroy();
+    a_encoded.destroy();
 }
+#endif
 
 TEST(Test_ArrayInt_no_encode)
 {
-    //    ArrayInteger a(Allocator::get_default());
-    //    ArrayInteger a1(Allocator::get_default());
-    //    a.create();
-    //    a.add(10);
-    //    a.add(11);
-    //    a.add(12);
-    //    // the original array is never encoded. a1 is the array to write down to disk
-    //    // in this case compression is not needed
-    //    CHECK_NOT(a.try_encode(a1));
-    //    CHECK_NOT(a.is_encoded());
-    //    CHECK(a.get(0) == 10);
-    //    CHECK(a.get(1) == 11);
-    //    CHECK(a.get(2) == 12);
-    //    a.destroy();
-    //    a1.destroy();
+    ArrayInteger a(Allocator::get_default());
+    ArrayInteger a1(Allocator::get_default());
+    a.create();
+    a.add(10);
+    a.add(11);
+    a.add(12);
+    // the original array is never encoded. a1 is the array to write down to disk
+    // in this case compression is not needed
+    CHECK_NOT(a.try_encode(a1));
+    CHECK_NOT(a.is_encoded());
+    CHECK(a.get(0) == 10);
+    CHECK(a.get(1) == 11);
+    CHECK(a.get(2) == 12);
+    a.destroy();
+    a1.destroy();
 }
 
 TEST(Test_array_same_size_less_bits)
 {
-    //    ArrayInteger a(Allocator::get_default());
-    //    ArrayInteger a1(Allocator::get_default());
-    //    a.create();
-    //    a.add(1000000);
-    //    a.add(1000000);
-    //    a.add(1000000);
-    //    CHECK(a.try_encode(a1));
-    //    CHECK_NOT(a.is_encoded());
-    //    CHECK(a.get_any(0) == 1000000);
-    //    CHECK(a.get_any(1) == 1000000);
-    //    CHECK(a.get_any(2) == 1000000);
-    //    CHECK(a1.is_encoded());
-    //    CHECK(a1.get_any(0) == 1000000);
-    //    CHECK(a1.get_any(1) == 1000000);
-    //    CHECK(a1.get_any(2) == 1000000);
-    //    a.destroy();
-    //    a1.destroy();
+    ArrayInteger a(Allocator::get_default());
+    ArrayInteger a1(Allocator::get_default());
+    a.create();
+    a.add(1000000);
+    a.add(1000000);
+    a.add(1000000);
+    CHECK(a.try_encode(a1));
+    CHECK_NOT(a.is_encoded());
+    CHECK(a.get_any(0) == 1000000);
+    CHECK(a.get_any(1) == 1000000);
+    CHECK(a.get_any(2) == 1000000);
+    CHECK(a1.is_encoded());
+    CHECK(a1.get_any(0) == 1000000);
+    CHECK(a1.get_any(1) == 1000000);
+    CHECK(a1.get_any(2) == 1000000);
+    a.destroy();
+    a1.destroy();
 }
 
 TEST(Test_ArrayInt_encode_decode_needed)
 {
-    //        ArrayInteger a(Allocator::get_default());
-    //        ArrayInteger a1(Allocator::get_default());
-    //        a.create();
-    //        a.add(10);
-    //        a.add(5);
-    //        a.add(5);
-    //        // uncompressed requires 3 x 4 bits, compressed takes 2 x 5 bits + 3 x 2 bits
-    //        // with 8 byte alignment this is both 16 bytes.
-    //        CHECK_NOT(a.try_encode(a1));
-    //        CHECK_NOT(a.is_encoded());
-    //        a.add(10);
-    //        a.add(15);
-    //        // uncompressed is 5x4 bits, compressed is 3x5 bits + 5x2 bits
-    //        // with 8 byte alignment this is both 16 bytes
-    //        CHECK_NOT(a.try_encode(a1));
-    //        CHECK_NOT(a.is_encoded());
-    //        a.add(10);
-    //        a.add(15);
-    //        a.add(10);
-    //        a.add(15);
-    //        // uncompressed is 9x4 bits, compressed is 3x5 bits + 9x2 bits
-    //        // with 8 byte alignment this is both 16 bytes
-    //        CHECK_NOT(a.try_encode(a1));
-    //        CHECK_NOT(a.is_encoded());
-    //        a.add(-1);
-    //        // the addition of -1 forces the array from unsigned to signed form
-    //        // changing from 4 bits per element to 8 bits.
-    //        // (1,2,4 bit elements are unsigned, larger elements are signed)
-    //        // uncompressed is 10x8 bits, compressed is 3x5 bits + 10x2 bits
-    //        // with alignment, this is 24 bytes uncompressed and 16 bytes compressed
-    //        CHECK(a.try_encode(a1));
-    //        CHECK_NOT(a.is_encoded());
-    //        CHECK(a.get(0) == 10);
-    //        CHECK(a.get(1) == 5);
-    //        CHECK(a.get(2) == 5);
-    //        CHECK(a.get(3) == 10);
-    //        CHECK(a.get(4) == 15);
-    //        CHECK(a1.is_encoded());
-    //        auto v = a1.get(0);
-    //        CHECK(v == a.get(0));
-    //        CHECK(a1.get(1) == a.get(1));
-    //        CHECK(a1.get(2) == a.get(2));
-    //        CHECK(a1.get(3) == a.get(3));
-    //        CHECK(a1.get(4) == a.get(4));
-    //        a.destroy();
-    //        a1.destroy();
+    ArrayInteger a(Allocator::get_default());
+    ArrayInteger a1(Allocator::get_default());
+    a.create();
+    a.add(10);
+    a.add(5);
+    a.add(5);
+    // uncompressed requires 3 x 4 bits, compressed takes 2 x 5 bits + 3 x 2 bits
+    // with 8 byte alignment this is both 16 bytes.
+    CHECK_NOT(a.try_encode(a1));
+    CHECK_NOT(a.is_encoded());
+    a.add(10);
+    a.add(15);
+    // uncompressed is 5x4 bits, compressed is 3x5 bits + 5x2 bits
+    // with 8 byte alignment this is both 16 bytes
+    CHECK_NOT(a.try_encode(a1));
+    CHECK_NOT(a.is_encoded());
+    a.add(10);
+    a.add(15);
+    a.add(10);
+    a.add(15);
+    // uncompressed is 9x4 bits, compressed is 3x5 bits + 9x2 bits
+    // with 8 byte alignment this is both 16 bytes
+    CHECK_NOT(a.try_encode(a1));
+    CHECK_NOT(a.is_encoded());
+    a.add(-1);
+    // the addition of -1 forces the array from unsigned to signed form
+    // changing from 4 bits per element to 8 bits.
+    // (1,2,4 bit elements are unsigned, larger elements are signed)
+    // uncompressed is 10x8 bits, compressed is 3x5 bits + 10x2 bits
+    // with alignment, this is 24 bytes uncompressed and 16 bytes compressed
+    CHECK(a.try_encode(a1));
+    CHECK_NOT(a.is_encoded());
+    CHECK(a.get(0) == 10);
+    CHECK(a.get(1) == 5);
+    CHECK(a.get(2) == 5);
+    CHECK(a.get(3) == 10);
+    CHECK(a.get(4) == 15);
+    CHECK(a1.is_encoded());
+    auto v = a1.get(0);
+    CHECK(v == a.get(0));
+    CHECK(a1.get(1) == a.get(1));
+    CHECK(a1.get(2) == a.get(2));
+    CHECK(a1.get(3) == a.get(3));
+    CHECK(a1.get(4) == a.get(4));
+    a.destroy();
+    a1.destroy();
 }
 
 TEST(Test_ArrayInt_negative_nums)
 {
-    //    ArrayInteger a(Allocator::get_default());
-    //    ArrayInteger a1(Allocator::get_default());
-    //    a.create();
-    //    a.add(-1000000);
-    //    a.add(0);
-    //    a.add(1000000);
-    //    CHECK_NOT(a.is_encoded());
-    //    CHECK(a.try_encode(a1));
-    //    a1.destroy();
-    //    CHECK(a.get(0) == -1000000);
-    //    CHECK(a.get(1) == 0);
-    //    CHECK(a.get(2) == 1000000);
-    //    a.add(-1000000);
-    //    CHECK(a.try_encode(a1));
-    //    CHECK_NOT(a.is_encoded());
-    //    CHECK(a.get(0) == -1000000);
-    //    CHECK(a.get(1) == 0);
-    //    CHECK(a.get(2) == 1000000);
-    //    CHECK(a.get(3) == -1000000);
-    //    a.add(0);
-    //    CHECK(a.try_encode(a1));
-    //    CHECK_NOT(a.is_encoded());
-    //    CHECK(a1.is_encoded());
-    //
-    //    CHECK(a1.get(3) == a.get(3));
-    //    CHECK(a1.get(4) == a.get(4));
-    //    CHECK(a1.get(0) == a.get(0));
-    //    CHECK(a1.get(1) == a.get(1));
-    //    CHECK(a1.get(2) == a.get(2));
-    //
-    //    a.add(1000000);
-    //    a1.destroy(); // this decodes the array
-    //    CHECK(a.try_encode(a1));
-    //    CHECK_NOT(a.is_encoded());
-    //    CHECK(a1.is_encoded());
-    //    CHECK(a1.get(0) == a.get(0));
-    //    CHECK(a1.get(1) == a.get(1));
-    //    CHECK(a1.get(2) == a.get(2));
-    //    CHECK(a1.try_decode());
-    //    a.add(-1000000);
-    //    a1.destroy();
-    //    CHECK(a.try_encode(a1));
-    //    CHECK_NOT(a.is_encoded());
-    //    CHECK(a1.is_encoded());
-    //    CHECK(a1.get(0) == a.get(0));
-    //    CHECK(a1.get(1) == a.get(1));
-    //    CHECK(a1.get(2) == a.get(2));
-    //    a.add(0);
-    //    a1.destroy();
-    //    CHECK(a.try_encode(a1));
-    //    CHECK_NOT(a.is_encoded());
-    //    CHECK(a1.is_encoded());
-    //    CHECK(a1.get(0) == a.get(0));
-    //    CHECK(a1.get(1) == a.get(1));
-    //    CHECK(a1.get(2) == a.get(2));
-    //    a.add(1000000);
-    //    a1.destroy();
-    //    CHECK(a.try_encode(a1));
-    //    CHECK_NOT(a.is_encoded());
-    //    CHECK(a1.is_encoded());
-    //    CHECK(a.size() == 9);
-    //    CHECK(a.size() == a1.size());
-    //    CHECK(a1.is_encoded());
-    //    CHECK(a1.get(0) == a.get(0));
-    //    CHECK(a1.get(1) == a.get(1));
-    //    CHECK(a1.get(2) == a.get(2));
-    //    CHECK(a1.get(3) == a.get(3));
-    //    CHECK(a1.get(4) == a.get(4));
-    //    CHECK(a1.get(5) == a.get(5));
-    //    CHECK(a1.get(6) == a.get(6));
-    //    CHECK(a1.get(7) == a.get(7));
-    //    CHECK(a1.get(8) == a.get(8));
-    //    a.destroy();
-    //    a1.destroy();
+    ArrayInteger a(Allocator::get_default());
+    ArrayInteger a1(Allocator::get_default());
+    a.create();
+    a.add(-1000000);
+    a.add(0);
+    a.add(1000000);
+    CHECK_NOT(a.is_encoded());
+    CHECK(a.try_encode(a1));
+    a1.destroy();
+    CHECK(a.get(0) == -1000000);
+    CHECK(a.get(1) == 0);
+    CHECK(a.get(2) == 1000000);
+    a.add(-1000000);
+    a.add(-1000000);
+    CHECK(a.try_encode(a1));
+    CHECK_NOT(a.is_encoded());
+    CHECK(a.get(0) == -1000000);
+    CHECK(a.get(1) == 0);
+    CHECK(a.get(2) == 1000000);
+    CHECK(a.get(3) == -1000000);
+    CHECK(a.get(4) == -1000000);
+    a.add(0);
+    a1.destroy();
+    CHECK(a.try_encode(a1));
+    CHECK_NOT(a.is_encoded());
+    CHECK(a1.is_encoded());
+
+    CHECK(a1.get(0) == a.get(0));
+    CHECK(a1.get(1) == a.get(1));
+    CHECK(a1.get(2) == a.get(2));
+    CHECK(a1.get(3) == a.get(3));
+    CHECK(a1.get(4) == a.get(4));
+    CHECK(a1.get(5) == a.get(5));
+
+    a.add(1000000);
+    a1.destroy(); // this decodes the array
+    CHECK(a.try_encode(a1));
+    CHECK_NOT(a.is_encoded());
+    CHECK(a1.is_encoded());
+    CHECK(a1.get(0) == a.get(0));
+    CHECK(a1.get(1) == a.get(1));
+    CHECK(a1.get(2) == a.get(2));
+    CHECK(a1.try_decode());
+    a.add(-1000000);
+    a1.destroy();
+    CHECK(a.try_encode(a1));
+    CHECK_NOT(a.is_encoded());
+    CHECK(a1.is_encoded());
+    CHECK(a1.get(0) == a.get(0));
+    CHECK(a1.get(1) == a.get(1));
+    CHECK(a1.get(2) == a.get(2));
+    a.add(0);
+    a1.destroy();
+    CHECK(a.try_encode(a1));
+    CHECK_NOT(a.is_encoded());
+    CHECK(a1.is_encoded());
+    CHECK(a1.get(0) == a.get(0));
+    CHECK(a1.get(1) == a.get(1));
+    CHECK(a1.get(2) == a.get(2));
+    a.add(1000000);
+    a1.destroy();
+    CHECK(a.try_encode(a1));
+    CHECK_NOT(a.is_encoded());
+    CHECK(a1.is_encoded());
+    CHECK(a.size() == 10);
+    CHECK(a.size() == a1.size());
+    CHECK(a1.is_encoded());
+    CHECK(a1.get(0) == a.get(0));
+    CHECK(a1.get(1) == a.get(1));
+    CHECK(a1.get(2) == a.get(2));
+    CHECK(a1.get(3) == a.get(3));
+    CHECK(a1.get(4) == a.get(4));
+    CHECK(a1.get(5) == a.get(5));
+    CHECK(a1.get(6) == a.get(6));
+    CHECK(a1.get(7) == a.get(7));
+    CHECK(a1.get(8) == a.get(8));
+    a.destroy();
+    a1.destroy();
 }
 
 TEST(Test_ArrayInt_compress_data)
 {
-    //    //-4427957085475570907
-    //    ArrayInteger a(Allocator::get_default());
-    //    ArrayInteger a1(Allocator::get_default());
-    //
-    //    //    a.create();
-    //    ////    //a.add(-4427957085475570907);
-    //    ////    //a.add(-4427957085475570907);
-    //    //    a.add(4);
-    //    //    a.add(5);
-    //    //    a.add(6);
-    //    //    a.add(7);
-    //    //    a.add(8);
-    //    //    a.try_encode(a1);
-    //    //    for(size_t i=0; i<a.size(); ++i)
-    //    //        CHECK(a1.get(i) == a.get(i));
-    //    //    a.destroy();
-    //    //    a1.destroy();
-    //    //
-    //    //    a.create();
-    //    //    a.add(-4427957085475570907);
-    //    //    a.add(-4427957085475570907);
-    //    //    a.try_encode(a1);
-    //    //    for(size_t i=0; i<a.size(); ++i)
-    //    //        CHECK(a1.get(i) == a.get(i));
-    //    //    a.destroy();
-    //    //    a1.destroy();
-    //
-    //
-    //    a.create();
-    //    // a.add(-4427957085475570907);
-    //    // a.add(-4427957085475570907);
-    //    for (size_t i = 0; i < 14; ++i)
-    //        a.add(i + 1);
-    //
-    //    // a.add(-4427957085475570907);
-    //    a.try_encode(a1);
-    //    for (size_t i = 0; i < a.size() - 1; ++i)
-    //        CHECK(a1.get(i) == a.get(i));
-    //    CHECK(a1.get(13) == a.get(13));
-    //    a.destroy();
-    //    a1.destroy();
-    //
-    //
-    //    //
-    //    //    ArrayInteger a(Allocator::get_default());
-    //    //    ArrayInteger a1(Allocator::get_default());
-    //    //    a.create();
-    //    //    a.add(16388);
-    //    //    a.add(409);
-    //    //    a.add(16388);
-    //    //    a.add(16388);
-    //    //    a.add(409);
-    //    //    a.add(16388);
-    //    //    CHECK(a.size() == 6);
-    //    //    // Current: [16388:16, 409:16, 16388:16, 16388:16, 409:16, 16388:16], space needed: 6*16 bits = 96
-    //    bits +
-    //    //    // header
-    //    //    // compress the array is a good option.
-    //    //    CHECK(a.try_encode(a1));
-    //    //    CHECK(a1.is_encoded());
-    //    //    // Compressed: [409:16, 16388:16][1:1,0:1,1:1,1:1,0:1,1:1], space needed: 2*16 bits + 6 * 1 bit = 38
-    //    bits +
-    //    //    // header
-    //    //    CHECK(a1.size() == a.size());
-    //    //    CHECK(a1.get(0) == a.get(0));
-    //    //    CHECK(a1.get(1) == a.get(1));
-    //    //    CHECK(a1.get(2) == a.get(2));
-    //    //    CHECK(a1.get(3) == a.get(3));
-    //    //    CHECK(a1.get(4) == a.get(4));
-    //    //    CHECK(a1.get(5) == a.get(5));
-    //    //    // decompress
-    //    //    CHECK(a1.try_decode());
-    //    //    a.add(20);
-    //    //    // compress again, it should be a viable option
-    //    //    a1.destroy();
-    //    //    CHECK(a.try_encode(a1));
-    //    //    CHECK(a1.is_encoded());
-    //    //    CHECK(a1.size() == 7);
-    //    //    CHECK(a1.get(0) == a.get(0));
-    //    //    CHECK(a1.get(1) == a.get(1));
-    //    //    CHECK(a1.get(2) == a.get(2));
-    //    //    CHECK(a1.get(3) == a.get(3));
-    //    //    CHECK(a1.get(4) == a.get(4));
-    //    //    CHECK(a1.get(5) == a.get(5));
-    //    //    CHECK(a1.get(6) == a.get(6));
-    //    //    CHECK(a1.try_decode());
-    //    //    CHECK_NOT(a1.is_encoded());
-    //    //    CHECK(a1.get(0) == a.get(0));
-    //    //    CHECK(a1.get(1) == a.get(1));
-    //    //    CHECK(a1.get(2) == a.get(2));
-    //    //    CHECK(a1.get(3) == a.get(3));
-    //    //    CHECK(a1.get(4) == a.get(4));
-    //    //    CHECK(a1.get(5) == a.get(5));
-    //    //    CHECK(a1.get(6) == a.get(6));
-    //    //    a.destroy();
-    //    //    a1.destroy();
+    ArrayInteger a(Allocator::get_default());
+    ArrayInteger a1(Allocator::get_default());
+
+    a.create();
+    a.add(-4427957085475570907);
+    a.add(-4427957085475570907);
+    a.add(-4427957085475570907);
+    a.add(-4427957085475570907);
+    a.add(4);
+    a.add(5);
+    a.add(6);
+    a.add(7);
+    a.add(8);
+    a.try_encode(a1);
+    CHECK(a1.is_encoded());
+    CHECK(a1.is_attached());
+    CHECK(a.is_attached());
+    for (size_t i = 0; i < a.size(); ++i)
+        CHECK(a1.get(i) == a.get(i));
+
+    a.destroy();
+    a1.destroy();
+
+    a.create();
+    a.add(-4427957085475570907);
+    a.add(-4427957085475570907);
+    a.add(-4427957085475570907);
+    a.add(-4427957085475570907);
+    a.try_encode(a1);
+    for (size_t i = 0; i < a.size(); ++i)
+        CHECK(a1.get(i) == a.get(i));
+    a.destroy();
+    a1.destroy();
+
+    a.create();
+
+    for (size_t i = 0; i < 14; ++i)
+        a.add(i + 1);
+
+    a.add(-4427957085475570907);
+    a.add(-4427957085475570907);
+    a.add(-4427957085475570907);
+    a.add(-4427957085475570907);
+    a.try_encode(a1);
+    CHECK(a1.is_encoded());
+    for (size_t i = 0; i < a.size(); ++i)
+        CHECK(a1.get(i) == a.get(i));
+    a.destroy();
+    a1.destroy();
+
+    a.create();
+    a.add(16388);
+    a.add(409);
+    a.add(16388);
+    a.add(16388);
+    a.add(409);
+    a.add(16388);
+    CHECK(a.size() == 6);
+    // Current: [16388:16, 409:16, 16388:16, 16388:16, 409:16, 16388:16], space needed: 6*16 bits = 96 bits +
+    // header
+    // compress the array is a good option.
+    CHECK(a.try_encode(a1));
+    CHECK(a1.is_encoded());
+    // Compressed: [409:16, 16388:16][1:1,0:1,1:1,1:1,0:1,1:1], space needed: 2*16 bits + 6 * 1 bit = 38 bits +
+    // header
+    CHECK(a1.size() == a.size());
+    CHECK(a1.get(0) == a.get(0));
+    CHECK(a1.get(1) == a.get(1));
+    CHECK(a1.get(2) == a.get(2));
+    CHECK(a1.get(3) == a.get(3));
+    CHECK(a1.get(4) == a.get(4));
+    CHECK(a1.get(5) == a.get(5));
+    // decompress
+    CHECK(a1.try_decode());
+    a.add(20);
+    // compress again, it should be a viable option
+    a1.destroy();
+    CHECK(a.try_encode(a1));
+    CHECK(a1.is_encoded());
+    CHECK(a1.size() == 7);
+    CHECK(a1.get(0) == a.get(0));
+    CHECK(a1.get(1) == a.get(1));
+    CHECK(a1.get(2) == a.get(2));
+    CHECK(a1.get(3) == a.get(3));
+    CHECK(a1.get(4) == a.get(4));
+    CHECK(a1.get(5) == a.get(5));
+    CHECK(a1.get(6) == a.get(6));
+    CHECK(a1.try_decode());
+    CHECK_NOT(a1.is_encoded());
+    CHECK(a1.get(0) == a.get(0));
+    CHECK(a1.get(1) == a.get(1));
+    CHECK(a1.get(2) == a.get(2));
+    CHECK(a1.get(3) == a.get(3));
+    CHECK(a1.get(4) == a.get(4));
+    CHECK(a1.get(5) == a.get(5));
+    CHECK(a1.get(6) == a.get(6));
+    a.destroy();
+    a1.destroy();
 }
 
 TEST(Test_ArrayInt_compress_data_init_from_mem)
 {
-    //    ArrayInteger a(Allocator::get_default());
-    //    ArrayInteger a1(Allocator::get_default());
-    //    a.create();
-    //    a.add(16388);
-    //    a.add(409);
-    //    a.add(16388);
-    //    a.add(16388);
-    //    a.add(409);
-    //    a.add(16388);
-    //    const auto sz = a.size();
-    //    CHECK(sz == 6);
-    //    // Current: [16388:16, 409:16, 16388:16, 16388:16, 409:16, 16388:16],
-    //    // space needed: 6*16 bits = 96 bits + header
-    //    // compress the array is a good option (it should already be compressed).
-    //    CHECK(a.try_encode(a1));
-    //    CHECK(a1.is_encoded());
-    //    //  Array should be in compressed form now
-    //    auto mem = a1.get_mem();
-    //    ArrayInteger a2(Allocator::get_default());
-    //    a2.init_from_mem(mem); // initialise a1 with a
-    //    // check a1
-    //    CHECK(a2.is_encoded());
-    //    const auto sz2 = a2.size();
-    //    CHECK(sz2 == 6);
-    //    CHECK(a2.get(0) == 16388);
-    //    CHECK(a2.get(1) == 409);
-    //    CHECK(a2.get(2) == 16388);
-    //    CHECK(a2.get(3) == 16388);
-    //    CHECK(a2.get(4) == 409);
-    //    CHECK(a2.get(5) == 16388);
-    //    // decompress a2 and compresses again
-    //    CHECK(a2.is_encoded());
-    //    CHECK(a2.try_decode());
-    //    CHECK_NOT(a2.is_encoded());
-    //    a2.add(20);
-    //    CHECK(a2.try_encode(a1));
-    //    CHECK(a1.is_encoded());
-    //    CHECK(a1.size() == 7);
-    //    CHECK(a1.get(0) == 16388);
-    //    CHECK(a1.get(1) == 409);
-    //    CHECK(a1.get(2) == 16388);
-    //    CHECK(a1.get(3) == 16388);
-    //    CHECK(a1.get(4) == 409);
-    //    CHECK(a1.get(5) == 16388);
-    //    CHECK(a1.get(6) == 20);
-    //    CHECK(a1.try_decode());
-    //    a.destroy();
-    //    a1.destroy();
-    //    a2.destroy();
-    //    CHECK_NOT(a.is_attached());
-    //    CHECK_NOT(a1.is_attached());
-    //    CHECK_NOT(a2.is_attached());
+    ArrayInteger a(Allocator::get_default());
+    ArrayInteger a1(Allocator::get_default());
+    a.create();
+    a.add(16388);
+    a.add(409);
+    a.add(16388);
+    a.add(16388);
+    a.add(409);
+    a.add(16388);
+    const auto sz = a.size();
+    CHECK(sz == 6);
+    // Current: [16388:16, 409:16, 16388:16, 16388:16, 409:16, 16388:16],
+    // space needed: 6*16 bits = 96 bits + header
+    // compress the array is a good option (it should already be compressed).
+    CHECK(a.try_encode(a1));
+    CHECK(a1.is_encoded());
+    //  Array should be in compressed form now
+    auto mem = a1.get_mem();
+    ArrayInteger a2(Allocator::get_default());
+    a2.init_from_mem(mem); // initialise a1 with a
+    // check a1
+    CHECK(a2.is_encoded());
+    const auto sz2 = a2.size();
+    CHECK(sz2 == 6);
+    CHECK(a2.get(0) == 16388);
+    CHECK(a2.get(1) == 409);
+    CHECK(a2.get(2) == 16388);
+    CHECK(a2.get(3) == 16388);
+    CHECK(a2.get(4) == 409);
+    CHECK(a2.get(5) == 16388);
+    // decompress a2 and compresses again
+    CHECK(a2.is_encoded());
+    CHECK(a2.try_decode());
+    CHECK_NOT(a2.is_encoded());
+    a2.add(20);
+    CHECK(a2.try_encode(a1));
+    CHECK(a1.is_encoded());
+    CHECK(a1.size() == 7);
+    CHECK(a1.get(0) == 16388);
+    CHECK(a1.get(1) == 409);
+    CHECK(a1.get(2) == 16388);
+    CHECK(a1.get(3) == 16388);
+    CHECK(a1.get(4) == 409);
+    CHECK(a1.get(5) == 16388);
+    CHECK(a1.get(6) == 20);
+    CHECK(a1.try_decode());
+    a.destroy();
+    a1.destroy();
+    a2.destroy();
+    CHECK_NOT(a.is_attached());
+    CHECK_NOT(a1.is_attached());
+    CHECK_NOT(a2.is_attached());
 }
 
 TEST(ArrayIntNull_SetNull)

--- a/test/test_shared.cpp
+++ b/test/test_shared.cpp
@@ -103,23 +103,21 @@ TEST(Query_QuickSort2)
 
     // Triggers QuickSort because range > len
     Table ttt;
-    auto ints = ttt.add_column(type_Int, "1");
+    // auto ints = ttt.add_column(type_Int, "1");
     auto strings = ttt.add_column(type_String, "2");
 
     for (size_t t = 0; t < 10000; t++) {
         Obj o = ttt.create_object();
-        //        o.set<int64_t>(ints, random.draw_int_mod(1100));
+        // o.set<int64_t>(ints, random.draw_int_mod(1100));
         o.set<StringData>(strings, "a");
     }
 
     Query q = ttt.where();
 
-    std::cerr << "GO";
-
     for (size_t t = 0; t < 1000; t++) {
         TableView tv = q.find_all();
         tv.sort(strings);
-        //        tv.ints(strings);
+        // tv.ints(strings);
     }
 }
 

--- a/test/test_upgrade_database.cpp
+++ b/test/test_upgrade_database.cpp
@@ -483,7 +483,7 @@ TEST_IF(Upgrade_Database_8_9, REALM_MAX_BPNODE_SIZE == 4 || REALM_MAX_BPNODE_SIZ
 #endif // TEST_READ_UPGRADE_MODE
 }
 
-ONLY(Upgrade_Database_6_10)
+TEST(Upgrade_Database_6_10)
 {
     std::string path = test_util::get_test_resource_path() + "test_upgrade_database_6.realm";
     CHECK_OR_RETURN(File::exists(path));


### PR DESCRIPTION
## What, How & Why?
This works only for equality and for fixed bit width at the moment. I will extend this work. But subword scanning seems to be paying out already.

```
   N values = 1000
   N runs = 100
   Positive values - Array::find(): 18 ms
   Positive values - Array::find(): 181.078 ns/value
   Positive values - ArrayEncode::find(): 21 ms
   Positive values - ArrayEncode::find(): 218.285 ns/value

   Negative values - Array::find(): 18 ms
   Negative values - Array::find(): 180.421 ns/value
   Negative values - ArrayEncode::find(): 12 ms
   Negative values - ArrayEncode::find(): 125.296 ns/value 

```

vs a normal find loop without parallel scan.

   ```
N values = 1000
   N runs = 100
   Positive values - Array::find(): 18 ms
   Positive values - Array::find(): 180.657 ns/value
   Positive values - ArrayEncode::find(): 147 ms
   Positive values - ArrayEncode::find(): 1471.51 ns/value

   Negative values - Array::find(): 18 ms
   Negative values - Array::find(): 180.715 ns/value
   Negative values - ArrayEncode::find(): 145 ms
   Negative values - ArrayEncode::find(): 1458.26 ns/value
```
It works only for array packed at the moment, in flex format we are going to be a little bit slower probably, I'd expect this to be due to the double indirection for fetching the value.

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed
* [ ] `bindgen/spec.yml`, if public C++ API changed
