### PR TITLE
Use the bfd linker in the armv7 toolchain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 -----------
 
 ### Internals
-* None.
+* The Linux-armv7 cross-compiling toolchain file prefers the bfd linker over gold because of issues linking against OpenSSL 3.2.0.
 
 ----------------------------------------------
 

--- a/tools/cmake/armv7-linux-gnueabihf.toolchain.cmake
+++ b/tools/cmake/armv7-linux-gnueabihf.toolchain.cmake
@@ -1,3 +1,8 @@
 set(_TRIPLET "armv7-unknown-linux-gnueabihf")
 set(_TOOLCHAIN_MD5 fbf817b1428bb35c93be8e6c15f73d7d)
 include("${CMAKE_CURRENT_LIST_DIR}/linux.toolchain.base.cmake")
+
+# Explicitly opt-in to the slower bfd linker over gold, because gold in GCC 11.2 doesn't play nice with R_ARM_REL32 relocations
+set(CMAKE_EXE_LINKER_FLAGS_INIT "-fuse-ld=bfd ${CMAKE_EXE_LINKER_FLAGS_INIT}")
+set(CMAKE_SHARED_LINKER_FLAGS_INIT "-fuse-ld=bfd ${CMAKE_SHARED_LINKER_FLAGS_INIT}")
+set(CMAKE_MODULE_LINKER_FLAGS_INIT "-fuse-ld=bfd ${CMAKE_MODULE_LINKER_FLAGS_INIT}")


### PR DESCRIPTION
## What, How & Why?
Explicitly opt-in to the slower bfd linker over gold, because gold in GCC 11.2 doesn't play nice with R_ARM_REL32 relocations and OpenSSL 3.2 started to expose symbols like `OPENSSL_armcap_P` with this kind of relocation.

## ☑️ ToDos
* [x] 📝 Changelog update

