### PR TITLE
Fix LnkLst propagation of context_flag when replacing the root during erase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Fixed an issue when removing items from a LnkLst that could result in invalidated links becoming visable which could cause crashes or exceptions when accessing those list items later on. ([#7414](https://github.com/realm/realm-core/pull/7414), since v10.0.0)
 
 ### Breaking changes
 * None.

--- a/src/realm/bplustree.cpp
+++ b/src/realm/bplustree.cpp
@@ -802,14 +802,14 @@ void BPlusTreeBase::bptree_erase(size_t n, BPlusTreeNode::EraseFunc func)
     size_t root_size = m_root->bptree_erase(n, func);
     while (!m_root->is_leaf() && root_size == 1) {
         BPlusTreeInner* node = static_cast<BPlusTreeInner*>(m_root.get());
-
+        ref_type orig_root_ref = node->get_ref();
         ref_type new_root_ref = node->clear_first_bp_node_ref();
-        node->destroy_deep();
-
         auto new_root = create_root_from_ref(new_root_ref);
 
         replace_root(std::move(new_root));
         root_size = m_root->get_node_size();
+        // destroy after replace_root for valid context flag lookup
+        Array::destroy_deep(orig_root_ref, m_alloc);
     }
 }
 

--- a/test/test_unresolved_links.cpp
+++ b/test/test_unresolved_links.cpp
@@ -270,6 +270,17 @@ TEST(Unresolved_LinkList)
 
     LnkLst stock_copy{stock1};
     CHECK_EQUAL(stock_copy.get(3), mercedes.get_key());
+    CHECK_EQUAL(stock_copy.size(), 4);
+
+    // Also check that the context flag is copied over when replacing the root during erase
+    stock_copy.remove(0);
+    CHECK_EQUAL(stock_copy.size(), 3);
+    stock_copy.remove(0);
+    CHECK_EQUAL(stock_copy.size(), 2);
+    stock_copy.remove(0);
+    CHECK_EQUAL(stock_copy.size(), 1);
+    stock_copy.remove(0);
+    CHECK_EQUAL(stock_copy.size(), 0);
 }
 
 TEST(Unresolved_LinkSet)


### PR DESCRIPTION
Jonathan reported a failure in a new evergreen runner that was running the client reset tests under a REALM_MAX_BPNODE_SIZE=4 configuration. It turns out that we have never run any sync tests with this enabled on CI. The test happened to hit a case of removing an element from a LnkLst that also had an invalidated object in it and this was causing strange [failures](https://spruce.mongodb.com/task/realm_core_stable_ubuntu2204_arm64_small_bpnode_object_store_tests_patch_ccc6bf93cad5d44aec533f504e5897f9a645e86d_65e1df509ccd4edc492fedb6_24_03_01_14_00_00?execution=0&sortBy=STATUS&sortDir=ASC).

```
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[2024/03/01 06:23:06.284] 3: realm-object-store-tests is a Catch2 v3.5.2 host application.
[2024/03/01 06:23:06.284] 3: Run with -? for options
[2024/03/01 06:23:06.284] 3:
[2024/03/01 06:23:06.284] 3: -------------------------------------------------------------------------------
[2024/03/01 06:23:06.284] 3: client reset collections of links - cf::ListOfObjects
[2024/03/01 06:23:06.284] 3:   local has unresolved links
[2024/03/01 06:23:06.284] 3:   local adds two new links and remote deletes a different dest object
[2024/03/01 06:23:06.284] 3: -------------------------------------------------------------------------------
[2024/03/01 06:23:06.284] 3: /data/mci/789a545b0869856ff4579cad2dba5e38/realm-core/test/object-store/sync/client_reset.cpp:2987
[2024/03/01 06:23:06.284] 3: ...............................................................................
[2024/03/01 06:23:06.284] 3:
[2024/03/01 06:23:06.284] 3: /data/mci/789a545b0869856ff4579cad2dba5e38/realm-core/test/object-store/sync/client_reset.cpp:2756: FAILED:
[2024/03/01 06:23:06.284] 3:   {Unknown expression after the reported line}
[2024/03/01 06:23:06.284] 3: due to unexpected exception with messages:
[2024/03/01 06:23:06.284] 3:   test_mode := DiscardLocal
[2024/03/01 06:23:06.284] 3:   No object with key '-3' in 'class_dest'
[2024/03/01 06:23:06.284] 3:
[2024/03/01 06:23:06.284] 3: Assertion failure: /data/mci/789a545b0869856ff4579cad2dba5e38/realm-core/test/object-store/sync/client_reset.cpp:2756
[2024/03/01 06:23:06.284] 3: 	 from expresion: '{Unknown expression after the reported line}'
[2024/03/01 06:23:06.284] 3: 	 with expansion: '{Unknown expression after the reported line}'
[2024/03/01 06:23:06.284] 3: 	 message: test_mode := DiscardLocal
[2024/03/01 06:23:06.284] 3: 	 message: No object with key '-3' in 'class_dest'
```

We were using a ref lookup to get the context flag from an array that had just been deleted, so when doing an erase on a LnkLst that triggered a root_replace,  the context flag was always false.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [x] C-API, if public C++ API changed
* [x] `bindgen/spec.yml`, if public C++ API changed
