### PR TITLE
Treat missing keys in dictionaries as null in queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Setting a Mixed property to an ObjLink equal to its existing value would remove the existing backlinks and then exit before re-adding them, resulting in later assertion failures due to the backlink state being invalid ([PR #7384](https://github.com/realm/realm-core/pull/7384), since v14.0.0).
 * Opening file with file format 23 in read-only mode will crash ([#7388](https://github.com/realm/realm-core/issues/7388), since v14.0.0)
 * Querying a dictionary over a link would sometimes result in out-of-bounds memory reads ([PR #7382](https://github.com/realm/realm-core/pull/7382), since v14.0.0).
+* Restore the pre-14.0.0 behavior of missing keys in dictionaries in queries  ([PR #7391](https://github.com/realm/realm-core/pull/7391))
 
 ### Breaking changes
 * None.

--- a/src/realm/collection.cpp
+++ b/src/realm/collection.cpp
@@ -161,6 +161,9 @@ void Collection::get_any(QueryCtrlBlock& ctrl, Mixed val, size_t index)
                             ctrl.matches.insert(k);
                         });
                     }
+                    else {
+                        ctrl.matches.insert(Mixed());
+                    }
                     return;
                 }
                 finish = start + 1;

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -5059,8 +5059,8 @@ TEST(Parser_Dictionary)
     verify_query(test_context, foo, "dict.@keys == {'Bar'}", 19);
     verify_query(test_context, foo, "ANY dict.@keys == {'Bar'}", 100);
     verify_query(test_context, foo, "dict.@keys == {'Bar', 'Foo'}", 3);
-    verify_query(test_context, foo, "dict['Value'] == NULL", 1);
-    verify_query(test_context, foo, "dict['Value'] == {}", 22); // Tricky - what does this even mean?
+    verify_query(test_context, foo, "dict['Value'] == NULL", 23);
+    verify_query(test_context, foo, "dict['Value'] == {}", 0); // Tricky - what does this even mean?
     verify_query(test_context, foo, "dict['Value'] == {0, 100}", 3);
     verify_query(test_context, foo, "dict['Value'].@type == 'int'", num_ints_for_value);
     verify_query(test_context, foo, "dict.@type == 'int'", 100);      // ANY is implied, all have int values
@@ -5075,7 +5075,7 @@ TEST(Parser_Dictionary)
     verify_query(test_context, origin, "link.dict.Value > 50", 3);
     verify_query(test_context, origin, "links.dict['Value'] > 50", 5);
     verify_query(test_context, origin, "links.dict > 50", 6);
-    verify_query(test_context, origin, "links.dict['Value'] == NULL", 1);
+    verify_query(test_context, origin, "links.dict['Value'] == NULL", 10);
 
     verify_query(test_context, foo, "dict.@size == 3", 17);
     verify_query(test_context, foo, "dict.@max == 100", 2);

--- a/test/test_query2.cpp
+++ b/test/test_query2.cpp
@@ -5746,7 +5746,7 @@ TEST(Query_Dictionary)
     tv = (origin->link(col_links).column<Dictionary>(col_dict) > 50).find_all();
     CHECK_EQUAL(tv.size(), 6);
     tv = (origin->link(col_links).column<Dictionary>(col_dict).key("Value") == null()).find_all();
-    CHECK_EQUAL(tv.size(), 1);
+    CHECK_EQUAL(tv.size(), 7);
 
     tv = (foo->column<Dictionary>(col_dict).keys().begins_with("F")).find_all();
     CHECK_EQUAL(tv.size(), 5);


### PR DESCRIPTION
This behavior is indeed weird, but changing it results in a very large number of test failures and introduces a different set of weird behavior: `dict['key'] != $1` and `NOT(dict['key'] == $1)` give different results, with the first excluding objects which are missing the key and the second including them. This change introduced the ability for a keypath to neither equal nor not equal a value which seems at least as weird as the thing it was fixing, and so doesn't justify a breaking change.

An alternative might be to make `!=` behave like `NOT(==)` so that `dict['missing'] == null` doesn't match and `dict['missing'] != null` does, but I didn't see a straightforward way to implement that.