### PR TITLE
Improve performance of aggregate operations on empty dictionaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Enhancements
 * Add support to synchronize collections embedded in Mixed properties and other collections (except sets) ([PR #7353](https://github.com/realm/realm-core/pull/7353)).
 * Improve performance of change notifications on nested collections somewhat ([PR #7402](https://github.com/realm/realm-core/pull/7402)).
+* Improve performance of aggregate operations on Dictionaries of objects, particularly when the dictionaries are empty ([PR #7418](https://github.com/realm/realm-core/pull/7418))
 
 ### Fixed
 * Fixed conflict resolution bug which may result in an crash when the AddInteger instruction on Mixed properties is merged against updates to a non-integer type ([PR #7353](https://github.com/realm/realm-core/pull/7353)).

--- a/src/realm/dictionary.cpp
+++ b/src/realm/dictionary.cpp
@@ -1190,6 +1190,14 @@ void Dictionary::set_collection_ref(Index index, ref_type ref, CollectionType ty
     m_values->set(ndx, Mixed(ref, type));
 }
 
+LinkCollectionPtr Dictionary::clone_as_obj_list() const
+{
+    if (get_value_data_type() == type_Link) {
+        return std::make_unique<DictionaryLinkValues>(*this);
+    }
+    return nullptr;
+}
+
 /************************* DictionaryLinkValues *************************/
 
 DictionaryLinkValues::DictionaryLinkValues(const Obj& obj, ColKey col_key)

--- a/src/realm/dictionary.hpp
+++ b/src/realm/dictionary.hpp
@@ -226,6 +226,8 @@ public:
 
     void to_json(std::ostream&, JSONOutputMode, util::FunctionRef<void(const Mixed&)>) const override;
 
+    LinkCollectionPtr clone_as_obj_list() const final;
+
 private:
     using Base::set_collection;
 

--- a/src/realm/object-store/results.cpp
+++ b/src/realm/object-store/results.cpp
@@ -810,13 +810,8 @@ Query Results::do_get_query() const
             return Query(m_table, std::make_unique<TableView>(m_table_view));
         }
         case Mode::Collection:
-            if (auto list = dynamic_cast<ObjList*>(m_collection.get())) {
-                return m_table->where(*list);
-            }
-            if (auto dict = dynamic_cast<Dictionary*>(m_collection.get())) {
-                if (dict->get_value_data_type() == type_Link) {
-                    return m_table->where(*dict);
-                }
+            if (auto objlist = m_collection->clone_as_obj_list()) {
+                return m_table->where(std::move(objlist));
             }
             return m_query;
         case Mode::Table:

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -1082,9 +1082,9 @@ void Table::do_erase_root_column(ColKey col_key)
     bump_storage_version();
 }
 
-Query Table::where(const DictionaryLinkValues& dictionary_of_links) const
+Query Table::where(const Dictionary& dict) const
 {
-    return Query(m_own_ref, dictionary_of_links);
+    return Query(m_own_ref, dict.clone_as_obj_list());
 }
 
 void Table::set_table_type(Type table_type, bool handle_backlinks)

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -591,7 +591,11 @@ public:
     {
         return Query(m_own_ref, list);
     }
-    Query where(const DictionaryLinkValues& dictionary_of_links) const;
+    Query where(const Dictionary& dict) const;
+    Query where(LinkCollectionPtr&& list) const
+    {
+        return Query(m_own_ref, std::move(list));
+    }
 
     Query query(const std::string& query_string,
                 const std::vector<mpark::variant<Mixed, std::vector<Mixed>>>& arguments = {}) const;


### PR DESCRIPTION
This fixes the one remaining v14 perf regression reported by the object store benchmarks. It ended up being a sort of fake optimization - it makes sum() on empty dictionaries more than twice as fast, but once there's a single object it's only 10% faster and is meaningless for any larger - but IMO it's a net improvement to the code.