### PR TITLE
Don't allow Core targets to be installed if submodule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -361,6 +361,11 @@ add_subdirectory(bindgen)
 # Install the licence and changelog files
 install(FILES LICENSE CHANGELOG.md DESTINATION "doc/realm" COMPONENT devel)
 
+# Only prepare test/install/package targets if we're not a submodule
+if(REALM_CORE_SUBMODULE_BUILD AND NOT DEFINED VCPKG_TOOLCHAIN)
+    return()
+endif()
+
 # Make the project importable from the build directory
 set(REALM_EXPORTED_TARGETS
         Storage
@@ -393,11 +398,6 @@ install(FILES tools/cmake/AcquireRealmDependency.cmake
         DESTINATION share/cmake/Realm
         COMPONENT devel
         )
-
-# Only prepare test/install/package targets if we're not a submodule
-if(REALM_CORE_SUBMODULE_BUILD)
-    return()
-endif()
 
 if(CMAKE_SYSTEM_NAME MATCHES "^Windows")
     # Increase the Catch2 virtual console width because our test names can be very long and they break test reports

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ project(RealmCore)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake")
 
-if(NOT CMAKE_SOURCE_DIR STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
+if(NOT DEFINED REALM_CORE_SUBMODULE_BUILD AND NOT CMAKE_SOURCE_DIR STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
     # Realm Core is being built as part of another project, likely an SDK
     set(REALM_CORE_SUBMODULE_BUILD ON)
 endif()
@@ -362,7 +362,7 @@ add_subdirectory(bindgen)
 install(FILES LICENSE CHANGELOG.md DESTINATION "doc/realm" COMPONENT devel)
 
 # Only prepare test/install/package targets if we're not a submodule
-if(REALM_CORE_SUBMODULE_BUILD AND NOT DEFINED VCPKG_TOOLCHAIN)
+if(REALM_CORE_SUBMODULE_BUILD)
     return()
 endif()
 

--- a/bindgen/src/realm_helpers.h
+++ b/bindgen/src/realm_helpers.h
@@ -179,7 +179,7 @@ struct Helpers {
     {
         size_t max_size = util::base64_decoded_size(input.size());
         std::unique_ptr<char[]> data(new char[max_size]);
-        if (auto size = util::base64_decode(input, data.get(), max_size)) {
+        if (auto size = util::base64_decode(input, {data.get(), max_size})) {
             OwnedBinaryData result(std::move(data), *size);
             return result;
         }


### PR DESCRIPTION
## What, How & Why?
https://github.com/realm/realm-core/pull/7334 incorrectly installed targets when Core is consumed as a submodule. While this is required for vcpkg support other SDK's relied on the original behaviour.
