### PR TITLE
RCORE-1987 network::Service does not start waiting on timers if no other events are currently active

### DIFF
--- a/src/realm/sync/network/network.hpp
+++ b/src/realm/sync/network/network.hpp
@@ -1279,6 +1279,9 @@ private:
 
 
 /// \brief A timer object supporting asynchronous wait operations.
+///
+/// NOTE: The DeadlineTimer is not thread safe and async_wait() or cancel()
+/// must be called prior to calling run() or directly from the event loop.
 class DeadlineTimer {
 public:
     DeadlineTimer(Service&);


### PR DESCRIPTION
## What, How & Why?
Since the DeadlineTimer is not thread safe, added comment that `async_wait()` or `cancel()` must be called from the event loop.

Fixes #7364

## ☑️ ToDos
* ~~[ ] 📝 Changelog update~~
* ~~[ ] 🚦 Tests (or not relevant)~~
* ~~[ ] C-API, if public C++ API changed~~
* ~~[ ] `bindgen/spec.yml`, if public C++ API changed~~
