### PR TITLE
Fix some warnings that Visual Studio keeps reporting

### DIFF
--- a/src/realm/array.cpp
+++ b/src/realm/array.cpp
@@ -269,7 +269,7 @@ void Array::init_from_mem(MemRef mem) noexcept
         // encoder knows which format we are compressed into, width and size are read accordingly with the format of
         // the header
         m_size = m_encoder.size();
-        m_width = m_encoder.width();
+        m_width = static_cast<uint_least8_t>(m_encoder.width());
         // we need to compute lower and upper bound, these are useful during Array::find and in general in every query
         // related optimisation.
         if (m_width) {
@@ -283,7 +283,6 @@ void Array::init_from_mem(MemRef mem) noexcept
         m_is_inner_bptree_node = get_is_inner_bptree_node_from_header(header);
         m_has_refs = get_hasrefs_from_header(header);
         m_context_flag = get_context_flag_from_header(header);
-        // TODO: evaluate if we can get rid of this.
         m_vtable = &VTableForEncodedArray::vtable;
         m_getter = m_vtable->getter;
     }

--- a/src/realm/array_encode.hpp
+++ b/src/realm/array_encode.hpp
@@ -69,7 +69,7 @@ private:
     bool always_encode(const Array&, Array&, bool) const; // for testing
 private:
     using Encoding = NodeHeader::Encoding;
-    Encoding m_encoding{NodeHeader::Encoding::WTypBits}; // this is not ok .... probably
+    Encoding m_encoding{NodeHeader::Encoding::WTypBits};
     size_t m_v_width = 0, m_v_size = 0, m_ndx_width = 0, m_ndx_size = 0;
     uint64_t m_v_mask = 0, m_ndx_mask = 0;
 

--- a/src/realm/node_header.hpp
+++ b/src/realm/node_header.hpp
@@ -409,11 +409,11 @@ public:
         }
         else if (enc == Encoding::Packed) {
             hb[2] = 0;
-            hb[3] = bits_pr_elem;
+            hb[3] = static_cast<uint8_t>(bits_pr_elem);
             hb[4] = (flags << 5) | (wtype_Extend << 3);
-            hb[5] = (uint8_t)enc - wtype_Extend;
+            hb[5] = static_cast<uint8_t>(enc) - wtype_Extend;
             auto hw = (uint16_t*)header;
-            hw[3] = num_elems;
+            hw[3] = static_cast<uint16_t>(num_elems);
         }
         else {
             REALM_ASSERT(false && "Illegal header encoding for chosen kind of header");
@@ -460,8 +460,8 @@ public:
         REALM_ASSERT(bits_pr_elemB <= 64);
         REALM_ASSERT(num_elemsA < 1024);
         REALM_ASSERT(num_elemsB < 1024);
-        hh[1] = ((bits_pr_elemB - 1) << 10) | num_elemsB;
-        hh[3] = ((bits_pr_elemA - 1) << 10) | num_elemsA;
+        hh[1] = static_cast<uint16_t>(((bits_pr_elemB - 1) << 10) | num_elemsB);
+        hh[3] = static_cast<uint16_t>(((bits_pr_elemA - 1) << 10) | num_elemsA);
     }
 
     // Setting element size for encodings with a single element size:
@@ -538,7 +538,7 @@ void inline NodeHeader::set_element_size<NodeHeader::Encoding::Packed>(char* hea
 {
     REALM_ASSERT(get_encoding(header) == Encoding::Packed);
     REALM_ASSERT(bits_per_element <= 64);
-    ((uint8_t*)header)[3] = static_cast<uint16_t>(bits_per_element);
+    ((uint8_t*)header)[3] = static_cast<uint8_t>(bits_per_element);
 }
 template <>
 void inline NodeHeader::set_element_size<NodeHeader::Encoding::WTypBits>(char* header, size_t bits_per_element)


### PR DESCRIPTION
## What, How & Why?
Visual Studio keeps reporting some warnings on some implicit casting that are indeed safe, considering the layout of the encoded arrays.
