### PR TITLE
Delete leftover code for Set's order differing from Mixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Internals
 * Fix several crashes when running the object store benchmarks ([#7403](https://github.com/realm/realm-core/pull/7403)).
+* Remove SetElementEquals and SetElementLessThan, as Mixed now uses the same comparisons as Set did.
 
 ----------------------------------------------
 

--- a/src/realm/bplustree.hpp
+++ b/src/realm/bplustree.hpp
@@ -207,6 +207,7 @@ public:
 
     virtual void erase(size_t) = 0;
     virtual void clear() = 0;
+    virtual void swap(size_t, size_t) = 0;
 
     void create();
     void destroy();
@@ -416,7 +417,7 @@ public:
         m_root->bptree_access(n, func);
     }
 
-    void swap(size_t ndx1, size_t ndx2)
+    void swap(size_t ndx1, size_t ndx2) override
     {
         if constexpr (std::is_same_v<T, StringData> || std::is_same_v<T, BinaryData>) {
             struct SwapBuffer {

--- a/src/realm/set.cpp
+++ b/src/realm/set.cpp
@@ -299,6 +299,31 @@ bool SetBase::do_init_from_parent(ref_type ref, bool allow_create) const
     return true;
 }
 
+void SetBase::resort_range(size_t start, size_t end)
+{
+    if (end > size()) {
+        end = size();
+    }
+    if (start >= end) {
+        return;
+    }
+    std::vector<size_t> indices;
+    indices.resize(end - start);
+    std::iota(indices.begin(), indices.end(), 0);
+    std::sort(indices.begin(), indices.end(), [&](auto a, auto b) {
+        return get_any(a + start) < get_any(b + start);
+    });
+    for (size_t i = 0; i < indices.size(); ++i) {
+        if (indices[i] != i) {
+            m_tree->swap(i + start, start + indices[i]);
+            auto it = std::find(indices.begin() + i, indices.end(), i);
+            REALM_ASSERT(it != indices.end());
+            *it = indices[i];
+            indices[i] = i;
+        }
+    }
+}
+
 /********************************* Set<Key> *********************************/
 
 template <>
@@ -444,32 +469,6 @@ void Set<Mixed>::migrate()
     }
 }
 
-template <class T>
-void Set<T>::do_resort(size_t start, size_t end)
-{
-    if (end > size()) {
-        end = size();
-    }
-    if (start >= end) {
-        return;
-    }
-    std::vector<size_t> indices;
-    indices.resize(end - start);
-    std::iota(indices.begin(), indices.end(), 0);
-    std::sort(indices.begin(), indices.end(), [&](auto a, auto b) {
-        return get(a + start) < get(b + start);
-    });
-    for (size_t i = 0; i < indices.size(); ++i) {
-        if (indices[i] != i) {
-            tree().swap(i + start, start + indices[i]);
-            auto it = std::find(indices.begin() + i, indices.end(), i);
-            REALM_ASSERT(it != indices.end());
-            *it = indices[i];
-            indices[i] = i;
-        }
-    }
-}
-
 template <>
 void Set<Mixed>::migration_resort()
 {
@@ -478,21 +477,21 @@ void Set<Mixed>::migration_resort()
     auto last_binary = std::partition_point(first_string, end(), [](const Mixed& item) {
         return item.is_type(type_String, type_Binary);
     });
-    do_resort(first_string.index(), last_binary.index());
+    resort_range(first_string.index(), last_binary.index());
 }
 
 template <>
 void Set<StringData>::migration_resort()
 {
     // sort order of strings changed
-    do_resort(0, size());
+    resort_range(0, size());
 }
 
 template <>
 void Set<BinaryData>::migration_resort()
 {
     // sort order of binaries changed
-    do_resort(0, size());
+    resort_range(0, size());
 }
 
 void LnkSet::remove_target_row(size_t link_ndx)

--- a/src/realm/set.cpp
+++ b/src/realm/set.cpp
@@ -525,7 +525,6 @@ void LnkSet::to_json(std::ostream& out, JSONOutputMode, util::FunctionRef<void(c
     out << "]";
 }
 
-
 void set_sorted_indices(size_t sz, std::vector<size_t>& indices, bool ascending)
 {
     indices.resize(sz);
@@ -536,48 +535,4 @@ void set_sorted_indices(size_t sz, std::vector<size_t>& indices, bool ascending)
         std::iota(indices.rbegin(), indices.rend(), 0);
     }
 }
-
-template <typename Iterator>
-static bool partition_points(const Set<Mixed>& set, std::vector<size_t>& indices, Iterator& first_string,
-                             Iterator& first_binary, Iterator& end)
-{
-    first_string = std::partition_point(indices.begin(), indices.end(), [&](size_t i) {
-        return set.get(i).is_type(type_Bool, type_Int, type_Float, type_Double, type_Decimal);
-    });
-    if (first_string == indices.end() || !set.get(*first_string).is_type(type_String))
-        return false;
-    first_binary = std::partition_point(first_string + 1, indices.end(), [&](size_t i) {
-        return set.get(i).is_type(type_String);
-    });
-    if (first_binary == indices.end() || !set.get(*first_binary).is_type(type_Binary))
-        return false;
-    end = std::partition_point(first_binary + 1, indices.end(), [&](size_t i) {
-        return set.get(i).is_type(type_Binary);
-    });
-    return true;
-}
-
-template <>
-void Set<Mixed>::sort(std::vector<size_t>& indices, bool ascending) const
-{
-    set_sorted_indices(size(), indices, true);
-
-    // The on-disk order is bool -> numbers -> string -> binary -> others
-    // We want to merge the string and binary sections to match the sort order
-    // of other collections. To do this we find the three partition points
-    // where the first string occurs, the first binary occurs, and the first
-    // non-binary after binaries occurs. If there's no strings or binaries we
-    // don't have to do anything. If they're both non-empty, we perform an
-    // in-place merge on the strings and binaries.
-    std::vector<size_t>::iterator first_string, first_binary, end;
-    if (partition_points(*this, indices, first_string, first_binary, end)) {
-        std::inplace_merge(first_string, first_binary, end, [&](auto a, auto b) {
-            return get(a) < get(b);
-        });
-    }
-    if (!ascending) {
-        std::reverse(indices.begin(), indices.end());
-    }
-}
-
 } // namespace realm

--- a/src/realm/set.cpp
+++ b/src/realm/set.cpp
@@ -55,7 +55,7 @@ void SetBase::clear_repl(Replication* repl) const
 static std::vector<Mixed> convert_to_set(const CollectionBase& rhs)
 {
     std::vector<Mixed> mixed(rhs.begin(), rhs.end());
-    std::sort(mixed.begin(), mixed.end(), SetElementLessThan<Mixed>());
+    std::sort(mixed.begin(), mixed.end());
     mixed.erase(std::unique(mixed.begin(), mixed.end()), mixed.end());
     return mixed;
 }
@@ -72,7 +72,7 @@ bool SetBase::is_subset_of(const CollectionBase& rhs) const
 template <class It1, class It2>
 bool SetBase::is_subset_of(It1 first, It2 last) const
 {
-    return std::includes(first, last, begin(), end(), SetElementLessThan<Mixed>{});
+    return std::includes(first, last, begin(), end());
 }
 
 bool SetBase::is_strict_subset_of(const CollectionBase& rhs) const
@@ -96,7 +96,7 @@ bool SetBase::is_superset_of(const CollectionBase& rhs) const
 template <class It1, class It2>
 bool SetBase::is_superset_of(It1 first, It2 last) const
 {
-    return std::includes(begin(), end(), first, last, SetElementLessThan<Mixed>{});
+    return std::includes(begin(), end(), first, last);
 }
 
 bool SetBase::is_strict_superset_of(const CollectionBase& rhs) const
@@ -120,13 +120,12 @@ bool SetBase::intersects(const CollectionBase& rhs) const
 template <class It1, class It2>
 bool SetBase::intersects(It1 first, It2 last) const
 {
-    SetElementLessThan<Mixed> less;
     auto it = begin();
     while (it != end() && first != last) {
-        if (less(*it, *first)) {
+        if (*it < *first) {
             ++it;
         }
-        else if (less(*first, *it)) {
+        else if (*first < *it) {
             ++first;
         }
         else {
@@ -161,7 +160,7 @@ template <class It1, class It2>
 void SetBase::assign_union(It1 first, It2 last)
 {
     std::vector<Mixed> the_diff;
-    std::set_difference(first, last, begin(), end(), std::back_inserter(the_diff), SetElementLessThan<Mixed>{});
+    std::set_difference(first, last, begin(), end(), std::back_inserter(the_diff));
     // 'the_diff' now contains all the elements that are in foreign set, but not in 'this'
     // Now insert those elements
     for (auto&& value : the_diff) {
@@ -185,7 +184,7 @@ template <class It1, class It2>
 void SetBase::assign_intersection(It1 first, It2 last)
 {
     std::vector<Mixed> intersection;
-    std::set_intersection(first, last, begin(), end(), std::back_inserter(intersection), SetElementLessThan<Mixed>{});
+    std::set_intersection(first, last, begin(), end(), std::back_inserter(intersection));
     clear();
     // Elements in intersection comes from foreign set, so ok to use here
     for (auto&& value : intersection) {
@@ -210,7 +209,7 @@ template <class It1, class It2>
 void SetBase::assign_difference(It1 first, It2 last)
 {
     std::vector<Mixed> intersection;
-    std::set_intersection(first, last, begin(), end(), std::back_inserter(intersection), SetElementLessThan<Mixed>{});
+    std::set_intersection(first, last, begin(), end(), std::back_inserter(intersection));
     // 'intersection' now contains all the elements that are in both foreign set and 'this'.
     // Remove those elements. The elements comes from the foreign set, so ok to refer to.
     for (auto&& value : intersection) {
@@ -235,9 +234,9 @@ template <class It1, class It2>
 void SetBase::assign_symmetric_difference(It1 first, It2 last)
 {
     std::vector<Mixed> difference;
-    std::set_difference(first, last, begin(), end(), std::back_inserter(difference), SetElementLessThan<Mixed>{});
+    std::set_difference(first, last, begin(), end(), std::back_inserter(difference));
     std::vector<Mixed> intersection;
-    std::set_intersection(first, last, begin(), end(), std::back_inserter(intersection), SetElementLessThan<Mixed>{});
+    std::set_intersection(first, last, begin(), end(), std::back_inserter(intersection));
     // Now remove the common elements and add the differences
     for (auto&& value : intersection) {
         erase_any(value);

--- a/src/realm/set.hpp
+++ b/src/realm/set.hpp
@@ -759,9 +759,6 @@ inline void Set<T>::sort(std::vector<size_t>& indices, bool ascending) const
     set_sorted_indices(sz, indices, ascending);
 }
 
-template <>
-void Set<Mixed>::sort(std::vector<size_t>& indices, bool ascending) const;
-
 template <class T>
 void Set<T>::distinct(std::vector<size_t>& indices, util::Optional<bool> sort_order) const
 {

--- a/src/realm/set.hpp
+++ b/src/realm/set.hpp
@@ -59,6 +59,8 @@ protected:
     static std::vector<Mixed> convert_to_mixed_set(const CollectionBase& rhs);
     bool do_init_from_parent(ref_type ref, bool allow_create) const;
 
+    void resort_range(size_t from, size_t to);
+
     REALM_COLD REALM_NORETURN void throw_invalid_null()
     {
         throw InvalidArgument(ErrorCodes::PropertyNotNullable,
@@ -227,7 +229,6 @@ private:
     void do_insert(size_t ndx, T value);
     void do_erase(size_t ndx);
     void do_clear();
-    void do_resort(size_t from, size_t to);
 
     iterator find_impl(const T& value) const;
 };

--- a/src/realm/set.hpp
+++ b/src/realm/set.hpp
@@ -412,91 +412,6 @@ void Set<StringData>::migration_resort();
 template <>
 void Set<BinaryData>::migration_resort();
 
-/// Compare set elements.
-///
-/// We cannot use `std::less<>` directly, because the ordering of set elements
-/// impacts the file format. For primitive types this is trivial (and can indeed
-/// be just `std::less<>`), but for example `Mixed` has specialized comparison
-/// that defines equality of numeric types.
-template <class T>
-struct SetElementLessThan {
-    bool operator()(const T& a, const T& b) const noexcept
-    {
-        // CAUTION: This routine is technically part of the file format, because
-        // it determines the storage order of Set elements.
-        return a < b;
-    }
-};
-
-template <class T>
-struct SetElementEquals {
-    bool operator()(const T& a, const T& b) const noexcept
-    {
-        // CAUTION: This routine is technically part of the file format, because
-        // it determines the storage order of Set elements.
-        return a == b;
-    }
-};
-
-template <>
-struct SetElementLessThan<Mixed> {
-    bool operator()(const Mixed& a, const Mixed& b) const noexcept
-    {
-        // CAUTION: This routine is technically part of the file format, because
-        // it determines the storage order of Set elements.
-
-        // These are the rules for comparison of Mixed types in a Set<Mixed>:
-        // - If both values are null they are equal
-        // - If only one value is null, that value is lesser than the other
-        // - All numeric types are compared as the corresponding real numbers
-        //   would compare. So integer 3 equals double 3.
-        // - String and binary types are compared using lexicographical comparison.
-        // - All other types are compared using the comparison operators defined
-        //   for the types.
-        // - If two values have different types, the rank of the types are compared.
-        //   the rank is as follows:
-        //       boolean
-        //       numeric
-        //       string
-        //       binary
-        //       Timestamp
-        //       ObjectId
-        //       UUID
-        //       TypedLink
-        //       Link
-        //
-        // The current Mixed::compare function implements these rules except when comparing
-        // string and binary. If that function is changed we should either implement the rules
-        // here or upgrade all Set<Mixed> columns.
-        if (a.is_type(type_String) && b.is_type(type_Binary)) {
-            return true;
-        }
-        if (a.is_type(type_Binary) && b.is_type(type_String)) {
-            return false;
-        }
-        return a.compare(b) < 0;
-    }
-};
-
-template <>
-struct SetElementEquals<Mixed> {
-    bool operator()(const Mixed& a, const Mixed& b) const noexcept
-    {
-        // CAUTION: This routine is technically part of the file format, because
-        // it determines the storage order of Set elements.
-
-        // See comments above
-
-        if (a.is_type(type_String) && b.is_type(type_Binary)) {
-            return false;
-        }
-        if (a.is_type(type_Binary) && b.is_type(type_String)) {
-            return false;
-        }
-        return a.compare(b) == 0;
-    }
-};
-
 inline SetBase::SetBase(const SetBase& other)
     : CollectionBase(other)
 {
@@ -656,7 +571,7 @@ template <class T>
 size_t Set<T>::find(T value) const
 {
     auto it = find_impl(value);
-    if (it != end() && SetElementEquals<T>{}(*it, value)) {
+    if (it != end() && *it == value) {
         return it.index();
     }
     return npos;
@@ -686,7 +601,7 @@ REALM_NOINLINE auto Set<T>::find_impl(const T& value) const -> iterator
 {
     auto b = this->begin();
     auto e = this->end(); // Note: This ends up calling `update_if_needed()`.
-    return std::lower_bound(b, e, value, SetElementLessThan<T>{});
+    return std::lower_bound(b, e, value);
 }
 
 template <class T>
@@ -698,7 +613,7 @@ std::pair<size_t, bool> Set<T>::insert(T value)
         throw_invalid_null();
 
     auto it = find_impl(value);
-    if (it != this->end() && SetElementEquals<T>{}(*it, value)) {
+    if (it != this->end() && *it == value) {
         return {it.index(), false};
     }
 
@@ -735,7 +650,7 @@ std::pair<size_t, bool> Set<T>::erase(T value)
 {
     auto it = find_impl(value); // Note: This ends up calling `update_if_needed()`.
 
-    if (it == end() || !SetElementEquals<T>{}(*it, value)) {
+    if (it == end() || *it != value) {
         return {npos, false};
     }
 

--- a/test/util/compare_groups.cpp
+++ b/test/util/compare_groups.cpp
@@ -108,7 +108,7 @@ different:
 template <class T>
 bool compare_set_values(const Set<T>& a, const Set<T>& b)
 {
-    return compare_arrays(a, b, SetElementEquals<T>{});
+    return compare_arrays(a, b);
 }
 
 bool compare_dictionaries(const Dictionary& a, const Dictionary& b)


### PR DESCRIPTION
Now that Mixed uses the same comparisons as Set we don't need all the support code for using a different order in Set.