### PR TITLE
Bson object should hold binary data in decoded form

### DIFF
--- a/src/realm/util/bson/bson.cpp
+++ b/src/realm/util/bson/bson.cpp
@@ -416,8 +416,11 @@ std::ostream& operator<<(std::ostream& out, const Bson& b)
             out << nlohmann::json(b.operator const std::string&()).dump();
             break;
         case Bson::Type::Binary: {
-            const std::vector<char>& vec = static_cast<std::vector<char>>(b);
-            out << "{\"$binary\":{\"base64\":\"" << std::string(vec.begin(), vec.end()) << "\",\"subType\":\"00\"}}";
+            const std::vector<char>& vec = static_cast<const std::vector<char>&>(b);
+            std::string encode_buffer;
+            encode_buffer.resize(util::base64_encoded_size(vec.size()));
+            util::base64_encode(vec, encode_buffer);
+            out << "{\"$binary\":{\"base64\":\"" << encode_buffer << "\",\"subType\":\"00\"}}";
             break;
         }
         case Bson::Type::Timestamp: {
@@ -658,16 +661,17 @@ static constexpr std::pair<std::string_view, FancyParser> bson_fancy_parsers[] =
          }
          if (!base64 || !subType)
              throw BsonError("invalid extended json $binary");
+         util::Optional<std::vector<char>> decoded_chars = util::base64_decode_to_vector(*base64);
+         if (!decoded_chars)
+             throw BsonError("Invalid base64 in $binary");
+
          if (subType == 0x04) { // UUID
-             util::Optional<std::vector<char>> uuidChrs = util::base64_decode_to_vector(*base64);
-             if (!uuidChrs)
-                 throw BsonError("Invalid base64 in $binary");
              UUID::UUIDBytes bytes{};
-             std::copy_n(uuidChrs->data(), bytes.size(), bytes.begin());
+             std::copy_n(decoded_chars->data(), bytes.size(), bytes.begin());
              return Bson(UUID(bytes));
          }
          else {
-             return Bson(std::move(*base64)); // TODO don't throw away the subType.
+             return Bson(std::move(*decoded_chars)); // TODO don't throw away the subType.
          }
      }},
     {"$date",

--- a/test/object-store/bson.cpp
+++ b/test/object-store/bson.cpp
@@ -157,8 +157,8 @@ TEST_CASE("canonical_extjson_corpus", "[bson]") {
 
         SECTION("subtype 0x00") {
             run_corpus<std::vector<char>>(
-                "x", {"{\"x\" : { \"$binary\" : {\"base64\" : \"//8=\", \"subType\" : \"00\"}}}", [](auto val) {
-                          std::string bin = "//8=";
+                "x", {"{\"x\" : { \"$binary\" : {\"base64\" : \"SGVsbG8K\", \"subType\" : \"00\"}}}", [](auto val) {
+                          std::string bin = "Hello\n";
                           CHECK(val == std::vector<char>(bin.begin(), bin.end()));
                       }});
         }
@@ -504,8 +504,9 @@ TEST_CASE("canonical_extjson_corpus", "[bson]") {
         auto canonical_extjson = remove_whitespace(
             "{\"_id\": {\"$oid\": \"57e193d7a9cc81b4027498b5\"}, \"String\": \"string\", \"Int32\": {\"$numberInt\": "
             "\"42\"}, \"Int64\": {\"$numberLong\": \"42\"}, \"Double\": {\"$numberDouble\": \"-1\"}, \"Binary\": { "
-            "\"$binary\" : {\"base64\": \"o0w498Or7cijeBSpkquNtg==\", \"subType\": \"00\"}}, \"BinaryUserDefined\": "
-            "{ \"$binary\" : {\"base64\": \"AQIDBAU=\", \"subType\": \"00\"}}, \"Subdocument\": {\"foo\": \"bar\"}, "
+            "\"$binary\" : {\"base64\": \"QmluYXJ5Cg==\", \"subType\": \"00\"}}, \"BinaryUserDefined\": "
+            "{ \"$binary\" : {\"base64\": \"QmluYXJ5IFVzZXIgRGVmaW5lZAo=\", \"subType\": \"00\"}}, \"Subdocument\": "
+            "{\"foo\": \"bar\"}, "
             "\"Array\": [{\"$numberInt\": \"1\"}, {\"$numberInt\": \"2\"}, {\"$numberInt\": \"3\"}, {\"$numberInt\": "
             "\"4\"}, {\"$numberInt\": \"5\"}], \"Timestamp\": {\"$timestamp\": {\"t\": 42, \"i\": 1}}, \"Regex\": "
             "{\"$regularExpression\": {\"pattern\": \"pattern\", \"options\": \"\"}}, \"DatetimeEpoch\": {\"$date\": "
@@ -514,8 +515,10 @@ TEST_CASE("canonical_extjson_corpus", "[bson]") {
             "false, \"Minkey\": {\"$minKey\": 1}, \"Maxkey\": {\"$maxKey\": 1}, \"Null\": null, \"UUID\": "
             "{\"$binary\":{\"base64\":\"AAAAAAAAAAAAAAAAAAAAAA==\", \"subType\":\"04\"}}}");
 
-        std::string binary = "o0w498Or7cijeBSpkquNtg==";
-        std::string binary_user_defined = "AQIDBAU=";
+        std::string binary = "Binary\n";
+        std::string binary_64 = "QmluYXJ5Cg==";
+        std::string binary_user_defined = "Binary User Defined\n";
+        std::string binary_user_defined_b64 = "QmluYXJ5IFVzZXIgRGVmaW5lZAo=";
 
         const BsonDocument document = {
             {"_id", ObjectId("57e193d7a9cc81b4027498b5")},


### PR DESCRIPTION
If you construct a Bson object from a std::vector<char>, the  extjson streaming format should encode the binary data in base64.

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- Link to relevant issue this fixes -->

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed
* [ ] `bindgen/spec.yml`, if public C++ API changed
