### PR TITLE
Make Obj trivial and add a separate ObjCollectionParent type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Fixed conflict resolution bug which may result in an crash when the AddInteger instruction on Mixed properties is merged against updates to a non-integer type ([PR #7353](https://github.com/realm/realm-core/pull/7353)).
 * Fix a spurious crash related to opening a Realm on background thread while the process was in the middle of exiting ([#7420](https://github.com/realm/realm-core/issues/7420jj))
 * Fix a data race in change notification delivery when running at debug log level ([PR #7402](https://github.com/realm/realm-core/pull/7402), since v14.0.0).
+* Fix a 10-15% performance regression when reading data from the Realm resulting from Obj being made a non-trivial type ([PR #7402](https://github.com/realm/realm-core/pull/7402), since v14.0.0).
 
 ### Breaking changes
 * Remove `realm_scheduler_set_default_factory()` and `realm_scheduler_has_default_factory()`, and change the `Scheduler` factory function to a bare function pointer rather than a `UniqueFunction` so that it does not have a non-trivial destructor.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Enhancements
 * Add support to synchronize collections embedded in Mixed properties and other collections (except sets) ([PR #7353](https://github.com/realm/realm-core/pull/7353)).
+* Improve performance of change notifications on nested collections somewhat ([PR #7402](https://github.com/realm/realm-core/pull/7402)).
 
 ### Fixed
 * Fixed conflict resolution bug which may result in an crash when the AddInteger instruction on Mixed properties is merged against updates to a non-integer type ([PR #7353](https://github.com/realm/realm-core/pull/7353)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixed
 * Fixed conflict resolution bug which may result in an crash when the AddInteger instruction on Mixed properties is merged against updates to a non-integer type ([PR #7353](https://github.com/realm/realm-core/pull/7353)).
 * Fix a spurious crash related to opening a Realm on background thread while the process was in the middle of exiting ([#7420](https://github.com/realm/realm-core/issues/7420jj))
+* Fix a data race in change notification delivery when running at debug log level ([PR #7402](https://github.com/realm/realm-core/pull/7402), since v14.0.0).
 
 ### Breaking changes
 * Remove `realm_scheduler_set_default_factory()` and `realm_scheduler_has_default_factory()`, and change the `Scheduler` factory function to a bare function pointer rather than a `UniqueFunction` so that it does not have a non-trivial destructor.

--- a/src/realm/collection.cpp
+++ b/src/realm/collection.cpp
@@ -237,4 +237,25 @@ void Collection::get_any(QueryCtrlBlock& ctrl, Mixed val, size_t index)
     }
 }
 
+UpdateStatus CollectionBase::do_init_from_parent(BPlusTreeBase* tree, ref_type ref, bool allow_create)
+{
+    if (ref) {
+        tree->init_from_ref(ref);
+    }
+    else {
+        if (tree->init_from_parent()) {
+            // All is well
+            return UpdateStatus::Updated;
+        }
+        if (!allow_create) {
+            tree->detach();
+            return UpdateStatus::Detached;
+        }
+        // The ref in the column was NULL, create the tree in place.
+        tree->create();
+        REALM_ASSERT(tree->is_attached());
+    }
+    return UpdateStatus::Updated;
+}
+
 } // namespace realm

--- a/src/realm/collection.hpp
+++ b/src/realm/collection.hpp
@@ -564,6 +564,11 @@ public:
         m_content_version = 0;
     }
 
+    CollectionParent* get_owner() const noexcept
+    {
+        return m_parent;
+    }
+
     void to_json(std::ostream&, JSONOutputMode, util::FunctionRef<void(const Mixed&)>) const override;
 
     using Interface::get_owner_key;

--- a/src/realm/collection.hpp
+++ b/src/realm/collection.hpp
@@ -53,17 +53,17 @@ public:
     {
         return m_obj;
     }
+    uint32_t parent_version() const noexcept final
+    {
+        return 0;
+    }
 
 protected:
     Obj m_obj;
     ref_type m_ref;
-    UpdateStatus update_if_needed_with_status() const final
+    UpdateStatus update_if_needed() const final
     {
         return UpdateStatus::Updated;
-    }
-    bool update_if_needed() const final
-    {
-        return true;
     }
     ref_type get_collection_ref(Index, CollectionType) const final
     {
@@ -255,6 +255,7 @@ protected:
     CollectionBase& operator=(CollectionBase&&) noexcept = default;
 
     void validate_index(const char* msg, size_t index, size_t size) const;
+    static UpdateStatus do_init_from_parent(BPlusTreeBase* tree, ref_type ref, bool allow_create);
 };
 
 inline std::string_view collection_type_name(CollectionType col_type, bool uppercase = false)
@@ -492,7 +493,7 @@ public:
         if (m_parent) {
             try {
                 // Update the parent. Will throw if parent is not existing.
-                switch (m_parent->update_if_needed_with_status()) {
+                switch (m_parent->update_if_needed()) {
                     case UpdateStatus::Updated:
                         // Make sure to update next time around
                         m_content_version = 0;
@@ -524,7 +525,7 @@ public:
     {
         try {
             // `has_changed()` sneakily modifies internal state.
-            update_if_needed_with_status();
+            update_if_needed();
             if (m_last_content_version != m_content_version) {
                 m_last_content_version = m_content_version;
                 return true;
@@ -573,14 +574,12 @@ protected:
     Obj m_obj_mem;
     std::shared_ptr<CollectionParent> m_col_parent;
     CollectionParent::Index m_index;
-    mutable size_t m_my_version = 0;
     ColKey m_col_key;
-    bool m_nullable = false;
-
     mutable uint_fast64_t m_content_version = 0;
-
     // Content version used by `has_changed()`.
     mutable uint_fast64_t m_last_content_version = 0;
+    mutable uint32_t m_parent_version = 0;
+    bool m_nullable = false;
 
     CollectionBaseImpl() = default;
     CollectionBaseImpl(const CollectionBaseImpl& other)
@@ -650,13 +649,14 @@ protected:
 
     UpdateStatus get_update_status() const
     {
-        UpdateStatus status = m_parent ? m_parent->update_if_needed_with_status() : UpdateStatus::Detached;
+        UpdateStatus status = m_parent ? m_parent->update_if_needed() : UpdateStatus::Detached;
 
         if (status != UpdateStatus::Detached) {
             auto content_version = m_alloc->get_content_version();
-            if (content_version != m_content_version || m_my_version != m_parent->m_parent_version) {
+            auto parent_version = m_parent->parent_version();
+            if (content_version != m_content_version || m_parent_version != parent_version) {
                 m_content_version = content_version;
-                m_my_version = m_parent->m_parent_version;
+                m_parent_version = parent_version;
                 status = UpdateStatus::Updated;
             }
         }
@@ -667,18 +667,14 @@ protected:
     /// Refresh the parent object (if needed) and compare version numbers.
     /// Return true if the collection should initialize from parent
     /// Throws if the owning object no longer exists.
-    bool should_update()
+    bool should_update() const
     {
         check_parent();
-        bool changed = m_parent->update_if_needed(); // Throws if the object does not exist.
-        auto content_version = m_alloc->get_content_version();
-
-        if (changed || content_version != m_content_version || m_my_version != m_parent->m_parent_version) {
-            m_content_version = content_version;
-            m_my_version = m_parent->m_parent_version;
-            return true;
+        auto status = get_update_status();
+        if (status == UpdateStatus::Detached) {
+            throw StaleAccessor("Parent no longer exists");
         }
-        return false;
+        return status == UpdateStatus::Updated;
     }
 
     void bump_content_version()
@@ -796,7 +792,7 @@ private:
     ///
     /// If no change has happened to the data, this function returns
     /// `UpdateStatus::NoChange`, and the caller is allowed to not do anything.
-    virtual UpdateStatus update_if_needed_with_status() const = 0;
+    virtual UpdateStatus update_if_needed() const = 0;
 };
 
 namespace _impl {
@@ -884,7 +880,7 @@ protected:
     /// `BPlusTree<T>`.
     virtual BPlusTree<ObjKey>* get_mutable_tree() const = 0;
 
-    /// Implements update_if_needed() in a way that ensures the consistency of
+    /// Implements `update_if_needed()` in a way that ensures the consistency of
     /// the unresolved list. Derived classes should call this instead of calling
     /// `update_if_needed()` on their inner accessor.
     UpdateStatus update_if_needed() const

--- a/src/realm/collection.hpp
+++ b/src/realm/collection.hpp
@@ -571,7 +571,7 @@ public:
     using Interface::get_target_table;
 
 protected:
-    Obj m_obj_mem;
+    ObjCollectionParent m_obj_mem;
     std::shared_ptr<CollectionParent> m_col_parent;
     CollectionParent::Index m_index;
     ColKey m_col_key;
@@ -724,19 +724,19 @@ protected:
     void set_backlink(ColKey col_key, ObjLink new_link) const
     {
         check_parent();
-        m_parent->set_backlink(col_key, new_link);
+        m_parent->get_object().set_backlink(col_key, new_link);
     }
     // Used when replacing a link, return true if CascadeState contains objects to remove
     bool replace_backlink(ColKey col_key, ObjLink old_link, ObjLink new_link, CascadeState& state) const
     {
         check_parent();
-        return m_parent->replace_backlink(col_key, old_link, new_link, state);
+        return m_parent->get_object().replace_backlink(col_key, old_link, new_link, state);
     }
     // Used when removing a backlink, return true if CascadeState contains objects to remove
     bool remove_backlink(ColKey col_key, ObjLink old_link, CascadeState& state) const
     {
         check_parent();
-        return m_parent->remove_backlink(col_key, old_link, state);
+        return m_parent->get_object().remove_backlink(col_key, old_link, state);
     }
 
     /// Reset the accessor's tracking of the content version. Derived classes

--- a/src/realm/collection_parent.cpp
+++ b/src/realm/collection_parent.cpp
@@ -66,14 +66,7 @@ bool StablePath::is_prefix_of(const StablePath& other) const noexcept
 {
     if (size() > other.size())
         return false;
-
-    auto it = other.begin();
-    for (auto& p : *this) {
-        if (!(p == *it))
-            return false;
-        ++it;
-    }
-    return true;
+    return std::equal(begin(), end(), other.begin());
 }
 
 /***************************** CollectionParent ******************************/

--- a/src/realm/collection_parent.cpp
+++ b/src/realm/collection_parent.cpp
@@ -79,211 +79,80 @@ void CollectionParent::check_level() const
         throw LogicError(ErrorCodes::LimitExceeded, "Max nesting level reached");
     }
 }
-void CollectionParent::set_backlink(ColKey col_key, ObjLink new_link) const
+
+template <typename Base, template <typename> typename Collection, typename LinkCol>
+std::unique_ptr<Base> create_collection(ColKey col_key, size_t level)
 {
-    if (new_link && new_link.get_obj_key()) {
-        auto t = get_table();
-        auto target_table = t->get_parent_group()->get_table(new_link.get_table_key());
-        ColKey backlink_col_key;
-        auto type = col_key.get_type();
-        if (type == col_type_TypedLink || type == col_type_Mixed || col_key.is_dictionary()) {
-            // This may modify the target table
-            backlink_col_key = target_table->find_or_add_backlink_column(col_key, t->get_key());
-            // it is possible that this was a link to the same table and that adding a backlink column has
-            // caused the need to update this object as well.
-            update_if_needed();
-        }
-        else {
-            backlink_col_key = t->get_opposite_column(col_key);
-        }
-        auto obj_key = new_link.get_obj_key();
-        auto target_obj = obj_key.is_unresolved() ? target_table->try_get_tombstone(obj_key)
-                                                  : target_table->try_get_object(obj_key);
-        if (!target_obj) {
-            throw InvalidArgument(ErrorCodes::KeyNotFound, "Target object not found");
-        }
-        target_obj.add_backlink(backlink_col_key, get_object().get_key());
+    bool nullable = col_key.get_attrs().test(col_attr_Nullable);
+    switch (col_key.get_type()) {
+        case col_type_Int:
+            if (nullable)
+                return std::make_unique<Collection<util::Optional<Int>>>(col_key);
+            return std::make_unique<Collection<Int>>(col_key);
+        case col_type_Bool:
+            if (nullable)
+                return std::make_unique<Collection<util::Optional<Bool>>>(col_key);
+            return std::make_unique<Collection<Bool>>(col_key);
+        case col_type_Float:
+            if (nullable)
+                return std::make_unique<Collection<util::Optional<Float>>>(col_key);
+            return std::make_unique<Collection<Float>>(col_key);
+        case col_type_Double:
+            if (nullable)
+                return std::make_unique<Collection<util::Optional<Double>>>(col_key);
+            return std::make_unique<Collection<Double>>(col_key);
+        case col_type_String:
+            return std::make_unique<Collection<String>>(col_key);
+        case col_type_Binary:
+            return std::make_unique<Collection<Binary>>(col_key);
+        case col_type_Timestamp:
+            return std::make_unique<Collection<Timestamp>>(col_key);
+        case col_type_Decimal:
+            return std::make_unique<Collection<Decimal128>>(col_key);
+        case col_type_ObjectId:
+            if (nullable)
+                return std::make_unique<Collection<util::Optional<ObjectId>>>(col_key);
+            return std::make_unique<Collection<ObjectId>>(col_key);
+        case col_type_UUID:
+            if (nullable)
+                return std::make_unique<Collection<util::Optional<UUID>>>(col_key);
+            return std::make_unique<Collection<UUID>>(col_key);
+        case col_type_TypedLink:
+            return std::make_unique<Collection<ObjLink>>(col_key);
+        case col_type_Mixed:
+            return std::make_unique<Collection<Mixed>>(col_key, level + 1);
+        case col_type_Link:
+            return std::make_unique<LinkCol>(col_key);
+        default:
+            REALM_TERMINATE("Unsupported column type.");
     }
 }
 
-bool CollectionParent::replace_backlink(ColKey col_key, ObjLink old_link, ObjLink new_link, CascadeState& state) const
+LstBasePtr CollectionParent::get_listbase_ptr(ColKey col_key, size_t level)
 {
-    bool recurse = remove_backlink(col_key, old_link, state);
-    set_backlink(col_key, new_link);
-
-    return recurse;
+    REALM_ASSERT(col_key.get_attrs().test(col_attr_List) || col_key.get_type() == col_type_Mixed);
+    return create_collection<LstBase, Lst, LnkLst>(col_key, level);
 }
 
-bool CollectionParent::remove_backlink(ColKey col_key, ObjLink old_link, CascadeState& state) const
+SetBasePtr CollectionParent::get_setbase_ptr(ColKey col_key, size_t level)
 {
-    if (old_link && old_link.get_obj_key()) {
-        auto t = get_table();
-        REALM_ASSERT(t->valid_column(col_key));
-        ObjKey old_key = old_link.get_obj_key();
-        auto target_obj = t->get_parent_group()->get_object(old_link);
-        TableRef target_table = target_obj.get_table();
-        ColKey backlink_col_key;
-        auto type = col_key.get_type();
-        if (type == col_type_TypedLink || type == col_type_Mixed || col_key.is_dictionary()) {
-            backlink_col_key = target_table->find_or_add_backlink_column(col_key, t->get_key());
-        }
-        else {
-            backlink_col_key = t->get_opposite_column(col_key);
-        }
-
-        bool strong_links = target_table->is_embedded();
-        bool is_unres = old_key.is_unresolved();
-
-        bool last_removed = target_obj.remove_one_backlink(backlink_col_key, get_object().get_key()); // Throws
-        if (is_unres) {
-            if (last_removed) {
-                // Check is there are more backlinks
-                if (!target_obj.has_backlinks(false)) {
-                    // Tombstones can be erased right away - there is no cascading effect
-                    target_table->m_tombstones->erase(old_key, state);
-                }
-            }
-        }
-        else {
-            return state.enqueue_for_cascade(target_obj, strong_links, last_removed);
-        }
-    }
-
-    return false;
+    REALM_ASSERT(col_key.get_attrs().test(col_attr_Set));
+    return create_collection<SetBase, Set, LnkSet>(col_key, level);
 }
 
-LstBasePtr CollectionParent::get_listbase_ptr(ColKey col_key) const
-{
-    auto table = get_table();
-    auto attr = table->get_column_attr(col_key);
-    REALM_ASSERT(attr.test(col_attr_List) || attr.test(col_attr_Nullable));
-    bool nullable = attr.test(col_attr_Nullable);
-
-    switch (table->get_column_type(col_key)) {
-        case type_Int: {
-            if (nullable)
-                return std::make_unique<Lst<util::Optional<Int>>>(col_key);
-            else
-                return std::make_unique<Lst<Int>>(col_key);
-        }
-        case type_Bool: {
-            if (nullable)
-                return std::make_unique<Lst<util::Optional<Bool>>>(col_key);
-            else
-                return std::make_unique<Lst<Bool>>(col_key);
-        }
-        case type_Float: {
-            if (nullable)
-                return std::make_unique<Lst<util::Optional<Float>>>(col_key);
-            else
-                return std::make_unique<Lst<Float>>(col_key);
-        }
-        case type_Double: {
-            if (nullable)
-                return std::make_unique<Lst<util::Optional<Double>>>(col_key);
-            else
-                return std::make_unique<Lst<Double>>(col_key);
-        }
-        case type_String: {
-            return std::make_unique<Lst<String>>(col_key);
-        }
-        case type_Binary: {
-            return std::make_unique<Lst<Binary>>(col_key);
-        }
-        case type_Timestamp: {
-            return std::make_unique<Lst<Timestamp>>(col_key);
-        }
-        case type_Decimal: {
-            return std::make_unique<Lst<Decimal128>>(col_key);
-        }
-        case type_ObjectId: {
-            if (nullable)
-                return std::make_unique<Lst<util::Optional<ObjectId>>>(col_key);
-            else
-                return std::make_unique<Lst<ObjectId>>(col_key);
-        }
-        case type_UUID: {
-            if (nullable)
-                return std::make_unique<Lst<util::Optional<UUID>>>(col_key);
-            else
-                return std::make_unique<Lst<UUID>>(col_key);
-        }
-        case type_TypedLink: {
-            return std::make_unique<Lst<ObjLink>>(col_key);
-        }
-        case type_Mixed: {
-            return std::make_unique<Lst<Mixed>>(col_key, get_level() + 1);
-        }
-        case type_Link:
-            return std::make_unique<LnkLst>(col_key);
-    }
-    REALM_TERMINATE("Unsupported column type");
-}
-
-SetBasePtr CollectionParent::get_setbase_ptr(ColKey col_key) const
-{
-    auto table = get_table();
-    auto attr = table->get_column_attr(col_key);
-    REALM_ASSERT(attr.test(col_attr_Set));
-    bool nullable = attr.test(col_attr_Nullable);
-
-    switch (table->get_column_type(col_key)) {
-        case type_Int:
-            if (nullable)
-                return std::make_unique<Set<util::Optional<Int>>>(col_key);
-            return std::make_unique<Set<Int>>(col_key);
-        case type_Bool:
-            if (nullable)
-                return std::make_unique<Set<util::Optional<Bool>>>(col_key);
-            return std::make_unique<Set<Bool>>(col_key);
-        case type_Float:
-            if (nullable)
-                return std::make_unique<Set<util::Optional<Float>>>(col_key);
-            return std::make_unique<Set<Float>>(col_key);
-        case type_Double:
-            if (nullable)
-                return std::make_unique<Set<util::Optional<Double>>>(col_key);
-            return std::make_unique<Set<Double>>(col_key);
-        case type_String:
-            return std::make_unique<Set<String>>(col_key);
-        case type_Binary:
-            return std::make_unique<Set<Binary>>(col_key);
-        case type_Timestamp:
-            return std::make_unique<Set<Timestamp>>(col_key);
-        case type_Decimal:
-            return std::make_unique<Set<Decimal128>>(col_key);
-        case type_ObjectId:
-            if (nullable)
-                return std::make_unique<Set<util::Optional<ObjectId>>>(col_key);
-            return std::make_unique<Set<ObjectId>>(col_key);
-        case type_UUID:
-            if (nullable)
-                return std::make_unique<Set<util::Optional<UUID>>>(col_key);
-            return std::make_unique<Set<UUID>>(col_key);
-        case type_TypedLink:
-            return std::make_unique<Set<ObjLink>>(col_key);
-        case type_Mixed:
-            return std::make_unique<Set<Mixed>>(col_key);
-        case type_Link:
-            return std::make_unique<LnkSet>(col_key);
-    }
-    REALM_TERMINATE("Unsupported column type.");
-}
-
-CollectionBasePtr CollectionParent::get_collection_ptr(ColKey col_key) const
+CollectionBasePtr CollectionParent::get_collection_ptr(ColKey col_key, size_t level)
 {
     if (col_key.is_list()) {
-        return get_listbase_ptr(col_key);
+        return get_listbase_ptr(col_key, level);
     }
     else if (col_key.is_set()) {
-        return get_setbase_ptr(col_key);
+        return get_setbase_ptr(col_key, level);
     }
     else if (col_key.is_dictionary()) {
-        return std::make_unique<Dictionary>(col_key, get_level() + 1);
+        return std::make_unique<Dictionary>(col_key, level + 1);
     }
     return {};
 }
-
 
 int64_t CollectionParent::generate_key(size_t sz)
 {
@@ -307,5 +176,13 @@ int64_t CollectionParent::generate_key(size_t sz)
     return key;
 }
 
+void CollectionParent::set_key(BPlusTreeMixed& tree, size_t index)
+{
+    int64_t key = generate_key(tree.size());
+    while (tree.find_key(key) != realm::not_found) {
+        key++;
+    }
+    tree.set_key(index, key);
+}
 
 } // namespace realm

--- a/src/realm/collection_parent.hpp
+++ b/src/realm/collection_parent.hpp
@@ -74,7 +74,7 @@ public:
     using Index = StableIndex;
 
     // Return the nesting level of the parent
-    size_t get_level() const noexcept
+    uint8_t get_level() const noexcept
     {
         return m_level;
     }
@@ -106,10 +106,9 @@ protected:
 #else
     static constexpr size_t s_max_level = 100;
 #endif
-    size_t m_level = 0;
-    mutable size_t m_parent_version = 0;
+    uint8_t m_level = 0;
 
-    constexpr CollectionParent(size_t level = 0)
+    constexpr CollectionParent(uint8_t level = 0)
         : m_level(level)
     {
     }
@@ -117,10 +116,7 @@ protected:
     virtual ~CollectionParent();
     /// Update the accessor (and return `UpdateStatus::Detached` if the
     // collection is not initialized.
-    virtual UpdateStatus update_if_needed_with_status() const = 0;
-    /// Check if the storage version has changed and update if it has
-    /// Return true if the object was updated
-    virtual bool update_if_needed() const = 0;
+    virtual UpdateStatus update_if_needed() const = 0;
     /// Get owning object
     virtual const Obj& get_object() const noexcept = 0;
     /// Get the top ref from pareht
@@ -132,6 +128,8 @@ protected:
     }
     /// Set the top ref in parent
     virtual void set_collection_ref(Index, ref_type ref, CollectionType) = 0;
+
+    virtual uint32_t parent_version() const noexcept = 0;
 
     // Used when inserting a new link. You will not remove existing links in this process
     void set_backlink(ColKey col_key, ObjLink new_link) const;

--- a/src/realm/collection_parent.hpp
+++ b/src/realm/collection_parent.hpp
@@ -20,15 +20,16 @@
 #define REALM_COLLECTION_PARENT_HPP
 
 #include <realm/alloc.hpp>
-#include <realm/table_ref.hpp>
-#include <realm/path.hpp>
 #include <realm/mixed.hpp>
+#include <realm/path.hpp>
+#include <realm/table_ref.hpp>
 
 namespace realm {
 
 class Obj;
 class Replication;
 class CascadeState;
+class BPlusTreeMixed;
 
 class Collection;
 class CollectionBase;
@@ -95,6 +96,13 @@ public:
     /// Get table of owning object
     virtual TableRef get_table() const noexcept = 0;
 
+    static LstBasePtr get_listbase_ptr(ColKey col_key, size_t level);
+    static SetBasePtr get_setbase_ptr(ColKey col_key, size_t level);
+    static CollectionBasePtr get_collection_ptr(ColKey col_key, size_t level);
+
+    static int64_t generate_key(size_t sz);
+    static void set_key(BPlusTreeMixed& tree, size_t index);
+
 protected:
     friend class Collection;
     template <class>
@@ -129,20 +137,8 @@ protected:
     /// Set the top ref in parent
     virtual void set_collection_ref(Index, ref_type ref, CollectionType) = 0;
 
+    /// Get the counter which is incremented whenever the root Obj is updated.
     virtual uint32_t parent_version() const noexcept = 0;
-
-    // Used when inserting a new link. You will not remove existing links in this process
-    void set_backlink(ColKey col_key, ObjLink new_link) const;
-    // Used when replacing a link, return true if CascadeState contains objects to remove
-    bool replace_backlink(ColKey col_key, ObjLink old_link, ObjLink new_link, CascadeState& state) const;
-    // Used when removing a backlink, return true if CascadeState contains objects to remove
-    bool remove_backlink(ColKey col_key, ObjLink old_link, CascadeState& state) const;
-
-    LstBasePtr get_listbase_ptr(ColKey col_key) const;
-    SetBasePtr get_setbase_ptr(ColKey col_key) const;
-    CollectionBasePtr get_collection_ptr(ColKey col_key) const;
-
-    static int64_t generate_key(size_t sz);
 };
 
 } // namespace realm

--- a/src/realm/dictionary.cpp
+++ b/src/realm/dictionary.cpp
@@ -441,11 +441,7 @@ void Dictionary::insert_collection(const PathElement& path_elem, CollectionType 
     if (!old_val || *old_val != new_val) {
         m_values->ensure_keys();
         auto [it, inserted] = insert(path_elem.get_key(), new_val);
-        int64_t key = generate_key(size());
-        while (m_values->find_key(key) != realm::not_found) {
-            key++;
-        }
-        m_values->set_key(it.index(), key);
+        set_key(*m_values, it.index());
     }
 }
 
@@ -682,7 +678,6 @@ void Dictionary::ensure_created()
 {
     constexpr bool allow_create = true;
     if (do_update_if_needed(allow_create) == UpdateStatus::Detached) {
-        // FIXME: untested
         throw StaleAccessor("Dictionary no longer exists");
     }
 }

--- a/src/realm/dictionary.hpp
+++ b/src/realm/dictionary.hpp
@@ -39,10 +39,7 @@ public:
     using Base = CollectionBaseImpl<DictionaryBase>;
     class Iterator;
 
-    Dictionary()
-        : CollectionParent(0)
-    {
-    }
+    Dictionary() = default;
     ~Dictionary();
 
     Dictionary(const Obj& obj, ColKey col_key)
@@ -213,11 +210,14 @@ public:
     {
         return get_obj().get_table();
     }
-    UpdateStatus update_if_needed_with_status() const override;
-    bool update_if_needed() const override;
+    UpdateStatus update_if_needed() const override;
     const Obj& get_object() const noexcept override
     {
         return get_obj();
+    }
+    uint32_t parent_version() const noexcept override
+    {
+        return m_parent_version;
     }
     ref_type get_collection_ref(Index, CollectionType) const override;
     bool check_collection_ref(Index, CollectionType) const noexcept override;
@@ -241,7 +241,7 @@ private:
 
     Dictionary(Allocator& alloc, ColKey col_key, ref_type ref);
 
-    bool init_from_parent(bool allow_create) const;
+    UpdateStatus init_from_parent(bool allow_create) const;
     Mixed do_get(size_t ndx) const;
     void do_erase(size_t ndx, Mixed key);
     Mixed do_get_key(size_t ndx) const;
@@ -263,12 +263,14 @@ private:
     void do_accumulate(size_t* return_ndx, AggregateType& agg) const;
 
     void ensure_created();
-    inline bool update() const
+    bool update() const
     {
-        return update_if_needed_with_status() != UpdateStatus::Detached;
+        return update_if_needed() != UpdateStatus::Detached;
     }
     void verify() const;
     void get_key_type();
+
+    UpdateStatus do_update_if_needed(bool allow_create) const;
 };
 
 class Dictionary::Iterator {
@@ -461,7 +463,7 @@ public:
     // Overrides of ObjCollectionBase:
     UpdateStatus do_update_if_needed() const final
     {
-        return m_source.update_if_needed_with_status();
+        return m_source.update_if_needed();
     }
     BPlusTree<ObjKey>* get_mutable_tree() const final
     {

--- a/src/realm/list.cpp
+++ b/src/realm/list.cpp
@@ -534,11 +534,7 @@ void Lst<Mixed>::insert_collection(const PathElement& path_elem, CollectionType 
     check_level();
     m_tree->ensure_keys();
     insert(path_elem.get_ndx(), Mixed(0, dict_or_list));
-    int64_t key = generate_key(size());
-    while (m_tree->find_key(key) != realm::not_found) {
-        key++;
-    }
-    m_tree->set_key(path_elem.get_ndx(), key);
+    set_key(*m_tree, path_elem.get_ndx());
     bump_content_version();
 }
 
@@ -560,11 +556,7 @@ void Lst<Mixed>::set_collection(const PathElement& path_elem, CollectionType dic
         set(ndx, new_val);
         int64_t key = m_tree->get_key(ndx);
         if (key == 0) {
-            key = generate_key(size());
-            while (m_tree->find_key(key) != realm::not_found) {
-                key++;
-            }
-            m_tree->set_key(ndx, key);
+            set_key(*m_tree, path_elem.get_ndx());
         }
         bump_content_version();
     }

--- a/src/realm/list.hpp
+++ b/src/realm/list.hpp
@@ -183,7 +183,7 @@ public:
         return *m_tree;
     }
 
-    UpdateStatus update_if_needed_with_status() const final
+    UpdateStatus update_if_needed() const final
     {
         auto status = Base::get_update_status();
         switch (status) {
@@ -199,9 +199,7 @@ public:
                 // perform lazy initialization by treating it as an update.
                 [[fallthrough]];
             case UpdateStatus::Updated: {
-                bool attached = init_from_parent(false);
-                Base::update_content_version();
-                return attached ? UpdateStatus::Updated : UpdateStatus::Detached;
+                return init_from_parent(false);
             }
         }
         REALM_UNREACHABLE();
@@ -214,14 +212,13 @@ public:
             // In case of errors, an exception is thrown.
             constexpr bool allow_create = true;
             init_from_parent(allow_create); // Throws
-            Base::update_content_version();
         }
     }
 
     /// Update the accessor and return true if it is attached after the update.
     inline bool update() const
     {
-        return update_if_needed_with_status() != UpdateStatus::Detached;
+        return update_if_needed() != UpdateStatus::Detached;
     }
 
     size_t translate_index(size_t ndx) const noexcept override
@@ -255,28 +252,15 @@ protected:
     using Base::m_col_key;
     using Base::m_nullable;
 
-    bool init_from_parent(bool allow_create) const
+    UpdateStatus init_from_parent(bool allow_create) const
     {
         if (!m_tree) {
             m_tree.reset(new BPlusTree<T>(get_alloc()));
             const ArrayParent* parent = this;
             m_tree->set_parent(const_cast<ArrayParent*>(parent), 0);
         }
-
-        if (m_tree->init_from_parent()) {
-            // All is well
-            return true;
-        }
-
-        if (!allow_create) {
-            m_tree->detach();
-            return false;
-        }
-
-        // The ref in the column was NULL, create the tree in place.
-        m_tree->create();
-        REALM_ASSERT(m_tree->is_attached());
-        return true;
+        Base::update_content_version();
+        return do_init_from_parent(m_tree.get(), 0, allow_create);
     }
 
     template <class Func>
@@ -448,7 +432,7 @@ public:
         return *m_tree;
     }
 
-    UpdateStatus update_if_needed_with_status() const final;
+    UpdateStatus update_if_needed() const final;
 
     void ensure_created()
     {
@@ -457,15 +441,13 @@ public:
             // In case of errors, an exception is thrown.
             constexpr bool allow_create = true;
             init_from_parent(allow_create); // Throws
-            Base::update_content_version();
-            CollectionParent::m_parent_version++;
         }
     }
 
     /// Update the accessor and return true if it is attached after the update.
     inline bool update() const
     {
-        return update_if_needed_with_status() != UpdateStatus::Detached;
+        return update_if_needed() != UpdateStatus::Detached;
     }
 
     // Overriding members in CollectionParent
@@ -500,10 +482,13 @@ public:
     {
         return get_obj().get_table();
     }
-    bool update_if_needed() const override;
     const Obj& get_object() const noexcept override
     {
         return get_obj();
+    }
+    uint32_t parent_version() const noexcept override
+    {
+        return m_parent_version;
     }
     ref_type get_collection_ref(Index, CollectionType) const override;
     bool check_collection_ref(Index, CollectionType) const noexcept override;
@@ -527,7 +512,7 @@ private:
     using Base::m_col_key;
     using Base::m_nullable;
 
-    bool init_from_parent(bool allow_create) const;
+    UpdateStatus init_from_parent(bool allow_create) const;
 
     template <class Func>
     void find_all_mixed_unresolved_links(Func&& func) const
@@ -800,7 +785,7 @@ private:
 
     UpdateStatus do_update_if_needed() const final
     {
-        return m_list.update_if_needed_with_status();
+        return m_list.update_if_needed();
     }
 
     BPlusTree<ObjKey>* get_mutable_tree() const final

--- a/src/realm/list.hpp
+++ b/src/realm/list.hpp
@@ -629,7 +629,7 @@ public:
     }
     void add(const Obj& obj)
     {
-        if (get_target_table()->get_key() != obj.get_table_key()) {
+        if (get_target_table() != obj.get_table()) {
             throw InvalidArgument("LnkLst::add: Wrong object type");
         }
         add(obj.get_key());

--- a/src/realm/obj.hpp
+++ b/src/realm/obj.hpp
@@ -57,42 +57,30 @@ class DeepChangeChecker;
 }
 
 // 'Object' would have been a better name, but it clashes with a class in ObjectStore
-class Obj : public CollectionParent {
+class Obj {
 public:
     constexpr Obj() = default;
     Obj(TableRef table, MemRef mem, ObjKey key, size_t row_ndx);
 
-    // Overriding members of CollectionParent:
-    UpdateStatus update_if_needed() const final;
+    // CollectionParent implementation
+    UpdateStatus update_if_needed() const;
     // Get the path in a minimal format without including object accessors.
     // If you need to obtain additional information for each object in the path,
     // you should use get_fat_path() or traverse_path() instead (see below).
-    FullPath get_path() const final;
+    FullPath get_path() const;
     std::string get_id() const;
-    Path get_short_path() const noexcept final;
-    ColKey get_col_key() const noexcept final;
-    StablePath get_stable_path() const noexcept final;
-    void add_index(Path& path, const Index& ndx) const final;
-    size_t find_index(const Index&) const final
-    {
-        return realm::npos;
-    }
+    Path get_short_path() const noexcept;
+    ColKey get_col_key() const noexcept;
+    StablePath get_stable_path() const noexcept;
+    void add_index(Path& path, const CollectionParent::Index& ndx) const;
 
-    TableRef get_table() const noexcept final
+    TableRef get_table() const noexcept
     {
         return m_table.cast_away_const();
     }
-    const Obj& get_object() const noexcept final
-    {
-        return *this;
-    }
-    ref_type get_collection_ref(Index, CollectionType) const final;
-    bool check_collection_ref(Index, CollectionType) const noexcept final;
-    void set_collection_ref(Index, ref_type, CollectionType) final;
-    uint32_t parent_version() const noexcept final
-    {
-        return m_version_counter;
-    }
+    ref_type get_collection_ref(CollectionParent::Index, CollectionType) const;
+    bool check_collection_ref(CollectionParent::Index, CollectionType) const noexcept;
+    void set_collection_ref(CollectionParent::Index, ref_type, CollectionType);
     StableIndex build_index(ColKey) const;
     bool check_index(StableIndex) const;
 
@@ -322,22 +310,18 @@ private:
     friend class ArrayBacklink;
     friend class CascadeState;
     friend class Cluster;
+    friend class CollectionParent;
     friend class ColumnListBase;
-    friend class CollectionBase;
+    friend class LinkCount;
+    friend class LinkMap;
+    friend class Lst<ObjKey>;
+    friend class ObjCollectionParent;
+    friend class Table;
     friend class TableView;
     template <class>
     friend class CollectionBaseImpl;
     template <class>
-    friend class Lst;
-    friend class LnkLst;
-    friend class LinkCount;
-    friend class Dictionary;
-    friend class LinkMap;
-    template <class>
     friend class Set;
-    friend class Table;
-    friend class Transaction;
-    friend class CollectionParent;
 
     mutable TableRef m_table;
     ObjKey m_key;
@@ -417,6 +401,82 @@ private:
     bool compare_values(Mixed, Mixed, ColKey, Obj, StringData) const;
     bool compare_list_in_mixed(Lst<Mixed>&, Lst<Mixed>&, ColKey, Obj, StringData) const;
     bool compare_dict_in_mixed(Dictionary&, Dictionary&, ColKey, Obj, StringData) const;
+
+    // Used when inserting a new link. You will not remove existing links in this process
+    void set_backlink(ColKey col_key, ObjLink new_link) const;
+    // Used when replacing a link, return true if CascadeState contains objects to remove
+    bool replace_backlink(ColKey col_key, ObjLink old_link, ObjLink new_link, CascadeState& state) const;
+    // Used when removing a backlink, return true if CascadeState contains objects to remove
+    bool remove_backlink(ColKey col_key, ObjLink old_link, CascadeState& state) const;
+};
+static_assert(std::is_trivially_destructible_v<Obj>);
+
+class ObjCollectionParent final : public Obj, public CollectionParent {
+public:
+    ObjCollectionParent() = default;
+    ObjCollectionParent(const Obj& obj) noexcept
+        : Obj(obj)
+    {
+    }
+    ObjCollectionParent& operator=(const Obj& obj) noexcept
+    {
+        static_cast<Obj&>(*this) = obj;
+        return *this;
+    }
+
+private:
+    FullPath get_path() const override
+    {
+        return Obj::get_path();
+    }
+    Path get_short_path() const override
+    {
+        return Obj::get_short_path();
+    }
+    ColKey get_col_key() const noexcept override
+    {
+        return Obj::get_col_key();
+    }
+    StablePath get_stable_path() const override
+    {
+        return Obj::get_stable_path();
+    }
+    void add_index(Path& path, const Index& ndx) const override
+    {
+        Obj::add_index(path, ndx);
+    }
+    size_t find_index(const Index&) const override
+    {
+        return realm::npos;
+    }
+    TableRef get_table() const noexcept override
+    {
+        return Obj::get_table();
+    }
+    UpdateStatus update_if_needed() const override
+    {
+        return Obj::update_if_needed();
+    }
+    const Obj& get_object() const noexcept override
+    {
+        return *this;
+    }
+    uint32_t parent_version() const noexcept override
+    {
+        return m_version_counter;
+    }
+    ref_type get_collection_ref(Index index, CollectionType type) const override
+    {
+        return Obj::get_collection_ref(index, type);
+    }
+    bool check_collection_ref(Index index, CollectionType type) const noexcept override
+    {
+        return Obj::check_collection_ref(index, type);
+    }
+    void set_collection_ref(Index index, ref_type ref, CollectionType type) override
+    {
+        Obj::set_collection_ref(index, ref, type);
+    }
 };
 
 std::ostream& operator<<(std::ostream&, const Obj& obj);

--- a/src/realm/object-store/collection_notifications.hpp
+++ b/src/realm/object-store/collection_notifications.hpp
@@ -106,7 +106,7 @@ struct CollectionChangeSet {
     // Per-column version of `modifications`
     std::unordered_map<int64_t, IndexSet> columns;
 
-    std::set<StablePath> paths;
+    std::set<StableIndex> paths;
 
     bool empty() const noexcept
     {

--- a/src/realm/object-store/impl/collection_notifier.hpp
+++ b/src/realm/object-store/impl/collection_notifier.hpp
@@ -381,6 +381,18 @@ private:
     RealmCoordinator* m_coordinator = nullptr;
 };
 
+class NotifierRunLogger {
+public:
+    NotifierRunLogger(util::Logger* logger, std::string_view name, std::string_view description);
+    ~NotifierRunLogger();
+
+private:
+    util::Logger* m_logger;
+    std::string_view m_name;
+    std::string_view m_description;
+    std::chrono::steady_clock::time_point m_start;
+};
+
 } // namespace realm::_impl
 
 #endif /* REALM_BACKGROUND_COLLECTION_HPP */

--- a/src/realm/object-store/impl/list_notifier.hpp
+++ b/src/realm/object-store/impl/list_notifier.hpp
@@ -34,6 +34,7 @@ public:
 private:
     PropertyType m_type;
     CollectionBasePtr m_list;
+    CollectionParent* m_collection_parent = nullptr;
 
     // The last-seen size of the collection so that when the parent of the collection
     // is deleted we can report each row as being deleted

--- a/src/realm/object-store/impl/object_notifier.cpp
+++ b/src/realm/object-store/impl/object_notifier.cpp
@@ -64,16 +64,7 @@ void ObjectNotifier::run()
 {
     if (!m_table || !m_info)
         return;
-    using namespace std::chrono;
-    auto t1 = steady_clock::now();
-    util::ScopeExit cleanup([&]() noexcept {
-        m_run_time_point = steady_clock::now();
-        if (m_logger) {
-            m_logger->log(util::LogCategory::notification, util::Logger::Level::debug,
-                          "ObjectNotifier %1 did run in %2 us", m_description,
-                          duration_cast<microseconds>(m_run_time_point - t1).count());
-        }
-    });
+    NotifierRunLogger log(m_logger.get(), "ObjectNotifier", m_description);
 
     auto it = m_info->tables.find(m_table->get_key());
     if (it != m_info->tables.end() && it->second.deletions_contains(m_obj_key)) {

--- a/src/realm/object-store/impl/results_notifier.cpp
+++ b/src/realm/object-store/impl/results_notifier.cpp
@@ -393,13 +393,13 @@ void ListResultsNotifier::run()
         std::iota(m_run_indices->begin(), m_run_indices->end(), 0);
     }
 
+    // Modifications to nested values in Mixed are recorded in replication as
+    // StableIndex and we have to look up the actual index afterwards
     if (m_change.paths.size()) {
         if (auto coll = dynamic_cast<CollectionParent*>(m_list.get())) {
             for (auto& p : m_change.paths) {
-                // Report changes in substructure as modifications on this list
-                auto ndx = coll->find_index(p[0]);
-                if (ndx != realm::not_found)
-                    m_change.modifications.add(ndx); // OK to insert same index again
+                if (auto ndx = coll->find_index(p); ndx != realm::not_found)
+                    m_change.modifications.add(ndx);
             }
         }
     }

--- a/src/realm/object-store/impl/results_notifier.cpp
+++ b/src/realm/object-store/impl/results_notifier.cpp
@@ -65,12 +65,12 @@ ResultsNotifier::ResultsNotifier(Results& target)
     , m_target_is_in_table_order(target.is_in_table_order())
 {
     if (m_logger) {
-        m_description = std::string("'") + std::string(m_query->get_table()->get_class_name()) + std::string("'");
+        m_description = "'" + std::string(m_query->get_table()->get_class_name()) + "'";
         if (m_query->has_conditions()) {
             m_description += " where \"";
             m_description += m_query->get_description_safe() + "\"";
         }
-        m_logger->log(util::LogCategory::notification, util::Logger::Level::debug, "Creating ResultsNotifier for ",
+        m_logger->log(util::LogCategory::notification, util::Logger::Level::debug, "Creating ResultsNotifier for %1",
                       m_description);
     }
     reattach();
@@ -151,19 +151,9 @@ void ResultsNotifier::calculate_changes()
 
 void ResultsNotifier::run()
 {
-    using namespace std::chrono;
+    NotifierRunLogger log(m_logger.get(), "ResultsNotifier", m_description);
 
     REALM_ASSERT(m_info || !has_run());
-
-    auto t1 = steady_clock::now();
-    util::ScopeExit cleanup([&]() noexcept {
-        m_run_time_point = steady_clock::now();
-        if (m_logger) {
-            m_logger->log(util::LogCategory::notification, util::Logger::Level::debug,
-                          "ResultsNotifier %1 did run in %2 us", m_description,
-                          duration_cast<microseconds>(m_run_time_point - t1).count());
-        }
-    });
 
     // Table's been deleted, so report all objects as deleted
     if (!m_query->get_table()) {
@@ -278,7 +268,7 @@ ListResultsNotifier::ListResultsNotifier(Results& target)
         auto path = m_list->get_short_path();
         auto prop_name = m_list->get_table()->get_column_name(path[0].get_col_key());
         path[0] = PathElement(prop_name);
-        std::string sort_order;
+        std::string_view sort_order = "";
         if (m_sort_order) {
             sort_order = *m_sort_order ? " sorted ascending" : " sorted descending";
         }
@@ -358,17 +348,6 @@ void ListResultsNotifier::calculate_changes()
 
 void ListResultsNotifier::run()
 {
-    using namespace std::chrono;
-    auto t1 = steady_clock::now();
-    util::ScopeExit cleanup([&]() noexcept {
-        m_run_time_point = steady_clock::now();
-        if (m_logger) {
-            m_logger->log(util::LogCategory::notification, util::Logger::Level::debug,
-                          "ListResultsNotifier %1 did run in %2 us", m_description,
-                          duration_cast<microseconds>(m_run_time_point - t1).count());
-        }
-    });
-
     if (!m_list || !m_list->is_attached()) {
         // List was deleted, so report all of the rows being removed
         m_change = {};
@@ -379,9 +358,10 @@ void ListResultsNotifier::run()
     }
 
     if (!need_to_run()) {
-        cleanup.cancel();
         return;
     }
+
+    NotifierRunLogger log(m_logger.get(), "ListResultsNotifier", m_description);
 
     m_run_indices = std::vector<size_t>();
     if (m_distinct)

--- a/src/realm/object-store/impl/transact_log_handler.cpp
+++ b/src/realm/object-store/impl/transact_log_handler.cpp
@@ -368,21 +368,19 @@ public:
     {
         modify_object(col, obj);
         auto table = current_table();
+        m_active_collection = nullptr;
         for (auto& c : m_info.collections) {
-
             if (c.table_key == table && c.obj_key == obj && c.path.is_prefix_of(path)) {
                 if (c.path.size() != path.size()) {
-                    StablePath sub_path;
-                    sub_path.insert(sub_path.begin(), path.begin() + c.path.size(), path.end());
-                    c.changes->paths.insert(std::move(sub_path));
+                    c.changes->paths.insert(path[c.path.size()]);
                 }
-                else {
+                // If there are multiple exact matches for this collection we
+                // use the first and then propagate the data to the others later
+                else if (!m_active_collection) {
                     m_active_collection = c.changes;
-                    return true;
                 }
             }
         }
-        m_active_collection = nullptr;
         return true;
     }
 

--- a/src/realm/path.hpp
+++ b/src/realm/path.hpp
@@ -271,54 +271,45 @@ private:
  */
 class StableIndex {
 public:
-    StableIndex()
-    {
-        value.raw = 0;
-    }
+    StableIndex() = default;
     StableIndex(ColKey col_key, int64_t salt)
     {
-        value.col_index = col_key.get_index().val;
-        value.is_collection = col_key.is_collection();
-        value.is_column = true;
-        value.salt = int32_t(salt);
+        m_col_index = col_key.get_index().val;
+        m_is_collection = col_key.is_collection();
+        m_is_column = true;
+        m_salt = int32_t(salt);
     }
     StableIndex(int64_t salt)
     {
-        value.raw = 0;
-        value.salt = int32_t(salt);
+        m_salt = int32_t(salt);
     }
     int64_t get_salt() const
     {
-        return value.salt;
+        return m_salt;
     }
     ColKey::Idx get_index() const noexcept
     {
-        return {unsigned(value.col_index)};
+        return {unsigned(m_col_index)};
     }
     bool is_collection() const noexcept
     {
-        return value.is_collection;
+        return m_is_collection;
     }
 
     bool operator==(const StableIndex& other) const noexcept
     {
-        return value.is_column ? value.col_index == other.value.col_index : value.salt == other.value.salt;
+        return m_is_column ? m_col_index == other.m_col_index : m_salt == other.m_salt;
     }
     bool operator<(const StableIndex& other) const noexcept
     {
-        return value.is_column ? value.col_index < other.value.col_index : value.salt < other.value.salt;
+        return m_is_column ? m_col_index < other.m_col_index : m_salt < other.m_salt;
     }
 
 private:
-    union {
-        struct {
-            bool is_column;
-            bool is_collection;
-            int16_t col_index;
-            int32_t salt;
-        };
-        int64_t raw;
-    } value;
+    bool m_is_column = false;
+    bool m_is_collection = false;
+    int16_t m_col_index = 0;
+    int32_t m_salt = 0;
 };
 
 static_assert(sizeof(StableIndex) == 8);

--- a/src/realm/replication.cpp
+++ b/src/realm/replication.cpp
@@ -177,7 +177,7 @@ void Replication::remove_object(const Table* t, ObjKey key)
     m_encoder.remove_object(key); // Throws
 }
 
-inline void Replication::select_obj(ObjKey key)
+void Replication::select_obj(ObjKey key)
 {
     if (key == m_selected_obj) {
         return;

--- a/src/realm/set.cpp
+++ b/src/realm/set.cpp
@@ -273,32 +273,6 @@ void CollectionBaseImpl<SetBase>::to_json(std::ostream& out, JSONOutputMode outp
     }
 }
 
-bool SetBase::do_init_from_parent(ref_type ref, bool allow_create) const
-{
-    try {
-        if (ref) {
-            m_tree->init_from_ref(ref);
-        }
-        else {
-            if (m_tree->init_from_parent()) {
-                // All is well
-                return true;
-            }
-            if (!allow_create) {
-                return false;
-            }
-            // The ref in the column was NULL, create the tree in place.
-            m_tree->create();
-            REALM_ASSERT(m_tree->is_attached());
-        }
-    }
-    catch (...) {
-        m_tree->detach();
-        throw;
-    }
-    return true;
-}
-
 void SetBase::resort_range(size_t start, size_t end)
 {
     if (end > size()) {

--- a/src/realm/set.hpp
+++ b/src/realm/set.hpp
@@ -103,7 +103,7 @@ public:
         this->set_owner(owner, col_key);
     }
 
-    Set(ColKey col_key)
+    Set(ColKey col_key, size_t = 0)
         : Base(col_key)
     {
         if (!col_key.is_set()) {

--- a/src/realm/set.hpp
+++ b/src/realm/set.hpp
@@ -57,7 +57,6 @@ protected:
     void erase_repl(Replication* repl, size_t index, Mixed value) const;
     void clear_repl(Replication* repl) const;
     static std::vector<Mixed> convert_to_mixed_set(const CollectionBase& rhs);
-    bool do_init_from_parent(ref_type ref, bool allow_create) const;
 
     void resort_range(size_t from, size_t to);
 
@@ -195,7 +194,7 @@ public:
         return tree();
     }
 
-    UpdateStatus update_if_needed_with_status() const final;
+    UpdateStatus update_if_needed() const final;
     void ensure_created();
 
     void migrate();
@@ -216,12 +215,12 @@ private:
         return static_cast<BPlusTree<T>&>(*m_tree);
     }
 
-    bool init_from_parent(bool allow_create) const;
+    UpdateStatus init_from_parent(bool allow_create) const;
 
     /// Update the accessor and return true if it is attached after the update.
     inline bool update() const
     {
-        return update_if_needed_with_status() != UpdateStatus::Detached;
+        return update_if_needed() != UpdateStatus::Detached;
     }
 
     // `do_` methods here perform the action after preconditions have been
@@ -377,7 +376,7 @@ private:
     // Overriding members of ObjCollectionBase:
     UpdateStatus do_update_if_needed() const final
     {
-        return m_set.update_if_needed_with_status();
+        return m_set.update_if_needed();
     }
 
     BPlusTree<ObjKey>* get_mutable_tree() const final
@@ -494,10 +493,9 @@ inline Set<T>& Set<T>::operator=(Set&& other) noexcept
 }
 
 template <typename T>
-UpdateStatus Set<T>::update_if_needed_with_status() const
+UpdateStatus Set<T>::update_if_needed() const
 {
-    auto status = Base::get_update_status();
-    switch (status) {
+    switch (get_update_status()) {
         case UpdateStatus::Detached: {
             m_tree.reset();
             return UpdateStatus::Detached;
@@ -509,11 +507,8 @@ UpdateStatus Set<T>::update_if_needed_with_status() const
             // The tree has not been initialized yet for this accessor, so
             // perform lazy initialization by treating it as an update.
             [[fallthrough]];
-        case UpdateStatus::Updated: {
-            bool attached = init_from_parent(false);
-            Base::update_content_version();
-            return attached ? UpdateStatus::Updated : UpdateStatus::Detached;
-        }
+        case UpdateStatus::Updated:
+            return init_from_parent(false);
     }
     REALM_UNREACHABLE();
 }
@@ -526,19 +521,19 @@ void Set<T>::ensure_created()
         // In case of errors, an exception is thrown.
         constexpr bool allow_create = true;
         init_from_parent(allow_create); // Throws
-        Base::update_content_version();
     }
 }
 
 template <typename T>
-bool Set<T>::init_from_parent(bool allow_create) const
+UpdateStatus Set<T>::init_from_parent(bool allow_create) const
 {
+    Base::update_content_version();
     if (!m_tree) {
         m_tree.reset(new BPlusTree<T>(get_alloc()));
         const ArrayParent* parent = this;
         m_tree->set_parent(const_cast<ArrayParent*>(parent), 0);
     }
-    return do_init_from_parent(Base::get_collection_ref(), allow_create);
+    return do_init_from_parent(m_tree.get(), Base::get_collection_ref(), allow_create);
 }
 
 template <typename U>

--- a/src/realm/transaction.cpp
+++ b/src/realm/transaction.cpp
@@ -419,7 +419,7 @@ _impl::History* Transaction::get_history() const
 Obj Transaction::import_copy_of(const Obj& original)
 {
     if (bool(original) && original.is_valid()) {
-        TableKey tk = original.get_table_key();
+        TableKey tk = original.get_table()->get_key();
         ObjKey rk = original.get_key();
         auto table = get_table(tk);
         if (table->is_valid(rk))

--- a/src/realm/util/logger.hpp
+++ b/src/realm/util/logger.hpp
@@ -497,6 +497,12 @@ protected:
     std::shared_ptr<Logger> m_chained_logger;
 };
 
+/// A logger that performs a noop when logging functions are called
+class NullLogger : public Logger {
+    // Since we don't want to log anything, do_log() does nothing
+    void do_log(const LogCategory&, Level, const std::string&) override {}
+};
+
 
 // Implementation
 

--- a/test/object-store/audit.cpp
+++ b/test/object-store/audit.cpp
@@ -52,18 +52,11 @@ using namespace std::string_literals;
 using Catch::Matchers::StartsWith;
 using nlohmann::json;
 
-namespace {
-class NullLogger : public util::Logger {
-    // Since we don't want to log anything, do_log() does nothing
-    void do_log(const util::LogCategory&, Level, const std::string&) override {}
-};
-} // namespace
-
 static auto audit_logger =
 #ifdef AUDIT_LOG_LEVEL
     std::make_shared<util::StderrLogger>(AUDIT_LOG_LEVEL);
 #else
-    std::make_shared<NullLogger>();
+    std::make_shared<util::NullLogger>();
 #endif
 
 namespace {

--- a/test/object-store/benchmarks/client_reset.cpp
+++ b/test/object-store/benchmarks/client_reset.cpp
@@ -139,10 +139,7 @@ struct BenchmarkLocalClientReset : public reset_utils::TestClientReset {
         Transaction& wt_local = (Transaction&)m_local->read_group();
         VersionID current_local_version = wt_local.get_version_of_current_transaction();
 
-        class NullLogger : public util::Logger {
-            // Since we don't want to log anything, do_log() does nothing
-            void do_log(const util::LogCategory&, Level, const std::string&) override {}
-        } logger;
+        util::NullLogger logger;
 
         if (m_mode == ClientResyncMode::Recover) {
             auto history_local = dynamic_cast<sync::ClientHistory*>(wt_local.get_replication()->_get_history_write());

--- a/test/object-store/dictionary.cpp
+++ b/test/object-store/dictionary.cpp
@@ -63,9 +63,7 @@ struct StringMaker<object_store::Dictionary> {
 namespace cf = realm::collection_fixtures;
 
 TEST_CASE("nested dictionary in mixed", "[dictionary]") {
-
     InMemoryTestFile config;
-    config.cache = false;
     config.automatic_change_notifications = false;
     config.schema = Schema{{"any_collection", {{"any", PropertyType::Mixed | PropertyType::Nullable}}}};
 

--- a/test/object-store/nested_collections.cpp
+++ b/test/object-store/nested_collections.cpp
@@ -36,7 +36,6 @@ using namespace realm;
 
 TEST_CASE("nested-list-mixed", "[nested-collections]") {
     InMemoryTestFile config;
-    config.cache = false;
     config.automatic_change_notifications = false;
     auto r = Realm::get_shared_realm(config);
     r->update_schema({{

--- a/test/object-store/object.cpp
+++ b/test/object-store/object.cpp
@@ -160,7 +160,6 @@ TEST_CASE("object") {
     _impl::RealmCoordinator::assert_no_open_realms();
 
     InMemoryTestFile config;
-    config.cache = false;
     config.automatic_change_notifications = false;
     config.schema_mode = SchemaMode::AdditiveExplicit;
     config.schema = Schema{

--- a/test/object-store/primitive_list.cpp
+++ b/test/object-store/primitive_list.cpp
@@ -983,7 +983,6 @@ TEST_CASE("list of mixed links", "[primitives]") {
 
 TEST_CASE("list of strings - with index", "[primitives]") {
     InMemoryTestFile config;
-    config.cache = false;
     config.automatic_change_notifications = false;
     config.schema = Schema{
         {"object",

--- a/test/test_client_reset.cpp
+++ b/test/test_client_reset.cpp
@@ -1477,13 +1477,6 @@ TEST(ClientReset_Recover_RecoverableChangesOnListsAfterUnrecoverableAreNotDuplic
     CHECK_EQUAL(changes.size(), 1);
 }
 
-namespace {
-class NullLogger : public util::Logger {
-    // Since we don't want to log anything, do_log() does nothing
-    void do_log(const util::LogCategory&, Level, const std::string&) override {}
-};
-} // namespace
-
 // Apply uploaded changes in src to dst as if they had been exchanged by sync
 void apply_changes(DB& src, DB& dst)
 {
@@ -1515,7 +1508,7 @@ void apply_changes(DB& src, DB& dst)
     dst_progress.download.server_version += remote_changesets.size();
     dst_progress.latest_server_version.version += remote_changesets.size();
 
-    NullLogger logger;
+    util::NullLogger logger;
     VersionInfo new_version;
     dst_history.integrate_server_changesets(dst_progress, nullptr, remote_changesets, new_version,
                                             DownloadBatchState::SteadyState, logger, dst.start_read());

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -5843,8 +5843,8 @@ TEST(Parser_CollectionLinks)
     Obj charlie = persons->create_object_with_primary_key("charlie");
 
     Obj david = persons->create_object_with_primary_key("david");
-    Obj elisabeth = persons->create_object_with_primary_key("elisabeth");
-    Obj felix = persons->create_object_with_primary_key("felix");
+    persons->create_object_with_primary_key("elisabeth");
+    persons->create_object_with_primary_key("felix");
 
     Obj gary = persons->create_object_with_primary_key("gary");
     Obj hutch = persons->create_object_with_primary_key("hutch");


### PR DESCRIPTION
Adding a base class and virtual functions to Obj turned out to have a measurable performance impact due to that it inhibits a lot of optimizations that are possible for trivial types (10-15% in the obj-c read benchmarks, which includes some SDK overhead so the slowdown in the core part is bigger). Moving the implementation of CollectionParent to a separate adaptor type fixes this, but requires some code movement.

I found the logic around when collections need to update difficult to follow and so attempted to simplify it. `update_if_needed()` did meaningfully different things on collections and Obj, with `Obj::update_if_needed_with_status()` being equivalent to `Collection::update_if_needed()`. I renamed these to make Obj match collection and use `checked_update_if_needed()` for the version that throws when detached. A lot of the updating logic was duplicated between the various collections, so I consolidated the parts which logically should always be identical.

All of the tests passed with clearly incorrect handling of m_parent_version (such as never setting it at all on ObjCollectionParent), which made it hard to tell what it was even needed for. I shifted it to only ever being incremented in Obj and then propagated downwards, which makes it harder to mask bugs. Making it uint32_t cuts the size of Obj by 8 bytes on 64-bit platforms since there's otherwise 7 bytes of trailing padding; it's unclear if this is actually useful.