### PR TITLE
WIP fix some warnings on windows + fix 32 bits builds an incorrect use of size_t 

### DIFF
--- a/src/realm/array.cpp
+++ b/src/realm/array.cpp
@@ -269,7 +269,7 @@ void Array::init_from_mem(MemRef mem) noexcept
         // encoder knows which format we are compressed into, width and size are read accordingly with the format of
         // the header
         m_size = m_encoder.size();
-        m_width = m_encoder.width();
+        m_width = static_cast<uint_least8_t>(m_encoder.width());
         // we need to compute lower and upper bound, these are useful during Array::find and in general in every query
         // related optimisation.
         if (m_width) {

--- a/src/realm/array_direct.hpp
+++ b/src/realm/array_direct.hpp
@@ -233,7 +233,7 @@ class bf_ref;
 class bf_iterator {
     uint64_t* data_area;
     uint64_t* first_word_ptr;
-    size_t field_position;
+    uint64_t field_position;
     uint8_t field_size;
     uint8_t step_size; // may be different than field_size if used for arrays of pairs
 
@@ -303,11 +303,12 @@ public:
         auto first_word = first_word_ptr[0];
         uint64_t mask = 0 - 1ULL;
         if (field_size < 64) {
-            mask = static_cast<size_t>((1ULL << field_size) - 1);
+            //we should never cast to size_t, but to uint64_t in order to support 32 bits
+            mask = static_cast<uint64_t>((1ULL << field_size) - 1);
             value &= mask;
         }
         // zero out field in first word:
-        auto first_word_mask = ~(mask << in_word_position);
+        uint64_t first_word_mask = ~(mask << in_word_position);
         first_word &= first_word_mask;
         // or in relevant part of value
         first_word |= value << in_word_position;
@@ -391,14 +392,14 @@ inline void write_bitfield(uint64_t* data_area, size_t field_position, size_t wi
 
 inline int64_t sign_extend_field_by_mask(size_t sign_mask, uint64_t value)
 {
-    uint64_t sign_extension = 0 - (value & sign_mask);
+    uint64_t sign_extension = (uint64_t)0 - (value & sign_mask);
     return value | sign_extension;
 }
 
 inline int64_t sign_extend_value(size_t width, uint64_t value)
 {
     uint64_t sign_mask = 1ULL << (width - 1);
-    uint64_t sign_extension = 0 - (value & sign_mask);
+    uint64_t sign_extension = (uint64_t)0 - (value & sign_mask);
     return value | sign_extension;
 }
 

--- a/src/realm/array_encode.cpp
+++ b/src/realm/array_encode.cpp
@@ -94,8 +94,8 @@ bool ArrayEncode::always_encode(const Array& origin, Array& arr, bool packed) co
 
 bool ArrayEncode::encode(const Array& origin, Array& arr) const
 {
-    // return false;
-    // return always_encode(origin, arr, true); // true packed, false flex
+    //return false;
+    return always_encode(origin, arr, true); // true packed, false flex
 
     std::vector<int64_t> values;
     std::vector<size_t> indices;
@@ -292,7 +292,11 @@ size_t ArrayEncode::packed_encoded_array_size(std::vector<int64_t>& values, size
 {
     using Encoding = NodeHeader::Encoding;
     const auto [min_value, max_value] = std::minmax_element(values.begin(), values.end());
-    v_width = std::max(Node::signed_to_num_bits(*min_value), Node::signed_to_num_bits(*max_value));
+    if (min_value == max_value)
+        v_width = Node::signed_to_num_bits(*min_value);
+    else 
+        v_width = std::max(Node::signed_to_num_bits(*min_value), Node::signed_to_num_bits(*max_value));
+    
     REALM_ASSERT_DEBUG(v_width > 0);
     return NodeHeader::calc_size<Encoding::Packed>(sz, v_width);
 }

--- a/src/realm/array_flex.cpp
+++ b/src/realm/array_flex.cpp
@@ -177,13 +177,13 @@ bool ArrayFlex::find_all(const Array& arr, int64_t value, size_t start, size_t e
 
 template <typename Cond, bool v>
 inline size_t ArrayFlex::parallel_subword_find(const Array& arr, uint64_t value, size_t width_mask, size_t offset,
-                                               uint_least8_t width, size_t start, size_t end) const
+                                               size_t width, size_t start, size_t end) const
 {
-    const auto MSBs = populate(width, width_mask);
-    const auto search_vector = populate(width, value);
-    const auto field_count = num_fields_for_width(width);
-    const auto bit_count_pr_iteration = num_bits_for_width(width);
-    auto total_bit_count_left = static_cast<signed>(end - start) * width;
+    const auto MSBs = populate(static_cast<int>(width), width_mask);
+    const auto search_vector = populate(static_cast<int>(width), value);
+    const auto field_count = num_fields_for_width(static_cast<int>(width));
+    const auto bit_count_pr_iteration = num_bits_for_width(static_cast<int>(width));
+    int64_t total_bit_count_left = static_cast<int64_t>((end - start) * width);
     REALM_ASSERT(total_bit_count_left >= 0);
     auto bitwidth_cmp = [&MSBs](uint64_t a, uint64_t b) {
         if constexpr (std::is_same_v<Cond, Equal>)
@@ -218,12 +218,12 @@ inline size_t ArrayFlex::parallel_subword_find(const Array& arr, uint64_t value,
         it.bump(bit_count_pr_iteration);
     }
     if (total_bit_count_left) {                         // final subword, may be partial
-        const auto word = it.get(total_bit_count_left); // <-- limit lookahead to avoid touching memory beyond array
+        const auto word = it.get(static_cast<unsigned int>(total_bit_count_left)); // <-- limit lookahead to avoid touching memory beyond array
         vector = bitwidth_cmp(word, search_vector);
         auto last_word_mask = 0xFFFFFFFFFFFFFFFFULL >> (64 - total_bit_count_left);
         vector &= last_word_mask;
         if (vector) {
-            int sub_word_index = first_field_marked(width, vector);
+            int sub_word_index = first_field_marked(static_cast<int>(width), vector);
             return start + sub_word_index;
         }
     }
@@ -343,7 +343,7 @@ int64_t ArrayFlex::sum(const Array& arr, size_t start, size_t end) const
 
     bf_iterator it_index{data, static_cast<size_t>(offset), ndx_width, ndx_width, start};
     for (; start < end; ++start, ++it_index) {
-        const auto v = read_bitfield(data, it_index.get_value() * v_width, v_width);
+        const auto v = read_bitfield(data, static_cast<size_t>(it_index.get_value() * v_width), v_width);
         acc += sign_extend_field_by_mask(mask, v);
     }
     return acc;

--- a/src/realm/array_flex.hpp
+++ b/src/realm/array_flex.hpp
@@ -50,7 +50,7 @@ private:
     bool find_all_match(size_t start, size_t end, size_t baseindex, QueryStateBase* state) const;
 
     template <typename Cond, bool = true> // true int64_t other uint64_t
-    inline size_t parallel_subword_find(const Array&, uint64_t, size_t, size_t, uint_least8_t, size_t, size_t) const;
+    inline size_t parallel_subword_find(const Array&, uint64_t, size_t, size_t, size_t, size_t, size_t) const;
 
     bool find_eq(const Array&, int64_t, size_t, size_t, size_t, QueryStateBase*) const;
     bool find_neq(const Array&, int64_t, size_t, size_t, size_t, QueryStateBase*) const;

--- a/src/realm/array_packed.cpp
+++ b/src/realm/array_packed.cpp
@@ -58,10 +58,6 @@ void ArrayPacked::copy_data(const Array& origin, Array& arr) const
         const auto v = origin.get(i);
         it_value.set_value(v);
         const auto sv = sign_extend_value(v_width, *it_value);
-        /* std::cout << "Value = " << origin.get(i) << ", stored = " << it_value.get_value()
-                  << ",  converted = " << sv
-                  << std::endl; */
-                  
         REALM_ASSERT_DEBUG(sv == v);
         ++it_value;
     }

--- a/src/realm/array_packed.cpp
+++ b/src/realm/array_packed.cpp
@@ -55,8 +55,14 @@ void ArrayPacked::copy_data(const Array& origin, Array& arr) const
     auto data = (uint64_t*)arr.m_data;
     bf_iterator it_value{data, 0, v_width, v_width, 0};
     for (size_t i = 0; i < v_size; ++i) {
-        it_value.set_value(origin.get(i));
-        REALM_ASSERT_DEBUG(sign_extend_value(v_width, it_value.get_value()) == origin.get(i));
+        const auto v = origin.get(i);
+        it_value.set_value(v);
+        const auto sv = sign_extend_value(v_width, *it_value);
+        /* std::cout << "Value = " << origin.get(i) << ", stored = " << it_value.get_value()
+                  << ",  converted = " << sv
+                  << std::endl; */
+                  
+        REALM_ASSERT_DEBUG(sv == v);
         ++it_value;
     }
 }

--- a/src/realm/node_header.hpp
+++ b/src/realm/node_header.hpp
@@ -174,13 +174,15 @@ public:
 
     static size_t unsigned_to_num_bits(uint64_t value)
     {
-        return 1 + log2(static_cast<size_t>(value));
+        return 1 + static_cast<size_t>(std::log2(value));
+        //REALM_DEBUG_ASSERT( == );
+        //return 1 + log2(value);
     }
 
     static size_t signed_to_num_bits(int64_t value)
     {
         if (value >= 0)
-            return 1 + unsigned_to_num_bits(value);
+            return 1+unsigned_to_num_bits(value);
         else
             return 1 + unsigned_to_num_bits(~value); // <-- is this correct????
     }
@@ -401,11 +403,11 @@ public:
         }
         else if (enc == Encoding::Packed) {
             hb[2] = 0;
-            hb[3] = bits_pr_elem;
+            hb[3] = static_cast<uint8_t>(bits_pr_elem);
             hb[4] = (flags << 5) | (wtype_Extend << 3);
             hb[5] = (uint8_t)enc - wtype_Extend;
             auto hw = (uint16_t*)header;
-            hw[3] = num_elems;
+            hw[3] = static_cast<uint16_t>(num_elems);
         }
         else {
             REALM_ASSERT(false && "Illegal header encoding for chosen kind of header");
@@ -452,8 +454,8 @@ public:
         REALM_ASSERT(bits_pr_elemB <= 64);
         REALM_ASSERT(num_elemsA < 1024);
         REALM_ASSERT(num_elemsB < 1024);
-        hh[1] = ((bits_pr_elemB - 1) << 10) | num_elemsB;
-        hh[3] = ((bits_pr_elemA - 1) << 10) | num_elemsA;
+        hh[1] = static_cast<uint16_t>(((bits_pr_elemB - 1) << 10) | num_elemsB);
+        hh[3] = static_cast<uint16_t>(((bits_pr_elemA - 1) << 10) | num_elemsA);
     }
 
     // Setting element size for encodings with a single element size:
@@ -530,7 +532,7 @@ void inline NodeHeader::set_element_size<NodeHeader::Encoding::Packed>(char* hea
 {
     REALM_ASSERT(get_encoding(header) == Encoding::Packed);
     REALM_ASSERT(bits_per_element <= 64);
-    ((uint8_t*)header)[3] = static_cast<uint16_t>(bits_per_element);
+    ((uint8_t*)header)[3] = static_cast<uint8_t>(bits_per_element);
 }
 template <>
 void inline NodeHeader::set_element_size<NodeHeader::Encoding::WTypBits>(char* header, size_t bits_per_element)

--- a/src/realm/utilities.hpp
+++ b/src/realm/utilities.hpp
@@ -156,10 +156,14 @@ private:
 };
 
 // log2 - returns -1 if x==0, otherwise log2(x)
-inline int log2(size_t x)
+// size_t is not the right type, or probably we should not use this utility for compressed arrays, on 32 bits size_t
+// is defined as unsigned int (max 32 bits), if we pass here a 64 bit number, size_t will overflow, and howevere max bit witdh can only be 32.
+// which is not necesserely correct. int64_t or uint64_t is supported on 32 bits machines.
+inline int log2(size_t x) 
 {
     if (x == 0)
         return -1;
+
 #if defined(__GNUC__)
 #ifdef REALM_PTR_64
     return 63 - __builtin_clzll(x); // returns int
@@ -175,6 +179,7 @@ inline int log2(size_t x)
 #endif
     return static_cast<int>(index);
 #else // not __GNUC__ and not _WIN32
+
     int r = 0;
     while (x >>= 1) {
         r++;

--- a/test/test_array_integer.cpp
+++ b/test/test_array_integer.cpp
@@ -1285,6 +1285,20 @@ NONCONCURRENT_TEST(Test_basic_find_GT_value_greater_32bit)
 
 #endif
 
+ONLY(Test_ArrayInt_negative_nums)
+{
+    ArrayInteger a(Allocator::get_default());
+    ArrayInteger a1(Allocator::get_default());
+    a.create();
+    a.add(4427957085475570907);
+    //a.add(-4427957085475570907);
+    CHECK_NOT(a.is_encoded());
+    CHECK(a.try_encode(a1));
+    CHECK(a1.get(0) == a.get(0));
+    //CHECK(a1.get(1) == a.get(1));
+    a1.destroy();
+}
+
 // packed is always on
 #if 0
 TEST(Test_ArrayInt_no_encode)
@@ -1305,7 +1319,6 @@ TEST(Test_ArrayInt_no_encode)
     a.destroy();
     a1.destroy();
 }
-#endif
 
 TEST(Test_array_same_size_less_bits)
 {
@@ -1328,7 +1341,6 @@ TEST(Test_array_same_size_less_bits)
     a1.destroy();
 }
 
-#if 0
 TEST(Test_ArrayInt_encode_decode_needed)
 {
     ArrayInteger a(Allocator::get_default());
@@ -1378,7 +1390,6 @@ TEST(Test_ArrayInt_encode_decode_needed)
     a.destroy();
     a1.destroy();
 }
-#endif
 
 TEST(Test_ArrayInt_negative_nums)
 {
@@ -1619,6 +1630,8 @@ TEST(Test_ArrayInt_compress_data_init_from_mem)
     CHECK_NOT(a1.is_attached());
     CHECK_NOT(a2.is_attached());
 }
+#endif
+
 
 TEST(ArrayIntNull_SetNull)
 {


### PR DESCRIPTION
## What, How & Why?
WIP. Contains some fixes for some warnings + uses `uint64_t` instead of `size_t` in order to make compressed arrays compatible with 32 bits builds.

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed
* [ ] `bindgen/spec.yml`, if public C++ API changed
