### PR TITLE
RCORE-2004 Make Realm::call_completion_callbacks() resilient to trasaction being deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@
 * Improve performance of change notifications on nested collections somewhat ([PR #7402](https://github.com/realm/realm-core/pull/7402)).
 
 ### Fixed
+* <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Fixed conflict resolution bug which may result in an crash when the AddInteger instruction on Mixed properties is merged against updates to a non-integer type ([PR #7353](https://github.com/realm/realm-core/pull/7353)).
 * Fix a spurious crash related to opening a Realm on background thread while the process was in the middle of exiting ([#7420](https://github.com/realm/realm-core/issues/7420jj))
 * Fix a data race in change notification delivery when running at debug log level ([PR #7402](https://github.com/realm/realm-core/pull/7402), since v14.0.0).
 * Fix a 10-15% performance regression when reading data from the Realm resulting from Obj being made a non-trivial type ([PR #7402](https://github.com/realm/realm-core/pull/7402), since v14.0.0).
+* Null pointer exception may be triggered when logging out and async commits callbacks not executed ([#7434](https://github.com/realm/realm-core/issues/7434), since v13.26.0)
 
 ### Breaking changes
 * Remove `realm_scheduler_set_default_factory()` and `realm_scheduler_has_default_factory()`, and change the `Scheduler` factory function to a bare function pointer rather than a `UniqueFunction` so that it does not have a non-trivial destructor.

--- a/src/realm/collection_parent.cpp
+++ b/src/realm/collection_parent.cpp
@@ -75,7 +75,7 @@ CollectionParent::~CollectionParent() {}
 
 void CollectionParent::check_level() const
 {
-    if (m_level + 1 > s_max_level) {
+    if (size_t(m_level) + 1 > s_max_level) {
         throw LogicError(ErrorCodes::LimitExceeded, "Max nesting level reached");
     }
 }

--- a/src/realm/object-store/shared_realm.cpp
+++ b/src/realm/object-store/shared_realm.cpp
@@ -765,12 +765,12 @@ void Realm::run_writes_on_proper_thread()
 
 void Realm::call_completion_callbacks()
 {
-    if (m_is_running_async_commit_completions) {
+    if (m_is_running_async_commit_completions || m_async_commit_q.empty()) {
         return;
     }
 
     CountGuard sending_completions(m_is_running_async_commit_completions);
-    auto error = m_transaction ? m_transaction->get_commit_exception() : nullptr;
+    auto error = m_transaction->get_commit_exception();
     auto completions = std::move(m_async_commit_q);
     m_async_commit_q.clear();
     for (auto& cb : completions) {

--- a/src/realm/object-store/shared_realm.cpp
+++ b/src/realm/object-store/shared_realm.cpp
@@ -777,7 +777,7 @@ void Realm::call_completion_callbacks()
     }
 
     CountGuard sending_completions(m_is_running_async_commit_completions);
-    auto error = m_transaction->get_commit_exception();
+    auto error = m_transaction ? m_transaction->get_commit_exception() : nullptr;
     auto completions = std::move(m_async_commit_q);
     m_async_commit_q.clear();
     for (auto& cb : completions) {

--- a/test/object-store/realm.cpp
+++ b/test/object-store/realm.cpp
@@ -2494,9 +2494,9 @@ TEST_CASE("Call run_async_completions after realm has been closed") {
         scheduler->cv.wait(lock, [&] {
             return !scheduler->callbacks.empty();
         });
-        realm->close();
         callbacks.swap(scheduler->callbacks);
     }
+    realm->close();
     // Call whatever functions that was added to scheduler.
     for (auto& cb : callbacks)
         cb();

--- a/test/object-store/realm.cpp
+++ b/test/object-store/realm.cpp
@@ -2440,6 +2440,68 @@ TEST_CASE("SharedRealm: async writes") {
 
     _impl::RealmCoordinator::clear_all_caches();
 }
+
+TEST_CASE("Call run_async_completions after realm has been closed") {
+    // This requires a special scheduler as we have to call Realm::close
+    // just after DB::AsyncCommitHelper has made a callback to the function
+    // that asks the scheduler to invoke run_async_completions()
+
+    struct ManualScheduler : util::Scheduler {
+        std::mutex mutex;
+        std::condition_variable cv;
+        std::vector<util::UniqueFunction<void()>> callbacks;
+
+        void invoke(util::UniqueFunction<void()>&& cb) override
+        {
+            {
+                std::lock_guard lock(mutex);
+                callbacks.push_back(std::move(cb));
+            }
+            cv.notify_all();
+        }
+
+        bool is_on_thread() const noexcept override
+        {
+            return true;
+        }
+        bool is_same_as(const Scheduler*) const noexcept override
+        {
+            return false;
+        }
+        bool can_invoke() const noexcept override
+        {
+            return true;
+        }
+    };
+
+    auto scheduler = std::make_shared<ManualScheduler>();
+
+    TestFile config;
+    config.schema_version = 0;
+    config.schema = Schema{{"object", {{"value", PropertyType::Int}}}};
+    config.scheduler = scheduler;
+    config.automatic_change_notifications = false;
+
+    auto realm = Realm::get_shared_realm(config);
+
+    realm->begin_transaction();
+    realm->async_commit_transaction([](std::exception_ptr) {});
+
+    std::vector<util::UniqueFunction<void()>> callbacks;
+    {
+        std::unique_lock lock(scheduler->mutex);
+        // Wait for scheduler to be invoked
+        scheduler->cv.wait(lock, [&] {
+            return !scheduler->callbacks.empty();
+        });
+        realm->close();
+        callbacks.swap(scheduler->callbacks);
+    }
+    // Call whatever functions that was added to scheduler.
+    for (auto& cb : callbacks)
+        cb();
+}
+
 // Our libuv scheduler currently does not support background threads, so we can
 // only run this on apple platforms
 #if REALM_PLATFORM_APPLE


### PR DESCRIPTION
## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- Link to relevant issue this fixes -->
Fixes #7434 
I was not able to reproduce the problem, so mayby we are not getting the full picture. But this change will at lease prevent a nullpointer exception if the transaction is terminated.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [x] C-API, if public C++ API changed
* [x] `bindgen/spec.yml`, if public C++ API changed
