### PR TITLE
Improve queries for encoded arrays.

### DIFF
--- a/src/realm/array.hpp
+++ b/src/realm/array.hpp
@@ -333,6 +333,8 @@ public:
     /// by doing a linear search for short sequences.
     size_t lower_bound_int(int64_t value) const noexcept;
     size_t upper_bound_int(int64_t value) const noexcept;
+    size_t lower_bound_int_encoded(int64_t value) const noexcept;
+    size_t upper_bound_int_encoded(int64_t value) const noexcept;
     //@}
 
     int64_t get_sum(size_t start = 0, size_t end = size_t(-1)) const

--- a/src/realm/array.hpp
+++ b/src/realm/array.hpp
@@ -421,8 +421,19 @@ public:
     template <class cond>
     size_t find_first(int64_t value, size_t start = 0, size_t end = size_t(-1)) const
     {
-        return do_find_first<cond>(value, start, end);
+        QueryStateFindFirst state;
+        Finder finder = m_vtable->finder[cond::condition];
+        (this->*finder)(value, start, end, 0, &state);
+        return state.m_state;
     }
+
+    template <class cond>
+    bool find(int64_t value, size_t start, size_t end, size_t baseIndex, QueryStateBase* state) const
+    {
+        Finder finder = m_vtable->finder[cond::condition];
+        return (this->*finder)(value, start, end, baseIndex, state);
+    }
+
 
     /// Get the specified element without the cost of constructing an
     /// array instance. If an array instance is already available, or
@@ -530,10 +541,6 @@ protected:
     void destroy_children(size_t offset = 0) noexcept;
 
 protected:
-    // attempt to remove the vtabler
-    template <typename cond>
-    size_t do_find_first(int64_t value, size_t start, size_t end) const;
-
     // Getters and Setters for adaptive-packed arrays
     typedef int64_t (Array::*Getter)(size_t) const; // Note: getters must not throw
     typedef void (Array::*Setter)(size_t, int64_t);
@@ -551,7 +558,7 @@ protected:
     struct VTableForEncodedArray;
 
     // This is the one installed into the m_vtable->finder slots.
-    template <class cond, size_t bitwidth>
+    template <class cond>
     bool find_vtable(int64_t value, size_t start, size_t end, size_t baseindex, QueryStateBase* state) const;
 
     template <size_t w>

--- a/src/realm/array_direct.hpp
+++ b/src/realm/array_direct.hpp
@@ -961,11 +961,11 @@ inline int64_t default_fetcher(int w, const char* data, size_t ndx)
 
 struct EncodedFetcher {
 
-    int64_t operator()(int w, const char* data, size_t ndx) const
+    int64_t operator()(int, const char* data, size_t ndx) const
     {
         return ptr->get(data, ndx);
     }
-    ArrayEncode* ptr;
+    const ArrayEncode* ptr;
 };
 static EncodedFetcher s_encoded_fetcher;
 
@@ -1159,7 +1159,7 @@ inline size_t lower_bound(const char* data, size_t size, int64_t value) noexcept
 
 inline size_t lower_bound(const char* data, size_t size, int64_t value, const ArrayEncode& encoder) noexcept
 {
-    impl::s_encoded_fetcher.ptr = (ArrayEncode*)&encoder;
+    impl::s_encoded_fetcher.ptr = &encoder;
     return impl::lower_bound<0>(data, 0, size, value, impl::s_encoded_fetcher);
 }
 
@@ -1171,7 +1171,7 @@ inline size_t upper_bound(const char* data, size_t size, int64_t value) noexcept
 
 inline size_t upper_bound(const char* data, size_t size, int64_t value, const ArrayEncode& encoder) noexcept
 {
-    impl::s_encoded_fetcher.ptr = (ArrayEncode*)&encoder;
+    impl::s_encoded_fetcher.ptr = &encoder;
     return impl::lower_bound<0>(data, 0, size, value, impl::s_encoded_fetcher);
 }
 

--- a/src/realm/array_direct.hpp
+++ b/src/realm/array_direct.hpp
@@ -195,7 +195,7 @@ public:
     }
     // 'num_bits' number of bits which must be read
     // WARNING returned word may be garbage above the first 'num_bits' bits.
-    uint64_t get(unsigned num_bits)
+    uint64_t get(uint64_t num_bits)
     {
         auto first_word = m_word_ptr[0];
         uint64_t result = first_word >> m_in_word_offset;
@@ -210,7 +210,7 @@ public:
         return result;
     }
     // bump the iterator the specified number of bits
-    void bump(unsigned num_bits)
+    void bump(uint64_t num_bits)
     {
         auto total_offset = m_in_word_offset + num_bits;
         m_word_ptr += total_offset >> 6;
@@ -455,18 +455,18 @@ constexpr int num_bits_table[65] = {-1, 64, 64, 63, 64, 60, 60, 63, // 0-7
                                     56, 57, 58, 59, 60, 61, 62, 63, // 56-63
                                     64};
 
-inline int num_fields_for_width(int width)
+inline int num_fields_for_width(size_t width)
 {
     REALM_ASSERT(width);
     return 64 / width;
 }
 
-inline uint64_t num_bits(int width)
+inline int num_bits(int width)
 {
     return num_fields_table[width];
 }
 
-inline int num_bits_for_width(int width)
+inline int num_bits_for_width(size_t width)
 {
     return num_bits_table[width];
 }
@@ -485,7 +485,7 @@ bool inline any_field_NE(int width, uint64_t A, uint64_t B)
 
 // Populate all fields in a vector with a given value of a give width.
 // Bits outside of the given field are ignored.
-constexpr uint64_t populate(int width, uint64_t value)
+constexpr uint64_t populate(size_t width, uint64_t value)
 {
     value &= 0xFFFFFFFFFFFFFFFFULL >> (64 - width);
     if (width < 8) {
@@ -795,7 +795,7 @@ constexpr uint32_t inverse_width[65] = {
     65536 * 64 / 61, 65536 * 64 / 62, 65536 * 64 / 63, 65536 * 64 / 64,
 };
 
-inline int countr_zero(uint64_t vector)
+inline size_t countr_zero(uint64_t vector)
 {
     unsigned long where;
 #if defined(_WIN64)
@@ -821,10 +821,11 @@ inline int countr_zero(uint64_t vector)
 #endif
 }
 
-inline int first_field_marked(int width, uint64_t vector)
+inline size_t first_field_marked(size_t width, uint64_t vector)
 {
     const auto lz = countr_zero(vector);
-    int field = (lz * inverse_width[width]) >> 22;
+    const auto field = (lz * inverse_width[width]) >> 22;
+    REALM_ASSERT_DEBUG(width != 0);
     REALM_ASSERT_DEBUG(field == (lz / width));
     return field;
 }

--- a/src/realm/array_direct.hpp
+++ b/src/realm/array_direct.hpp
@@ -195,7 +195,7 @@ public:
     }
     // 'num_bits' number of bits which must be read
     // WARNING returned word may be garbage above the first 'num_bits' bits.
-    uint64_t get(uint64_t num_bits)
+    uint64_t get(size_t num_bits)
     {
         auto first_word = m_word_ptr[0];
         uint64_t result = first_word >> m_in_word_offset;
@@ -210,7 +210,7 @@ public:
         return result;
     }
     // bump the iterator the specified number of bits
-    void bump(uint64_t num_bits)
+    void bump(size_t num_bits)
     {
         auto total_offset = m_in_word_offset + num_bits;
         m_word_ptr += total_offset >> 6;
@@ -297,7 +297,7 @@ public:
         // note: above shifts in zeroes above the bitfield
         return result;
     }
-    void set_value(uint64_t value) const
+    void set_value(size_t value) const
     {
         auto in_word_position = field_position & 0x3F;
         auto first_word = first_word_ptr[0];

--- a/src/realm/array_direct.hpp
+++ b/src/realm/array_direct.hpp
@@ -297,7 +297,7 @@ public:
         // note: above shifts in zeroes above the bitfield
         return result;
     }
-    void set_value(size_t value) const
+    void set_value(uint64_t value) const
     {
         auto in_word_position = field_position & 0x3F;
         auto first_word = first_word_ptr[0];

--- a/src/realm/array_encode.cpp
+++ b/src/realm/array_encode.cpp
@@ -238,10 +238,6 @@ void ArrayEncode::init(const char* h)
         m_v_mask = 1ULL << (m_v_width - 1);
         m_MSBs = populate(m_v_width, m_v_mask);
         m_vtable = &VTableForPacked::vtable;
-        m_getter = m_vtable->m_getter;
-        m_data_getter = m_vtable->m_data_getter;
-        // TODO: investigate if it is worth it
-        // m_finder = (FinderTable*)&m_vtable->m_finder;
     }
     else if (m_encoding == Encoding::Flex) {
         m_v_width = NodeHeader::get_elementA_size<Encoding::Flex>(h);
@@ -253,9 +249,6 @@ void ArrayEncode::init(const char* h)
         m_MSBs = populate(m_v_width, m_v_mask);
         m_ndx_MSBs = populate(m_ndx_width, m_ndx_mask);
         m_vtable = &VTableForFlex::vtable;
-        m_getter = m_vtable->m_getter;
-        m_data_getter = m_vtable->m_data_getter;
-        // m_finder = (FinderTable*)&m_vtable->m_finder;
     }
 }
 
@@ -264,16 +257,16 @@ int64_t ArrayEncode::get(const Array& arr, size_t ndx) const
     using Encoding = NodeHeader::Encoding;
     REALM_ASSERT_DEBUG(arr.is_attached());
     REALM_ASSERT_DEBUG(m_encoding == Encoding::Flex || m_encoding == Encoding::Packed);
-    REALM_ASSERT_DEBUG(m_getter);
-    return (this->*m_getter)(arr, ndx);
+    REALM_ASSERT_DEBUG(m_vtable->m_getter);
+    return (this->*(m_vtable->m_getter))(arr, ndx);
 }
 
 int64_t ArrayEncode::get(const char* data, size_t ndx) const
 {
     using Encoding = NodeHeader::Encoding;
     REALM_ASSERT_DEBUG(m_encoding == Encoding::Flex || m_encoding == Encoding::Packed);
-    REALM_ASSERT_DEBUG(m_data_getter);
-    return (this->*m_data_getter)(data, ndx);
+    REALM_ASSERT_DEBUG(m_vtable->m_data_getter);
+    return (this->*(m_vtable->m_data_getter))(data, ndx);
 }
 
 void ArrayEncode::get_chunk(const Array& arr, size_t ndx, int64_t res[8]) const

--- a/src/realm/array_encode.cpp
+++ b/src/realm/array_encode.cpp
@@ -95,7 +95,7 @@ bool ArrayEncode::always_encode(const Array& origin, Array& arr, bool packed) co
 bool ArrayEncode::encode(const Array& origin, Array& arr) const
 {
     // return false;
-    // return always_encode(origin, arr, true); // true packed, false flex
+    // return always_encode(origin, arr, false); // true packed, false flex
 
     std::vector<int64_t> values;
     std::vector<size_t> indices;
@@ -180,6 +180,9 @@ void ArrayEncode::init(const char* h)
         m_v_width = NodeHeader::get_element_size<Encoding::Packed>(h);
         m_v_size = NodeHeader::get_num_elements<Encoding::Packed>(h);
         m_v_mask = 1ULL << (m_v_width - 1);
+        m_MSBs = populate(m_v_width, m_v_mask);
+        m_field_count = num_fields_for_width(m_v_width);
+        m_bit_count_pr_iteration = num_bits_for_width(m_v_width);
     }
     else if (m_encoding == Encoding::Flex) {
         m_v_width = NodeHeader::get_elementA_size<Encoding::Flex>(h);
@@ -188,6 +191,14 @@ void ArrayEncode::init(const char* h)
         m_ndx_size = NodeHeader::get_arrayB_num_elements<Encoding::Flex>(h);
         m_v_mask = 1ULL << (m_v_width - 1);
         m_ndx_mask = 1ULL << (m_ndx_width - 1);
+        // values
+        m_MSBs = populate(m_v_width, m_v_mask);
+        m_field_count = num_fields_for_width(m_v_width);
+        m_bit_count_pr_iteration = num_bits_for_width(m_v_width);
+        // ndxs
+        m_ndx_MSBs = populate(m_ndx_width, m_ndx_mask);
+        m_ndx_field_count = num_fields_for_width(m_ndx_width);
+        m_ndx_bit_count_pr_iteration = num_bits_for_width(m_ndx_width);
     }
 }
 

--- a/src/realm/array_encode.cpp
+++ b/src/realm/array_encode.cpp
@@ -35,10 +35,23 @@ template size_t ArrayEncode::find_first<Equal>(const Array&, int64_t, size_t, si
 template size_t ArrayEncode::find_first<NotEqual>(const Array&, int64_t, size_t, size_t) const;
 template size_t ArrayEncode::find_first<Greater>(const Array&, int64_t, size_t, size_t) const;
 template size_t ArrayEncode::find_first<Less>(const Array&, int64_t, size_t, size_t) const;
-template bool ArrayEncode::find_all<Equal>(const Array&, int64_t, size_t, size_t, size_t, QueryStateBase*) const;
-template bool ArrayEncode::find_all<NotEqual>(const Array&, int64_t, size_t, size_t, size_t, QueryStateBase*) const;
-template bool ArrayEncode::find_all<Greater>(const Array&, int64_t, size_t, size_t, size_t, QueryStateBase*) const;
-template bool ArrayEncode::find_all<Less>(const Array&, int64_t, size_t, size_t, size_t, QueryStateBase*) const;
+
+template bool ArrayEncode::find_all_packed<Equal>(const Array&, int64_t, size_t, size_t, size_t,
+                                                  QueryStateBase*) const;
+template bool ArrayEncode::find_all_packed<NotEqual>(const Array&, int64_t, size_t, size_t, size_t,
+                                                     QueryStateBase*) const;
+template bool ArrayEncode::find_all_packed<Greater>(const Array&, int64_t, size_t, size_t, size_t,
+                                                    QueryStateBase*) const;
+template bool ArrayEncode::find_all_packed<Less>(const Array&, int64_t, size_t, size_t, size_t,
+                                                 QueryStateBase*) const;
+
+template bool ArrayEncode::find_all_flex<Equal>(const Array&, int64_t, size_t, size_t, size_t, QueryStateBase*) const;
+template bool ArrayEncode::find_all_flex<NotEqual>(const Array&, int64_t, size_t, size_t, size_t,
+                                                   QueryStateBase*) const;
+template bool ArrayEncode::find_all_flex<Greater>(const Array&, int64_t, size_t, size_t, size_t,
+                                                  QueryStateBase*) const;
+template bool ArrayEncode::find_all_flex<Less>(const Array&, int64_t, size_t, size_t, size_t, QueryStateBase*) const;
+
 
 template <typename T, typename... Arg>
 inline void encode_array(const T& encoder, Array& arr, size_t byte_size, Arg&&... args)
@@ -174,15 +187,18 @@ bool ArrayEncode::decode(Array& arr) const
 
 void ArrayEncode::init(const char* h)
 {
-    using Encoding = NodeHeader::Encoding;
     m_encoding = NodeHeader::get_encoding(h);
+    init_widths(h);
+    // init_masks();
+    init_vtable();
+}
+
+void ArrayEncode::init_widths(const char* h)
+{
     if (m_encoding == Encoding::Packed) {
         m_v_width = NodeHeader::get_element_size<Encoding::Packed>(h);
         m_v_size = NodeHeader::get_num_elements<Encoding::Packed>(h);
         m_v_mask = 1ULL << (m_v_width - 1);
-        m_MSBs = populate(m_v_width, m_v_mask);
-        m_field_count = num_fields_for_width(m_v_width);
-        m_bit_count_pr_iteration = num_bits_for_width(m_v_width);
     }
     else if (m_encoding == Encoding::Flex) {
         m_v_width = NodeHeader::get_elementA_size<Encoding::Flex>(h);
@@ -191,15 +207,55 @@ void ArrayEncode::init(const char* h)
         m_ndx_size = NodeHeader::get_arrayB_num_elements<Encoding::Flex>(h);
         m_v_mask = 1ULL << (m_v_width - 1);
         m_ndx_mask = 1ULL << (m_ndx_width - 1);
-        // values
-        m_MSBs = populate(m_v_width, m_v_mask);
-        m_field_count = num_fields_for_width(m_v_width);
-        m_bit_count_pr_iteration = num_bits_for_width(m_v_width);
-        // ndxs
-        m_ndx_MSBs = populate(m_ndx_width, m_ndx_mask);
-        m_ndx_field_count = num_fields_for_width(m_ndx_width);
-        m_ndx_bit_count_pr_iteration = num_bits_for_width(m_ndx_width);
     }
+}
+
+void ArrayEncode::init_vtable()
+{
+    if (m_encoding == Encoding::Packed) {
+        m_getter = &ArrayEncode::get_packed;
+        m_getter_from_data = &ArrayEncode::get_from_data_packed;
+        m_getter_chunk = &ArrayEncode::get_chunk_packed;
+        m_setter_direct = &ArrayEncode::set_direct_packed;
+        m_finder[cond_Equal] = &ArrayEncode::find_all_packed<Equal>;
+        m_finder[cond_NotEqual] = &ArrayEncode::find_all_packed<NotEqual>;
+        m_finder[cond_Less] = &ArrayEncode::find_all_packed<Less>;
+        m_finder[cond_Greater] = &ArrayEncode::find_all_packed<Greater>;
+        m_accumulator = &ArrayEncode::sum_packed;
+    }
+    else if (m_encoding == Encoding::Flex) {
+        m_getter = &ArrayEncode::get_flex;
+        m_getter_from_data = &ArrayEncode::get_from_data_flex;
+        m_getter_chunk = &ArrayEncode::get_chunk_flex;
+        m_setter_direct = &ArrayEncode::set_direct_flex;
+        m_finder[cond_Equal] = &ArrayEncode::find_all_flex<Equal>;
+        m_finder[cond_NotEqual] = &ArrayEncode::find_all_flex<NotEqual>;
+        m_finder[cond_Less] = &ArrayEncode::find_all_flex<Less>;
+        m_finder[cond_Greater] = &ArrayEncode::find_all_flex<Greater>;
+        m_accumulator = &ArrayEncode::sum_flex;
+    }
+}
+
+void ArrayEncode::init_masks()
+{
+    //    if (m_encoding == Encoding::Packed) {
+    //        m_v_mask = 1ULL << (m_v_width - 1);
+    //        m_MSBs = populate(m_v_width, m_v_mask);
+    //        m_field_count = num_fields_for_width(m_v_width);
+    //        m_bit_count_pr_iteration = num_bits_for_width(m_v_width);
+    //    }
+    //    else if(m_encoding == Encoding::Flex){
+    //        m_v_mask = 1ULL << (m_v_width - 1);
+    //        m_ndx_mask = 1ULL << (m_ndx_width - 1);
+    //        // values
+    //        m_MSBs = populate(m_v_width, m_v_mask);
+    //        m_field_count = num_fields_for_width(m_v_width);
+    //        m_bit_count_pr_iteration = num_bits_for_width(m_v_width);
+    //        // ndxs
+    //        m_ndx_MSBs = populate(m_ndx_width, m_ndx_mask);
+    //        m_ndx_field_count = num_fields_for_width(m_ndx_width);
+    //        m_ndx_bit_count_pr_iteration = num_bits_for_width(m_ndx_width);
+    //    }
 }
 
 int64_t ArrayEncode::get(const Array& arr, size_t ndx) const
@@ -207,52 +263,48 @@ int64_t ArrayEncode::get(const Array& arr, size_t ndx) const
     using Encoding = NodeHeader::Encoding;
     REALM_ASSERT_DEBUG(arr.is_attached());
     REALM_ASSERT_DEBUG(m_encoding == Encoding::Flex || m_encoding == Encoding::Packed);
-    return is_packed() ? s_packed.get(arr, ndx) : s_flex.get(arr, ndx);
+    REALM_ASSERT_DEBUG(m_getter);
+    return (this->*m_getter)(arr, ndx);
 }
 
 int64_t ArrayEncode::get(const char* data, size_t ndx) const
 {
     using Encoding = NodeHeader::Encoding;
     REALM_ASSERT_DEBUG(m_encoding == Encoding::Flex || m_encoding == Encoding::Packed);
-    return m_encoding == Encoding::Packed
-               ? s_packed.get(data, ndx, m_v_width, m_v_size, m_v_mask)
-               : s_flex.get(data, ndx, m_v_width, m_v_size, m_ndx_width, m_ndx_size, m_v_mask);
+    REALM_ASSERT_DEBUG(m_getter_from_data);
+    return (this->*m_getter_from_data)(data, ndx);
 }
 
 void ArrayEncode::get_chunk(const Array& arr, size_t ndx, int64_t res[8]) const
 {
     REALM_ASSERT_DEBUG(arr.is_attached());
-    return is_packed() ? s_packed.get_chunk(arr, ndx, res) : s_flex.get_chunk(arr, ndx, res);
+    REALM_ASSERT_DEBUG(m_getter_chunk);
+    return (this->*m_getter_chunk)(arr, ndx, res);
 }
 
 void ArrayEncode::set_direct(const Array& arr, size_t ndx, int64_t value) const
 {
     REALM_ASSERT_DEBUG(is_packed() || is_flex());
-    is_packed() ? s_packed.set_direct(arr, ndx, value) : s_flex.set_direct(arr, ndx, value);
+    REALM_ASSERT_DEBUG(m_setter_direct);
+    return (this->*m_setter_direct)(arr, ndx, value);
 }
 
 template <typename Cond>
 size_t ArrayEncode::find_first(const Array& arr, int64_t value, size_t start, size_t end) const
 {
+    REALM_ASSERT_DEBUG(is_packed() || is_flex());
+    REALM_ASSERT(m_finder);
     QueryStateFindFirst state;
     find_all<Cond>(arr, value, start, end, 0, &state);
     return state.m_state;
-}
-
-template <typename Cond>
-bool ArrayEncode::find_all(const Array& arr, int64_t value, size_t start, size_t end, size_t baseindex,
-                           QueryStateBase* state) const
-{
-    REALM_ASSERT_DEBUG(is_packed() || is_flex());
-    return is_packed() ? s_packed.find_all<Cond>(arr, value, start, end, baseindex, state)
-                       : s_flex.find_all<Cond>(arr, value, start, end, baseindex, state);
 }
 
 int64_t ArrayEncode::sum(const Array& arr, size_t start, size_t end) const
 {
     REALM_ASSERT_DEBUG(is_packed() || is_flex());
     REALM_ASSERT_DEBUG(arr.m_size >= start && arr.m_size <= end);
-    return is_packed() ? s_packed.sum(arr, start, end) : s_flex.sum(arr, start, end);
+    REALM_ASSERT_DEBUG(m_accumulator);
+    return (this->*m_accumulator)(arr, start, end);
 }
 
 void ArrayEncode::set(char* data, size_t w, size_t ndx, int64_t v) const
@@ -275,16 +327,6 @@ void ArrayEncode::set(char* data, size_t w, size_t ndx, int64_t v) const
         realm::set_direct<64>(data, ndx, v);
     else
         REALM_UNREACHABLE();
-}
-
-bool inline ArrayEncode::is_packed() const
-{
-    return m_encoding == NodeHeader::Encoding::Packed;
-}
-
-bool inline ArrayEncode::is_flex() const
-{
-    return m_encoding == NodeHeader::Encoding::Flex;
 }
 
 size_t ArrayEncode::flex_encoded_array_size(const std::vector<int64_t>& values, const std::vector<size_t>& indices,
@@ -346,4 +388,68 @@ void ArrayEncode::encode_values(const Array& arr, std::vector<int64_t>& values, 
     }
 #endif
     REALM_ASSERT_DEBUG(indices.size() == sz);
+}
+
+int64_t ArrayEncode::get_packed(const Array& arr, size_t ndx) const
+{
+    return s_packed.get(arr, ndx);
+}
+
+int64_t ArrayEncode::get_flex(const Array& arr, size_t ndx) const
+{
+    return s_flex.get(arr, ndx);
+}
+
+int64_t ArrayEncode::get_from_data_packed(const char* data, size_t ndx) const
+{
+    return s_packed.get(data, ndx, *this);
+}
+
+int64_t ArrayEncode::get_from_data_flex(const char* data, size_t ndx) const
+{
+    return s_flex.get(data, ndx, *this);
+}
+
+void ArrayEncode::get_chunk_packed(const Array& arr, size_t ndx, int64_t res[8]) const
+{
+    s_packed.get_chunk(arr, ndx, res);
+}
+
+void ArrayEncode::get_chunk_flex(const Array& arr, size_t ndx, int64_t res[8]) const
+{
+    s_flex.get_chunk(arr, ndx, res);
+}
+
+void ArrayEncode::set_direct_packed(const Array& arr, size_t ndx, int64_t value) const
+{
+    s_packed.set_direct(arr, ndx, value);
+}
+
+void ArrayEncode::set_direct_flex(const Array& arr, size_t ndx, int64_t value) const
+{
+    s_flex.set_direct(arr, ndx, value);
+}
+
+template <typename Cond>
+bool ArrayEncode::find_all_packed(const Array& arr, int64_t value, size_t start, size_t end, size_t baseindex,
+                                  QueryStateBase* state) const
+{
+    return s_packed.find_all<Cond>(arr, value, start, end, baseindex, state);
+}
+
+template <typename Cond>
+bool ArrayEncode::find_all_flex(const Array& arr, int64_t value, size_t start, size_t end, size_t baseindex,
+                                QueryStateBase* state) const
+{
+    return s_flex.find_all<Cond>(arr, value, start, end, baseindex, state);
+}
+
+int64_t ArrayEncode::sum_packed(const Array& array, size_t start, size_t end) const
+{
+    return s_packed.sum(array, start, end);
+}
+
+int64_t ArrayEncode::sum_flex(const Array& array, size_t start, size_t end) const
+{
+    return s_flex.sum(array, start, end);
 }

--- a/src/realm/array_encode.cpp
+++ b/src/realm/array_encode.cpp
@@ -236,7 +236,9 @@ void ArrayEncode::init(const char* h)
         m_MSBs = populate(m_v_width, m_v_mask);
         m_vtable = &VTableForPacked::vtable;
         m_getter = m_vtable->m_getter;
-        m_finder = const_cast<FinderTable*>(&m_vtable->m_finder);
+        m_data_getter = m_vtable->m_data_getter;
+        // TODO: investigate if it is worth it
+        // m_finder = (FinderTable*)&m_vtable->m_finder;
     }
     else if (m_encoding == Encoding::Flex) {
         m_v_width = NodeHeader::get_elementA_size<Encoding::Flex>(h);
@@ -249,7 +251,8 @@ void ArrayEncode::init(const char* h)
         m_ndx_MSBs = populate(m_ndx_width, m_ndx_mask);
         m_vtable = &VTableForFlex::vtable;
         m_getter = m_vtable->m_getter;
-        m_finder = const_cast<FinderTable*>(&m_vtable->m_finder);
+        m_data_getter = m_vtable->m_data_getter;
+        // m_finder = (FinderTable*)&m_vtable->m_finder;
     }
 }
 
@@ -266,10 +269,8 @@ int64_t ArrayEncode::get(const char* data, size_t ndx) const
 {
     using Encoding = NodeHeader::Encoding;
     REALM_ASSERT_DEBUG(m_encoding == Encoding::Flex || m_encoding == Encoding::Packed);
-    REALM_ASSERT_DEBUG(m_vtable->m_data_getter);
-    // REALM_ASSERT_DEBUG(m_data_getter);
-    // return (this->*m_data_getter)(data, ndx);
-    return (this->*(m_vtable->m_data_getter))(data, ndx);
+    REALM_ASSERT_DEBUG(m_data_getter);
+    return (this->*m_data_getter)(data, ndx);
 }
 
 void ArrayEncode::get_chunk(const Array& arr, size_t ndx, int64_t res[8]) const

--- a/src/realm/array_encode.hpp
+++ b/src/realm/array_encode.hpp
@@ -40,8 +40,18 @@ public:
     // init from mem B
     inline size_t size() const;
     inline size_t width() const;
-    inline uint64_t width_mask() const;
+    inline size_t ndx_size() const;
+    inline size_t ndx_width() const;
     inline NodeHeader::Encoding get_encoding() const;
+    inline size_t v_size() const;
+    inline uint64_t width_mask() const;
+    inline uint64_t ndx_mask() const;
+    inline uint64_t msb() const;
+    inline uint64_t ndx_msb() const;
+    inline size_t field_count() const;
+    inline size_t ndx_field_count() const;
+    inline size_t bit_count_per_iteration() const;
+    inline size_t ndx_bit_count_per_iteration() const;
 
     // get/set
     int64_t get(const Array&, size_t) const;
@@ -73,6 +83,11 @@ private:
     size_t m_v_width = 0, m_v_size = 0, m_ndx_width = 0, m_ndx_size = 0;
     uint64_t m_v_mask = 0, m_ndx_mask = 0;
 
+    // these can all be computed during compression.
+    uint64_t m_MSBs = 0, m_ndx_MSBs = 0;
+    size_t m_field_count = 0, m_ndx_field_count = 0;
+    size_t m_bit_count_pr_iteration = 0, m_ndx_bit_count_pr_iteration = 0;
+
     friend class ArrayPacked;
     friend class ArrayFlex;
 };
@@ -82,7 +97,21 @@ inline size_t ArrayEncode::size() const
 {
     using Encoding = NodeHeader::Encoding;
     REALM_ASSERT_DEBUG(m_encoding == Encoding::Packed || m_encoding == Encoding::Flex);
-    return m_encoding == Encoding::Packed ? m_v_size : m_ndx_size;
+    return m_encoding == Encoding::Packed ? v_size() : ndx_size();
+}
+
+inline size_t ArrayEncode::v_size() const
+{
+    using Encoding = NodeHeader::Encoding;
+    REALM_ASSERT_DEBUG(m_encoding == Encoding::Packed || m_encoding == Encoding::Flex);
+    return m_v_size;
+}
+
+inline size_t ArrayEncode::ndx_size() const
+{
+    using Encoding = NodeHeader::Encoding;
+    REALM_ASSERT_DEBUG(m_encoding == Encoding::Packed || m_encoding == Encoding::Flex);
+    return m_ndx_size;
 }
 
 inline size_t ArrayEncode::width() const
@@ -92,14 +121,72 @@ inline size_t ArrayEncode::width() const
     return m_v_width;
 }
 
-inline uint64_t ArrayEncode::width_mask() const
+inline size_t ArrayEncode::ndx_width() const
 {
-    return m_v_mask;
+    using Encoding = NodeHeader::Encoding;
+    REALM_ASSERT_DEBUG(m_encoding == Encoding::Packed || m_encoding == Encoding::Flex);
+    return m_ndx_width;
 }
 
 inline NodeHeader::Encoding ArrayEncode::get_encoding() const
 {
     return m_encoding;
+}
+
+inline uint64_t ArrayEncode::width_mask() const
+{
+    using Encoding = NodeHeader::Encoding;
+    REALM_ASSERT_DEBUG(m_encoding == Encoding::Packed || m_encoding == Encoding::Flex);
+    return m_v_mask;
+}
+
+inline uint64_t ArrayEncode::ndx_mask() const
+{
+    using Encoding = NodeHeader::Encoding;
+    REALM_ASSERT_DEBUG(m_encoding == Encoding::Packed || m_encoding == Encoding::Flex);
+    return m_ndx_mask;
+}
+
+inline uint64_t ArrayEncode::msb() const
+{
+    using Encoding = NodeHeader::Encoding;
+    REALM_ASSERT_DEBUG(m_encoding == Encoding::Packed || m_encoding == Encoding::Flex);
+    return m_MSBs;
+}
+
+inline uint64_t ArrayEncode::ndx_msb() const
+{
+    using Encoding = NodeHeader::Encoding;
+    REALM_ASSERT_DEBUG(m_encoding == Encoding::Packed || m_encoding == Encoding::Flex);
+    return m_ndx_MSBs;
+}
+
+inline size_t ArrayEncode::field_count() const
+{
+    using Encoding = NodeHeader::Encoding;
+    REALM_ASSERT_DEBUG(m_encoding == Encoding::Packed || m_encoding == Encoding::Flex);
+    return m_field_count;
+}
+
+inline size_t ArrayEncode::ndx_field_count() const
+{
+    using Encoding = NodeHeader::Encoding;
+    REALM_ASSERT_DEBUG(m_encoding == Encoding::Packed || m_encoding == Encoding::Flex);
+    return m_ndx_field_count;
+}
+
+inline size_t ArrayEncode::bit_count_per_iteration() const
+{
+    using Encoding = NodeHeader::Encoding;
+    REALM_ASSERT_DEBUG(m_encoding == Encoding::Packed || m_encoding == Encoding::Flex);
+    return m_bit_count_pr_iteration;
+}
+
+inline size_t ArrayEncode::ndx_bit_count_per_iteration() const
+{
+    using Encoding = NodeHeader::Encoding;
+    REALM_ASSERT_DEBUG(m_encoding == Encoding::Packed || m_encoding == Encoding::Flex);
+    return m_ndx_bit_count_pr_iteration;
 }
 
 } // namespace realm

--- a/src/realm/array_encode.hpp
+++ b/src/realm/array_encode.hpp
@@ -92,8 +92,8 @@ private:
     const VTable* m_vtable = nullptr;
     // cached in order to avoid indirection since they are used in a critical path
     Getter m_getter = nullptr;
+    DataGetter m_data_getter = nullptr;
     FinderTable* m_finder = nullptr;
-    // Finder m_finder[cond_VTABLE_FINDER_COUNT];
 
     // getting and setting interface specifically for encoding formats
     int64_t get_packed(const Array&, size_t) const;
@@ -212,18 +212,21 @@ inline bool ArrayEncode::find_all(const Array& arr, int64_t value, size_t start,
                                   QueryStateBase* state) const
 {
     REALM_ASSERT_DEBUG(is_packed() || is_flex());
-    REALM_ASSERT_DEBUG(m_finder);
     if constexpr (std::is_same_v<Cond, Equal>) {
-        return (this->*(m_finder->operator[](cond_Equal)))(arr, value, start, end, baseindex, state);
+        // return (this->*((*m_finder)[cond_Equal]))(arr, value, start, end, baseindex, state);
+        return (this->*(m_vtable->m_finder[cond_Equal]))(arr, value, start, end, baseindex, state);
     }
     if constexpr (std::is_same_v<Cond, NotEqual>) {
-        return (this->*(m_finder->operator[](cond_NotEqual)))(arr, value, start, end, baseindex, state);
+        // return (this->*((*m_finder)[cond_NotEqual]))(arr, value, start, end, baseindex, state);
+        return (this->*(m_vtable->m_finder[cond_NotEqual]))(arr, value, start, end, baseindex, state);
     }
     if constexpr (std::is_same_v<Cond, Less>) {
-        return (this->*(m_finder->operator[](cond_Less)))(arr, value, start, end, baseindex, state);
+        // return (this->*((*m_finder)[cond_Less]))(arr, value, start, end, baseindex, state);
+        return (this->*(m_vtable->m_finder[cond_Less]))(arr, value, start, end, baseindex, state);
     }
     if constexpr (std::is_same_v<Cond, Greater>) {
-        return (this->*(m_finder->operator[](cond_Greater)))(arr, value, start, end, baseindex, state);
+        // return (this->*((*m_finder)[cond_Greater]))(arr, value, start, end, baseindex, state);
+        return (this->*(m_vtable->m_finder[cond_Greater]))(arr, value, start, end, baseindex, state);
     }
     REALM_UNREACHABLE();
 }

--- a/src/realm/array_encode.hpp
+++ b/src/realm/array_encode.hpp
@@ -80,20 +80,16 @@ private:
     using Accumulator = int64_t (ArrayEncode::*)(const Array&, size_t, size_t) const;
 
     struct VTable {
-        Getter m_getter;
-        DataGetter m_data_getter;
-        ChunkGetterChunk m_chunk_getter;
-        DirectSetter m_direct_setter;
+        Getter m_getter{nullptr};
+        DataGetter m_data_getter{nullptr};
+        ChunkGetterChunk m_chunk_getter{nullptr};
+        DirectSetter m_direct_setter{nullptr};
         FinderTable m_finder;
-        Accumulator m_accumulator;
+        Accumulator m_accumulator{nullptr};
     };
     struct VTableForPacked;
     struct VTableForFlex;
     const VTable* m_vtable = nullptr;
-    // cached in order to avoid indirection since they are used in a critical path
-    Getter m_getter = nullptr;
-    DataGetter m_data_getter = nullptr;
-    FinderTable* m_finder = nullptr;
 
     // getting and setting interface specifically for encoding formats
     int64_t get_packed(const Array&, size_t) const;
@@ -213,19 +209,15 @@ inline bool ArrayEncode::find_all(const Array& arr, int64_t value, size_t start,
 {
     REALM_ASSERT_DEBUG(is_packed() || is_flex());
     if constexpr (std::is_same_v<Cond, Equal>) {
-        // return (this->*((*m_finder)[cond_Equal]))(arr, value, start, end, baseindex, state);
         return (this->*(m_vtable->m_finder[cond_Equal]))(arr, value, start, end, baseindex, state);
     }
     if constexpr (std::is_same_v<Cond, NotEqual>) {
-        // return (this->*((*m_finder)[cond_NotEqual]))(arr, value, start, end, baseindex, state);
         return (this->*(m_vtable->m_finder[cond_NotEqual]))(arr, value, start, end, baseindex, state);
     }
     if constexpr (std::is_same_v<Cond, Less>) {
-        // return (this->*((*m_finder)[cond_Less]))(arr, value, start, end, baseindex, state);
         return (this->*(m_vtable->m_finder[cond_Less]))(arr, value, start, end, baseindex, state);
     }
     if constexpr (std::is_same_v<Cond, Greater>) {
-        // return (this->*((*m_finder)[cond_Greater]))(arr, value, start, end, baseindex, state);
         return (this->*(m_vtable->m_finder[cond_Greater]))(arr, value, start, end, baseindex, state);
     }
     REALM_UNREACHABLE();

--- a/src/realm/array_flex.cpp
+++ b/src/realm/array_flex.cpp
@@ -204,7 +204,7 @@ bool ArrayFlex::find_eq(const Array& arr, int64_t value, size_t start, size_t en
     const auto offset = v_size * v_width;
     const uint64_t* data = (const uint64_t*)arr.m_data;
 
-    auto MSBs = populate(v_width, encoder.width_mask());
+    auto MSBs = encoder.msb();
     auto search_vector = populate(v_width, value);
     auto v_start = parallel_subword_find(vector_compare<Equal>, data, 0, v_width, MSBs, search_vector, 0, v_size);
     if (v_start == v_size)
@@ -213,8 +213,8 @@ bool ArrayFlex::find_eq(const Array& arr, int64_t value, size_t start, size_t en
     MSBs = encoder.ndx_msb();
     search_vector = populate(ndx_width, v_start);
     while (start < end) {
-        start = parallel_subword_find(vector_compare<Equal, ArrayFlex::WordTypeIndex>, data, offset, ndx_width, MSBs,
-                                      search_vector, start, end);
+        start =
+            parallel_subword_find(vector_compare<Equal>, data, offset, ndx_width, MSBs, search_vector, start, end);
         if (start < end)
             if (!state->match(start + baseindex))
                 return false;
@@ -243,8 +243,8 @@ bool ArrayFlex::find_neq(const Array& arr, int64_t value, size_t start, size_t e
     MSBs = encoder.ndx_msb();
     search_vector = populate(ndx_width, v_start);
     while (start < end) {
-        start = parallel_subword_find(vector_compare<NotEqual, ArrayFlex::WordTypeIndex>, data, offset, ndx_width,
-                                      MSBs, search_vector, start, end);
+        start =
+            parallel_subword_find(vector_compare<NotEqual>, data, offset, ndx_width, MSBs, search_vector, start, end);
         if (start < end)
             if (!state->match(start + baseindex))
                 return false;
@@ -273,8 +273,7 @@ bool ArrayFlex::find_lt(const Array& arr, int64_t value, size_t start, size_t en
     MSBs = encoder.ndx_msb();
     search_vector = populate(ndx_width, v_start);
     while (start < end) {
-        start = parallel_subword_find(vector_compare<Less, ArrayFlex::WordTypeIndex>, data, offset, ndx_width, MSBs,
-                                      search_vector, start, end);
+        start = parallel_subword_find(vector_compare<Less>, data, offset, ndx_width, MSBs, search_vector, start, end);
         if (start < end)
             if (!state->match(start + baseindex))
                 return false;

--- a/src/realm/array_flex.cpp
+++ b/src/realm/array_flex.cpp
@@ -237,7 +237,7 @@ inline size_t ArrayFlex::parallel_subword_find(const Array& arr, size_t offset, 
     REALM_ASSERT_DEBUG(total_bit_count_left >= 0);
     unaligned_word_iter it((uint64_t*)(arr.m_data), offset + start * width);
     uint64_t vector = 0;
-    while (total_bit_count_left >= (int64_t)bit_count_pr_iteration) {
+    while (total_bit_count_left >= (unsigned)bit_count_pr_iteration) {
         const auto word = it.get(bit_count_pr_iteration);
         vector = bitwidth_cmp<Cond, Type>(MSBs, word, search_vector);
         if (vector) {

--- a/src/realm/array_flex.hpp
+++ b/src/realm/array_flex.hpp
@@ -19,8 +19,9 @@
 #ifndef REALM_ARRAY_FLEX_HPP
 #define REALM_ARRAY_FLEX_HPP
 
-#include <realm/array_encode.hpp>
-#include <realm/node_header.hpp>
+#include <cstdint>
+#include <stddef.h>
+#include <vector>
 
 namespace realm {
 //
@@ -28,6 +29,8 @@ namespace realm {
 // Decompress array in WTypeBits formats
 //
 class Array;
+class ArrayEncode;
+class QueryStateBase;
 class ArrayFlex {
 public:
     // encoding/decoding
@@ -35,7 +38,7 @@ public:
     void copy_data(const Array&, const std::vector<int64_t>&, const std::vector<size_t>&) const;
     // getters/setters
     int64_t get(const Array&, size_t) const;
-    int64_t get(const char*, size_t, size_t, size_t, size_t, size_t, uint64_t) const;
+    int64_t get(const char*, size_t, const ArrayEncode&) const;
     void get_chunk(const Array& h, size_t ndx, int64_t res[8]) const;
     void set_direct(const Array&, size_t, int64_t) const;
 

--- a/src/realm/array_flex.hpp
+++ b/src/realm/array_flex.hpp
@@ -44,14 +44,15 @@ public:
 
     int64_t sum(const Array&, size_t, size_t) const;
 
+    struct WordTypeValue {};
+    struct WordTypeIndex {};
+
 private:
     int64_t do_get(uint64_t*, size_t, size_t, size_t, size_t, size_t, uint64_t) const;
     bool find_all_match(size_t start, size_t end, size_t baseindex, QueryStateBase* state) const;
 
-    template <typename Cond, bool = true> // true int64_t, false uint64_t
-    inline size_t parallel_subword_find(const Array&, uint64_t, uint64_t, size_t, uint_least8_t, size_t,
-                                        size_t) const;
-
+    template <typename Cond, typename WordType = WordTypeValue>
+    inline size_t parallel_subword_find(const Array&, size_t, size_t, size_t, size_t, uint64_t, int64_t) const;
     bool find_eq(const Array&, int64_t, size_t, size_t, size_t, QueryStateBase*) const;
     bool find_neq(const Array&, int64_t, size_t, size_t, size_t, QueryStateBase*) const;
     bool find_lt(const Array&, int64_t, size_t, size_t, size_t, QueryStateBase*) const;

--- a/src/realm/array_integer.cpp
+++ b/src/realm/array_integer.cpp
@@ -125,12 +125,6 @@ void ArrayIntNull::replace_nulls_with(int64_t new_null)
 
 void ArrayIntNull::avoid_null_collision(int64_t value)
 {
-    // if the array is compressed, Array::set is called before copy on write will be happening.
-    // So we need to decompress here.
-    if (is_encoded()) {
-        decode_array(*this);
-    }
-
     if (m_width == 64) {
         if (value == null_value()) {
             int_fast64_t new_null = choose_random_null(value);

--- a/src/realm/array_integer_tpl.hpp
+++ b/src/realm/array_integer_tpl.hpp
@@ -27,9 +27,7 @@ namespace realm {
 template <class cond>
 bool ArrayInteger::find(value_type value, size_t start, size_t end, QueryStateBase* state) const
 {
-    if (is_encoded())
-        return find_encoded<cond>(value, start, end, 0, state);
-    return ArrayWithFind(*this).find<cond>(value, start, end, 0, state);
+    return Array::find<cond>(value, start, end, 0, state);
 }
 
 
@@ -77,11 +75,12 @@ bool ArrayIntNull::find_impl(value_type opt_value, size_t start, size_t end, Que
                 value = *opt_value;
             }
         }
-        // if encoded use specialised find
-        if (is_encoded())
-            return find_encoded<cond>(value, start2, end2, baseindex2, state);
-        // Fall back to plain Array find.
-        return ArrayWithFind(*this).find<cond>(value, start2, end2, baseindex2, state);
+        return Array::find<cond>(value, start2, end2, baseindex2, state);
+        //        // if encoded use specialised find
+        //        if (is_encoded())
+        //            return find_encoded<cond>(value, start2, end2, baseindex2, state);
+        //        // Fall back to plain Array find.
+        //        return ArrayWithFind(*this).find<cond>(value, start2, end2, baseindex2, state);
     }
     else {
         cond c;

--- a/src/realm/array_integer_tpl.hpp
+++ b/src/realm/array_integer_tpl.hpp
@@ -76,11 +76,6 @@ bool ArrayIntNull::find_impl(value_type opt_value, size_t start, size_t end, Que
             }
         }
         return Array::find<cond>(value, start2, end2, baseindex2, state);
-        //        // if encoded use specialised find
-        //        if (is_encoded())
-        //            return find_encoded<cond>(value, start2, end2, baseindex2, state);
-        //        // Fall back to plain Array find.
-        //        return ArrayWithFind(*this).find<cond>(value, start2, end2, baseindex2, state);
     }
     else {
         cond c;

--- a/src/realm/array_packed.cpp
+++ b/src/realm/array_packed.cpp
@@ -65,8 +65,8 @@ void ArrayPacked::copy_data(const Array& origin, Array& arr) const
 void ArrayPacked::set_direct(const Array& arr, size_t ndx, int64_t value) const
 {
     REALM_ASSERT_DEBUG(arr.is_encoded());
-    const auto v_width = arr.m_encoder.m_v_width;
-    const auto v_size = arr.m_encoder.m_v_size;
+    const auto v_width = arr.m_encoder.width();
+    const auto v_size = arr.m_encoder.size();
     REALM_ASSERT_DEBUG(ndx < v_size);
     auto data = (uint64_t*)arr.m_data;
     bf_iterator it_value{data, static_cast<size_t>(ndx * v_width), v_width, v_width, 0};
@@ -168,7 +168,7 @@ bool ArrayPacked::find_all(const Array& arr, int64_t value, size_t start, size_t
 
     // in packed format a parallel subword find pays off also for width >= 32
 
-    const auto MSBs = populate(arr.m_width, arr.get_encoder().width_mask());
+    const auto MSBs = arr.get_encoder().msb();
     const auto search_vector = populate(arr.m_width, value);
     while (start < end) {
         start = parallel_subword_find(vector_compare<Cond>, (const uint64_t*)arr.m_data, 0, arr.m_width, MSBs,

--- a/src/realm/array_packed.cpp
+++ b/src/realm/array_packed.cpp
@@ -176,7 +176,6 @@ bool ArrayPacked::find_all(const Array& arr, int64_t value, size_t start, size_t
         if (start < end)
             if (!state->match(start + baseindex))
                 return false;
-
         ++start;
     }
     return true;

--- a/src/realm/array_packed.cpp
+++ b/src/realm/array_packed.cpp
@@ -202,7 +202,7 @@ size_t ArrayPacked::parallel_subword_find(const Array& arr, size_t start, size_t
 
     unaligned_word_iter it((uint64_t*)arr.m_data, start * arr.m_width);
     uint64_t vector = 0;
-    while (total_bit_count_left >= (int64_t)bit_count_pr_iteration) {
+    while (total_bit_count_left >= (unsigned)bit_count_pr_iteration) {
         const auto word = it.get(bit_count_pr_iteration);
         vector = bitwidth_cmp<Cond>(MSBs, word, search_vector);
         if (vector) {

--- a/src/realm/array_packed.hpp
+++ b/src/realm/array_packed.hpp
@@ -50,7 +50,7 @@ private:
     bool find_all_match(size_t start, size_t end, size_t baseindex, QueryStateBase* state) const;
 
     template <typename Cond>
-    size_t parallel_subword_find(const Array&, int64_t, size_t, size_t) const;
+    size_t parallel_subword_find(const Array&, size_t, size_t, uint64_t, int64_t) const;
 };
 } // namespace realm
 

--- a/src/realm/array_packed.hpp
+++ b/src/realm/array_packed.hpp
@@ -19,9 +19,8 @@
 #ifndef REALM_ARRAY_PACKED_HPP
 #define REALM_ARRAY_PACKED_HPP
 
-#include <realm/array_encode.hpp>
-#include <realm/node_header.hpp>
-#include <realm/array.hpp>
+#include <cstdint>
+#include <stddef.h>
 
 namespace realm {
 
@@ -30,6 +29,8 @@ namespace realm {
 // Decompress array in WTypeBits formats
 //
 class Array;
+class ArrayEncode;
+class QueryStateBase;
 class ArrayPacked {
 public:
     // encoding/decoding
@@ -37,7 +38,7 @@ public:
     void copy_data(const Array&, Array&) const;
     // get or set
     int64_t get(const Array&, size_t) const;
-    int64_t get(const char*, size_t, size_t, size_t, uint64_t) const;
+    int64_t get(const char*, size_t, const ArrayEncode&) const;
     void get_chunk(const Array&, size_t, int64_t res[8]) const;
     void set_direct(const Array&, size_t, int64_t) const;
 

--- a/src/realm/array_unsigned.cpp
+++ b/src/realm/array_unsigned.cpp
@@ -46,7 +46,6 @@ inline uint8_t ArrayUnsigned::bit_width(uint64_t value)
 
 inline void ArrayUnsigned::_set(size_t ndx, uint8_t width, uint64_t value)
 {
-    // REALM_ASSERT_DEBUG(!is_encoded()); //why is this failing??
     if (width == 8) {
         reinterpret_cast<uint8_t*>(m_data)[ndx] = uint8_t(value);
     }
@@ -63,7 +62,6 @@ inline void ArrayUnsigned::_set(size_t ndx, uint8_t width, uint64_t value)
 
 inline uint64_t ArrayUnsigned::_get(size_t ndx, uint8_t width) const
 {
-    // REALM_ASSERT_DEBUG(!is_encoded());
     if (width == 8) {
         return reinterpret_cast<uint8_t*>(m_data)[ndx];
     }
@@ -175,7 +173,6 @@ size_t ArrayUnsigned::upper_bound(uint64_t value) const noexcept
 
 void ArrayUnsigned::insert(size_t ndx, uint64_t value)
 {
-    // REALM_ASSERT_DEBUG(!is_encoded());
     REALM_ASSERT_DEBUG(m_width >= 8);
 
     bool do_expand = value > (uint64_t)m_ubound;
@@ -224,7 +221,6 @@ void ArrayUnsigned::insert(size_t ndx, uint64_t value)
 
 void ArrayUnsigned::erase(size_t ndx)
 {
-    // REALM_ASSERT_DEBUG(!is_encoded());
     REALM_ASSERT_DEBUG(m_width >= 8);
 
     copy_on_write(); // Throws
@@ -249,7 +245,6 @@ uint64_t ArrayUnsigned::get(size_t index) const
 
 void ArrayUnsigned::set(size_t ndx, uint64_t value)
 {
-    // REALM_ASSERT_DEBUG(!is_encoded()); //todo this is failing
     REALM_ASSERT_DEBUG(m_width >= 8);
     copy_on_write(); // Throws
 

--- a/src/realm/parser/generated/query_flex.cpp
+++ b/src/realm/parser/generated/query_flex.cpp
@@ -101,6 +101,7 @@ typedef int16_t flex_int16_t;
 typedef uint16_t flex_uint16_t;
 typedef int32_t flex_int32_t;
 typedef uint32_t flex_uint32_t;
+typedef uint64_t flex_uint64_t;
 #else
 typedef signed char flex_int8_t;
 typedef short int flex_int16_t;
@@ -330,7 +331,7 @@ struct yy_buffer_state
 	/* Number of characters read into yy_ch_buf, not including EOB
 	 * characters.
 	 */
-	int yy_n_chars;
+	yy_size_t yy_n_chars;
 
 	/* Whether we "own" the buffer - i.e., we know we created it,
 	 * and can realloc() it to grow it, and should free() it to
@@ -428,7 +429,7 @@ static void yy_init_buffer ( YY_BUFFER_STATE b, FILE *file , yyscan_t yyscanner 
 
 YY_BUFFER_STATE yy_scan_buffer ( char *base, yy_size_t size , yyscan_t yyscanner );
 YY_BUFFER_STATE yy_scan_string ( const char *yy_str , yyscan_t yyscanner );
-YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, int len , yyscan_t yyscanner );
+YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, yy_size_t len , yyscan_t yyscanner );
 
 /* %endif */
 
@@ -495,7 +496,7 @@ static void yynoreturn yy_fatal_error ( const char* msg , yyscan_t yyscanner );
 #define YY_DO_BEFORE_ACTION \
 	yyg->yytext_ptr = yy_bp; \
 /* %% [2.0] code to fiddle yytext and yyleng for yymore() goes here \ */\
-	yyleng = (int) (yy_cp - yy_bp); \
+	yyleng = (yy_size_t) (yy_cp - yy_bp); \
 	yyg->yy_hold_char = *yy_cp; \
 	*yy_cp = '\0'; \
 /* %% [3.0] code to copy yytext_ptr to yytext[] goes here, if %array \ */\
@@ -1309,8 +1310,8 @@ struct yyguts_t
     size_t yy_buffer_stack_max; /**< capacity of stack. */
     YY_BUFFER_STATE * yy_buffer_stack; /**< Stack as an array. */
     char yy_hold_char;
-    int yy_n_chars;
-    int yyleng_r;
+    yy_size_t yy_n_chars;
+    yy_size_t yyleng_r;
     char *yy_c_buf_p;
     int yy_init;
     int yy_start;
@@ -1402,7 +1403,7 @@ void yyset_out  ( FILE * _out_str , yyscan_t yyscanner );
 
 
 
-			int yyget_leng ( yyscan_t yyscanner );
+			yy_size_t yyget_leng ( yyscan_t yyscanner );
 
 
 
@@ -1516,7 +1517,7 @@ static int input ( yyscan_t yyscanner );
 	if ( YY_CURRENT_BUFFER_LVALUE->yy_is_interactive ) \
 		{ \
 		int c = '*'; \
-		int n; \
+		yy_size_t n; \
 		for ( n = 0; n < max_size && \
 			     (c = getc( yyin )) != EOF && c != '\n'; ++n ) \
 			buf[n] = (char) c; \
@@ -2266,7 +2267,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 	else
 		{
-			int num_to_read =
+			yy_size_t num_to_read =
 			YY_CURRENT_BUFFER_LVALUE->yy_buf_size - number_to_move - 1;
 
 		while ( num_to_read <= 0 )
@@ -2280,7 +2281,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 			if ( b->yy_is_our_buffer )
 				{
-				int new_size = b->yy_buf_size * 2;
+				yy_size_t new_size = b->yy_buf_size * 2;
 
 				if ( new_size <= 0 )
 					b->yy_buf_size += b->yy_buf_size / 8;
@@ -2338,7 +2339,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 	if ((yyg->yy_n_chars + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
 		/* Extend the array by 50%, plus the number we really need. */
-		int new_size = yyg->yy_n_chars + number_to_move + (yyg->yy_n_chars >> 1);
+		yy_size_t new_size = yyg->yy_n_chars + number_to_move + (yyg->yy_n_chars >> 1);
 		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) yyrealloc(
 			(void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf, (yy_size_t) new_size , yyscanner );
 		if ( ! YY_CURRENT_BUFFER_LVALUE->yy_ch_buf )
@@ -2466,7 +2467,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 		else
 			{ /* need more input */
-			int offset = (int) (yyg->yy_c_buf_p - yyg->yytext_ptr);
+			yy_size_t offset = yyg->yy_c_buf_p - yyg->yytext_ptr;
 			++yyg->yy_c_buf_p;
 
 			switch ( yy_get_next_buffer( yyscanner ) )
@@ -2935,12 +2936,12 @@ YY_BUFFER_STATE yy_scan_string (const char * yystr , yyscan_t yyscanner)
  * @param yyscanner The scanner object.
  * @return the newly allocated buffer state object.
  */
-YY_BUFFER_STATE yy_scan_bytes  (const char * yybytes, int  _yybytes_len , yyscan_t yyscanner)
+YY_BUFFER_STATE yy_scan_bytes  (const char * yybytes, yy_size_t  _yybytes_len , yyscan_t yyscanner)
 {
 	YY_BUFFER_STATE b;
 	char *buf;
 	yy_size_t n;
-	int i;
+	yy_size_t i;
     
 	/* Get memory for full buffer, including space for trailing EOB's. */
 	n = (yy_size_t) (_yybytes_len + 2);
@@ -2999,7 +3000,7 @@ static void yynoreturn yy_fatal_error (const char* msg , yyscan_t yyscanner)
 	do \
 		{ \
 		/* Undo effects of setting up yytext. */ \
-        int yyless_macro_arg = (n); \
+        yy_size_t yyless_macro_arg = (n); \
         YY_LESS_LINENO(yyless_macro_arg);\
 		yytext[yyleng] = yyg->yy_hold_char; \
 		yyg->yy_c_buf_p = yytext + yyless_macro_arg; \
@@ -3087,7 +3088,7 @@ FILE *yyget_out  (yyscan_t yyscanner)
 /** Get the length of the current token.
  * @param yyscanner The scanner object.
  */
-int yyget_leng  (yyscan_t yyscanner)
+yy_size_t yyget_leng  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     return yyleng;

--- a/src/realm/parser/generated/query_flex.hpp
+++ b/src/realm/parser/generated/query_flex.hpp
@@ -100,6 +100,7 @@ typedef int16_t flex_int16_t;
 typedef uint16_t flex_uint16_t;
 typedef int32_t flex_int32_t;
 typedef uint32_t flex_uint32_t;
+typedef uint64_t flex_uint64_t;
 #else
 typedef signed char flex_int8_t;
 typedef short int flex_int16_t;
@@ -278,7 +279,7 @@ struct yy_buffer_state
 	/* Number of characters read into yy_ch_buf, not including EOB
 	 * characters.
 	 */
-	int yy_n_chars;
+	yy_size_t yy_n_chars;
 
 	/* Whether we "own" the buffer - i.e., we know we created it,
 	 * and can realloc() it to grow it, and should free() it to
@@ -339,7 +340,7 @@ void yypop_buffer_state ( yyscan_t yyscanner );
 
 YY_BUFFER_STATE yy_scan_buffer ( char *base, yy_size_t size , yyscan_t yyscanner );
 YY_BUFFER_STATE yy_scan_string ( const char *yy_str , yyscan_t yyscanner );
-YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, int len , yyscan_t yyscanner );
+YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, yy_size_t len , yyscan_t yyscanner );
 
 /* %endif */
 
@@ -459,7 +460,7 @@ void yyset_out  ( FILE * _out_str , yyscan_t yyscanner );
 
 
 
-			int yyget_leng ( yyscan_t yyscanner );
+			yy_size_t yyget_leng ( yyscan_t yyscanner );
 
 
 

--- a/test/test_array_integer.cpp
+++ b/test/test_array_integer.cpp
@@ -35,7 +35,6 @@ using namespace realm::test_util;
 // #define ARRAY_PERFORMANCE_TESTING
 #if !defined(REALM_DEBUG) && defined(ARRAY_PERFORMANCE_TESTING)
 NONCONCURRENT_TEST(perf_array_encode_get_vs_array_get_less_32bit)
-// ONLY(perf_array_encode_get_vs_array_get_less_32bit)
 {
     using namespace std;
     using namespace std::chrono;
@@ -133,7 +132,6 @@ NONCONCURRENT_TEST(perf_array_encode_get_vs_array_get_less_32bit)
 
 
 NONCONCURRENT_TEST(Test_basic_find_EQ_less_32bit)
-// ONLY(Test_basic_find_EQ_less_32bit)
 {
     using namespace std;
     using namespace std::chrono;
@@ -174,11 +172,6 @@ NONCONCURRENT_TEST(Test_basic_find_EQ_less_32bit)
     a.try_encode(a_encoded);
     CHECK(a_encoded.is_encoded());
     CHECK(a_encoded.size() == a.size());
-
-    //    std::cout << "Array: " << std::endl;
-    //    for(size_t i=0; i<a_encoded.size(); ++i)
-    //        std::cout << a_encoded.get(i) << ", ";
-    //    std::cout << std::endl;
 
     // verify that both find the same thing
     for (size_t j = 0; j < n_runs; ++j) {
@@ -264,7 +257,6 @@ NONCONCURRENT_TEST(Test_basic_find_EQ_less_32bit)
 }
 
 NONCONCURRENT_TEST(Test_basic_find_NEQ_value_less_32bit)
-// ONLY(Test_basic_find_NEQ_value_less_32bit)
 {
     using namespace std;
     using namespace std::chrono;
@@ -394,7 +386,6 @@ NONCONCURRENT_TEST(Test_basic_find_NEQ_value_less_32bit)
 }
 
 NONCONCURRENT_TEST(Test_basic_find_LT_value_less_32bit)
-// ONLY(Test_basic_find_LT_value_less_32bit)
 {
     using namespace std;
     using namespace std::chrono;
@@ -437,11 +428,6 @@ NONCONCURRENT_TEST(Test_basic_find_LT_value_less_32bit)
     a.try_encode(a_encoded);
     CHECK(a_encoded.is_encoded());
     CHECK(a_encoded.size() == a.size());
-
-    //   std::cout << "Array: " << std::endl;
-    //   for(size_t i=0; i<a_encoded.size(); ++i)
-    //       std::cout << a_encoded.get(i) << ", ";
-    //    std::cout << std::endl;
 
     // verify that both find the same thing
     state1 = {};
@@ -531,7 +517,6 @@ NONCONCURRENT_TEST(Test_basic_find_LT_value_less_32bit)
 }
 
 NONCONCURRENT_TEST(Test_basic_find_GT_value_less_32bit)
-// ONLY(Test_basic_find_GT_value_less_32bit)
 {
     // GT subword parallel search is not working... TODO : investigate
     using namespace std;
@@ -575,11 +560,6 @@ NONCONCURRENT_TEST(Test_basic_find_GT_value_less_32bit)
     a.try_encode(a_encoded);
     CHECK(a_encoded.is_encoded());
     CHECK(a_encoded.size() == a.size());
-
-    //       std::cout << "Array: " << std::endl;
-    //       for(size_t i=0; i<a_encoded.size(); ++i)
-    //           std::cout << a_encoded.get(i) << ", ";
-    //        std::cout << std::endl;
 
     // verify that both find the same thing
     state1 = {};
@@ -669,7 +649,6 @@ NONCONCURRENT_TEST(Test_basic_find_GT_value_less_32bit)
 }
 
 NONCONCURRENT_TEST(perf_array_encode_get_vs_array_get_greater_32bit)
-// ONLY(perf_array_encode_get_vs_array_get_greater_32bit)
 {
     using namespace std;
     using namespace std::chrono;
@@ -767,7 +746,6 @@ NONCONCURRENT_TEST(perf_array_encode_get_vs_array_get_greater_32bit)
 }
 
 NONCONCURRENT_TEST(Test_basic_find_EQ_greater_32bit)
-// ONLY(Test_basic_find_EQ_greater_32bit)
 {
     using namespace std;
     using namespace std::chrono;
@@ -1150,9 +1128,7 @@ NONCONCURRENT_TEST(Test_basic_find_LT_value_greater_32bit)
     a_encoded.destroy();
 }
 
-// NONCONCURRENT_TEST(Test_basic_find_GT_value_greater_32bit)
 NONCONCURRENT_TEST(Test_basic_find_GT_value_greater_32bit)
-// ONLY(Test_basic_find_GT_value_greater_32bit)
 {
     using namespace std;
     using namespace std::chrono;


### PR DESCRIPTION
## What, How & Why?
Avoid to compute the same mask over and over again inside parallel subscan.
The PR has become a little bit bigger and overlaps with  https://github.com/realm/realm-core/pull/7447 .
I think we should first merge 7447 and the go ahead with this. 
This commit: 1b1532e8c2d9b85fe77607b76e6db1ba86087c3e has introduced the same concept we have for Array, essentially a vtable used for fetching the right implementation based on the type of encoding we are in. 
The vtable is set during the init phase, which happens when the array is converted into a compressed format (during a commit).
Perf wise, timestamps are as fast as integers or even faster than current master implementation. 
