### PR TITLE
Use the correct allocator for queries on dictionaries over links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * List KVO information was being populated for non-list collections ([PR #7378](https://github.com/realm/realm-core/pull/7378), since v14.0.0)
 * Setting a Mixed property to an ObjLink equal to its existing value would remove the existing backlinks and then exit before re-adding them, resulting in later assertion failures due to the backlink state being invalid ([PR #7384](https://github.com/realm/realm-core/pull/7384), since v14.0.0).
 * Opening file with file format 23 in read-only mode will crash ([#7388](https://github.com/realm/realm-core/issues/7388), since v14.0.0)
+* Querying a dictionary over a link would sometimes result in out-of-bounds memory reads ([PR #7382](https://github.com/realm/realm-core/pull/7382), since v14.0.0).
 
 ### Breaking changes
 * None.

--- a/src/realm/query_expression.cpp
+++ b/src/realm/query_expression.cpp
@@ -377,7 +377,7 @@ SizeOperator<int64_t> Columns<Dictionary>::size()
 
 void Columns<Dictionary>::evaluate(size_t index, ValueBase& destination)
 {
-    Collection::QueryCtrlBlock ctrl(m_path, *get_base_table(), !m_path_only_unary_keys);
+    Collection::QueryCtrlBlock ctrl(m_path, *m_link_map.get_target_table(), !m_path_only_unary_keys);
 
     if (links_exist()) {
         REALM_ASSERT(!m_leaf);


### PR DESCRIPTION
The base table's allocator was being used to read from the target table.