### PR TITLE
Avoid doing unneeded logger work in Replication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@
 * Passing a double as argument for a Query on Decimal128 did not work ([#7386](https://github.com/realm/realm-core/issues/7386), since v14.0.0)
 * Opening file with file format 23 in read-only mode will crash ([#7388](https://github.com/realm/realm-core/issues/7388), since v14.0.0)
 * Querying a dictionary over a link would sometimes result in out-of-bounds memory reads ([PR #7382](https://github.com/realm/realm-core/pull/7382), since v14.0.0).
-* Restore the pre-14.0.0 behavior of missing keys in dictionaries in queries  ([PR #7391](https://github.com/realm/realm-core/pull/7391))
+* Restore the pre-14.0.0 behavior of missing keys in dictionaries in queries ([PR #7391](https://github.com/realm/realm-core/pull/7391))
+* Fix a ~10% performance regression for bulk insertion when using a log level which does not include debug/trace ([PR #7400](https://github.com/realm/realm-core/pull/7400), since v14.0.0)
 
 ### Breaking changes
 * None.

--- a/src/realm/replication.hpp
+++ b/src/realm/replication.hpp
@@ -26,8 +26,9 @@
 #include <string>
 
 #include <realm/util/assert.hpp>
-#include <realm/util/safe_int_ops.hpp>
 #include <realm/util/buffer.hpp>
+#include <realm/util/logger.hpp>
+#include <realm/util/safe_int_ops.hpp>
 #include <realm/impl/cont_transact_hist.hpp>
 #include <realm/impl/transact_log.hpp>
 
@@ -438,6 +439,13 @@ private:
                                   Mixed index) const;
     Path get_prop_name(Path&&) const;
     size_t transact_log_size();
+
+    util::Logger* would_log(util::Logger::Level level) const noexcept
+    {
+        if (m_logger && m_logger->would_log(level))
+            return m_logger;
+        return nullptr;
+    }
 };
 
 class Replication::Interrupted : public std::exception {


### PR DESCRIPTION
Most of the replication log statements do some work including memory allocations which are then thrown away if the log level it too high, so always check the log level first. A few places don't actually benefit from this, but it's easier to consistently check the log level every time.

This makes the obj-c bulk insert benchmark slightly faster than v13.27.0 rather than ~10% slower.