### PR TITLE
RCORE-2007 Added Resumption delay configuration to SyncClientTimeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Enhancements
 * <New feature description> (PR [#????](https://github.com/realm/realm-core/pull/????))
-* None.
+* Added Resumption delay configuration to SyncClientTimeouts. ([PR #7441](https://github.com/realm/realm-core/pull/7441))
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)

--- a/bindgen/spec.yml
+++ b/bindgen/spec.yml
@@ -570,6 +570,18 @@ records:
       fast_reconnect_limit:
         type: uint64_t
         default: 60000
+      resumption_delay_interval:
+        type: uint64_t
+        default: 1000
+      max_resumption_delay_interval:
+        type: uint64_t
+        default: 300000
+      resumption_delay_backoff_multiplier:
+        type: int
+        default: 2
+      resumption_delay_jitter_divisor:
+        type: uint8_t
+        default: 4
 
   SyncClientConfig:
     fields:

--- a/bindgen/spec.yml
+++ b/bindgen/spec.yml
@@ -553,6 +553,21 @@ records:
       before_notify: 'Nullable<util::UniqueFunction<(r: SharedRealm)>>'
       schema_did_change: 'Nullable<util::UniqueFunction<(r: SharedRealm)>>' # new schema available as r.schema
 
+  ResumptionDelayInfo:
+    fields:
+      max_resumption_delay_interval:
+        type: std::chrono::milliseconds
+        default: 3000000
+      resumption_delay_interval:
+        type: std::chrono::milliseconds
+        default: 1000
+      resumption_delay_backoff_multiplier:
+        type: int
+        default: 2
+      delay_jitter_divisor:
+        type: int
+        default: 4
+
   SyncClientTimeouts:
     fields:
       connect_timeout:
@@ -570,18 +585,9 @@ records:
       fast_reconnect_limit:
         type: uint64_t
         default: 60000
-      resumption_delay_interval:
-        type: uint64_t
-        default: 1000
-      max_resumption_delay_interval:
-        type: uint64_t
-        default: 300000
-      resumption_delay_backoff_multiplier:
-        type: int
-        default: 2
-      resumption_delay_jitter_divisor:
-        type: uint8_t
-        default: 4
+      reconnect_backoff_info:
+        type: ResumptionDelayInfo
+        default: {}
 
   SyncClientConfig:
     fields:

--- a/src/realm.h
+++ b/src/realm.h
@@ -3650,8 +3650,6 @@ RLM_API void realm_sync_client_config_set_max_resumption_delay_interval(realm_sy
                                                                         uint64_t) RLM_API_NOEXCEPT;
 RLM_API void realm_sync_client_config_set_resumption_delay_backoff_multiplier(realm_sync_client_config_t*,
                                                                               int) RLM_API_NOEXCEPT;
-RLM_API void realm_sync_client_config_set_resumption_delay_jitter_divisor(realm_sync_client_config_t*,
-                                                                          int) RLM_API_NOEXCEPT;
 RLM_API void realm_sync_client_config_set_sync_socket(realm_sync_client_config_t*,
                                                       realm_sync_socket_t*) RLM_API_NOEXCEPT;
 RLM_API void realm_sync_client_config_set_default_binding_thread_observer(

--- a/src/realm.h
+++ b/src/realm.h
@@ -3678,7 +3678,7 @@ RLM_API void realm_sync_client_config_set_max_resumption_delay_interval(realm_sy
 RLM_API void realm_sync_client_config_set_resumption_delay_backoff_multiplier(realm_sync_client_config_t*,
                                                                               int) RLM_API_NOEXCEPT;
 RLM_API void realm_sync_client_config_set_resumption_delay_jitter_divisor(realm_sync_client_config_t*,
-                                                                          uint8_t) RLM_API_NOEXCEPT;
+                                                                          int) RLM_API_NOEXCEPT;
 RLM_API void realm_sync_client_config_set_sync_socket(realm_sync_client_config_t*,
                                                       realm_sync_socket_t*) RLM_API_NOEXCEPT;
 RLM_API void realm_sync_client_config_set_default_binding_thread_observer(

--- a/src/realm.h
+++ b/src/realm.h
@@ -3671,6 +3671,14 @@ RLM_API void realm_sync_client_config_set_pong_keepalive_timeout(realm_sync_clie
                                                                  uint64_t) RLM_API_NOEXCEPT;
 RLM_API void realm_sync_client_config_set_fast_reconnect_limit(realm_sync_client_config_t*,
                                                                uint64_t) RLM_API_NOEXCEPT;
+RLM_API void realm_sync_client_config_set_resumption_delay_interval(realm_sync_client_config_t*,
+                                                                    uint64_t) RLM_API_NOEXCEPT;
+RLM_API void realm_sync_client_config_set_max_resumption_delay_interval(realm_sync_client_config_t*,
+                                                                        uint64_t) RLM_API_NOEXCEPT;
+RLM_API void realm_sync_client_config_set_resumption_delay_backoff_multiplier(realm_sync_client_config_t*,
+                                                                              int) RLM_API_NOEXCEPT;
+RLM_API void realm_sync_client_config_set_resumption_delay_jitter_divisor(realm_sync_client_config_t*,
+                                                                          uint8_t) RLM_API_NOEXCEPT;
 RLM_API void realm_sync_client_config_set_sync_socket(realm_sync_client_config_t*,
                                                       realm_sync_socket_t*) RLM_API_NOEXCEPT;
 RLM_API void realm_sync_client_config_set_default_binding_thread_observer(

--- a/src/realm/object-store/c_api/sync.cpp
+++ b/src/realm/object-store/c_api/sync.cpp
@@ -212,6 +212,30 @@ RLM_API void realm_sync_client_config_set_fast_reconnect_limit(realm_sync_client
     config->timeouts.fast_reconnect_limit = limit;
 }
 
+RLM_API void realm_sync_client_config_set_resumption_delay_interval(realm_sync_client_config_t* config,
+                                                                    uint64_t interval) noexcept
+{
+    config->timeouts.resumption_delay_interval = interval;
+}
+
+RLM_API void realm_sync_client_config_set_max_resumption_delay_interval(realm_sync_client_config_t* config,
+                                                                        uint64_t interval) noexcept
+{
+    config->timeouts.max_resumption_delay_interval = interval;
+}
+
+RLM_API void realm_sync_client_config_set_resumption_delay_backoff_multiplier(realm_sync_client_config_t* config,
+                                                                              int multiplier) noexcept
+{
+    config->timeouts.resumption_delay_backoff_multiplier = multiplier;
+}
+
+RLM_API void realm_sync_client_config_set_resumption_delay_jitter_divisor(realm_sync_client_config_t* config,
+                                                                          uint8_t divisor) noexcept
+{
+    config->timeouts.resumption_delay_jitter_divisor = divisor;
+}
+
 /// Register an app local callback handler for bindings interested in registering callbacks before/after
 /// the ObjectStore thread runs for this app. This only works for the default socket provider implementation.
 /// IMPORTANT: If a function is supplied that handles the exception, it must call abort() or cause the

--- a/src/realm/object-store/c_api/sync.cpp
+++ b/src/realm/object-store/c_api/sync.cpp
@@ -215,25 +215,25 @@ RLM_API void realm_sync_client_config_set_fast_reconnect_limit(realm_sync_client
 RLM_API void realm_sync_client_config_set_resumption_delay_interval(realm_sync_client_config_t* config,
                                                                     uint64_t interval) noexcept
 {
-    config->timeouts.resumption_delay_interval = interval;
+    config->timeouts.reconnect_backoff_info.resumption_delay_interval = std::chrono::milliseconds{interval};
 }
 
 RLM_API void realm_sync_client_config_set_max_resumption_delay_interval(realm_sync_client_config_t* config,
                                                                         uint64_t interval) noexcept
 {
-    config->timeouts.max_resumption_delay_interval = interval;
+    config->timeouts.reconnect_backoff_info.max_resumption_delay_interval = std::chrono::milliseconds{interval};
 }
 
 RLM_API void realm_sync_client_config_set_resumption_delay_backoff_multiplier(realm_sync_client_config_t* config,
                                                                               int multiplier) noexcept
 {
-    config->timeouts.resumption_delay_backoff_multiplier = multiplier;
+    config->timeouts.reconnect_backoff_info.resumption_delay_backoff_multiplier = multiplier;
 }
 
 RLM_API void realm_sync_client_config_set_resumption_delay_jitter_divisor(realm_sync_client_config_t* config,
-                                                                          uint8_t divisor) noexcept
+                                                                          int divisor) noexcept
 {
-    config->timeouts.resumption_delay_jitter_divisor = divisor;
+    config->timeouts.reconnect_backoff_info.delay_jitter_divisor = divisor;
 }
 
 /// Register an app local callback handler for bindings interested in registering callbacks before/after

--- a/src/realm/object-store/c_api/sync.cpp
+++ b/src/realm/object-store/c_api/sync.cpp
@@ -230,12 +230,6 @@ RLM_API void realm_sync_client_config_set_resumption_delay_backoff_multiplier(re
     config->timeouts.reconnect_backoff_info.resumption_delay_backoff_multiplier = multiplier;
 }
 
-RLM_API void realm_sync_client_config_set_resumption_delay_jitter_divisor(realm_sync_client_config_t* config,
-                                                                          int divisor) noexcept
-{
-    config->timeouts.reconnect_backoff_info.delay_jitter_divisor = divisor;
-}
-
 /// Register an app local callback handler for bindings interested in registering callbacks before/after
 /// the ObjectStore thread runs for this app. This only works for the default socket provider implementation.
 /// IMPORTANT: If a function is supplied that handles the exception, it must call abort() or cause the

--- a/src/realm/object-store/sync/impl/sync_client.hpp
+++ b/src/realm/object-store/sync/impl/sync_client.hpp
@@ -81,7 +81,7 @@ struct SyncClient {
             c.reconnect_backoff_info.resumption_delay_backoff_multiplier =
                 config.timeouts.reconnect_backoff_info.resumption_delay_backoff_multiplier;
             if (c.reconnect_backoff_info.resumption_delay_interval.count() < 1000)
-                logger->info("A resumption delay interval less than 1000 (1 second) is not recommended");
+                logger->warn("A resumption delay interval less than 1000 (1 second) is not recommended");
             if (c.reconnect_backoff_info.resumption_delay_backoff_multiplier < 1)
                 throw InvalidArgument("Delay backoff multiplier in reconnect backoff info cannot be less than 1");
             return c;

--- a/src/realm/object-store/sync/impl/sync_client.hpp
+++ b/src/realm/object-store/sync/impl/sync_client.hpp
@@ -74,13 +74,16 @@ struct SyncClient {
                 c.pong_keepalive_timeout = config.timeouts.pong_keepalive_timeout;
             if (config.timeouts.fast_reconnect_limit > 1000)
                 c.fast_reconnect_limit = config.timeouts.fast_reconnect_limit;
-            c.reconnect_backoff_info = config.timeouts.reconnect_backoff_info;
+            c.reconnect_backoff_info.resumption_delay_interval =
+                config.timeouts.reconnect_backoff_info.resumption_delay_interval;
+            c.reconnect_backoff_info.max_resumption_delay_interval =
+                config.timeouts.reconnect_backoff_info.max_resumption_delay_interval;
+            c.reconnect_backoff_info.resumption_delay_backoff_multiplier =
+                config.timeouts.reconnect_backoff_info.resumption_delay_backoff_multiplier;
             if (c.reconnect_backoff_info.resumption_delay_interval.count() < 1000)
                 logger->info("A resumption delay interval less than 1000 (1 second) is not recommended");
             if (c.reconnect_backoff_info.resumption_delay_backoff_multiplier < 1)
                 throw InvalidArgument("Delay backoff multiplier in reconnect backoff info cannot be less than 1");
-            if (c.reconnect_backoff_info.delay_jitter_divisor < 0)
-                throw InvalidArgument("Delay jitter divisor in reconnect backoff info cannot be less than 0");
             return c;
         }())
         , m_logger_ptr(logger)

--- a/src/realm/object-store/sync/impl/sync_client.hpp
+++ b/src/realm/object-store/sync/impl/sync_client.hpp
@@ -74,6 +74,17 @@ struct SyncClient {
                 c.pong_keepalive_timeout = config.timeouts.pong_keepalive_timeout;
             if (config.timeouts.fast_reconnect_limit > 1000)
                 c.fast_reconnect_limit = config.timeouts.fast_reconnect_limit;
+            if (config.timeouts.resumption_delay_interval >= 1000)
+                c.reconnect_backoff_info.resumption_delay_interval =
+                    std::chrono::milliseconds(config.timeouts.resumption_delay_interval);
+            if (config.timeouts.max_resumption_delay_interval > 30000)
+                c.reconnect_backoff_info.max_resumption_delay_interval =
+                    std::chrono::milliseconds(config.timeouts.max_resumption_delay_interval);
+            if (config.timeouts.resumption_delay_backoff_multiplier >= 1)
+                c.reconnect_backoff_info.resumption_delay_backoff_multiplier =
+                    config.timeouts.resumption_delay_backoff_multiplier;
+            c.reconnect_backoff_info.delay_jitter_divisor =
+                static_cast<int>(config.timeouts.resumption_delay_jitter_divisor);
 
             return c;
         }())

--- a/src/realm/object-store/sync/impl/sync_client.hpp
+++ b/src/realm/object-store/sync/impl/sync_client.hpp
@@ -83,8 +83,7 @@ struct SyncClient {
             if (config.timeouts.resumption_delay_backoff_multiplier >= 1)
                 c.reconnect_backoff_info.resumption_delay_backoff_multiplier =
                     config.timeouts.resumption_delay_backoff_multiplier;
-            c.reconnect_backoff_info.delay_jitter_divisor =
-                static_cast<int>(config.timeouts.resumption_delay_jitter_divisor);
+            c.reconnect_backoff_info.delay_jitter_divisor = config.timeouts.resumption_delay_jitter_divisor;
 
             return c;
         }())

--- a/src/realm/object-store/sync/impl/sync_client.hpp
+++ b/src/realm/object-store/sync/impl/sync_client.hpp
@@ -74,17 +74,13 @@ struct SyncClient {
                 c.pong_keepalive_timeout = config.timeouts.pong_keepalive_timeout;
             if (config.timeouts.fast_reconnect_limit > 1000)
                 c.fast_reconnect_limit = config.timeouts.fast_reconnect_limit;
-            if (config.timeouts.resumption_delay_interval >= 1000)
-                c.reconnect_backoff_info.resumption_delay_interval =
-                    std::chrono::milliseconds(config.timeouts.resumption_delay_interval);
-            if (config.timeouts.max_resumption_delay_interval > 30000)
-                c.reconnect_backoff_info.max_resumption_delay_interval =
-                    std::chrono::milliseconds(config.timeouts.max_resumption_delay_interval);
-            if (config.timeouts.resumption_delay_backoff_multiplier >= 1)
-                c.reconnect_backoff_info.resumption_delay_backoff_multiplier =
-                    config.timeouts.resumption_delay_backoff_multiplier;
-            c.reconnect_backoff_info.delay_jitter_divisor = config.timeouts.resumption_delay_jitter_divisor;
-
+            c.reconnect_backoff_info = config.timeouts.reconnect_backoff_info;
+            if (c.reconnect_backoff_info.resumption_delay_interval.count() < 1000)
+                logger->info("A resumption delay interval less than 1000 (1 second) is not recommended");
+            if (c.reconnect_backoff_info.resumption_delay_backoff_multiplier < 1)
+                throw InvalidArgument("Delay backoff multiplier in reconnect backoff info cannot be less than 1");
+            if (c.reconnect_backoff_info.delay_jitter_divisor < 0)
+                throw InvalidArgument("Delay jitter divisor in reconnect backoff info cannot be less than 0");
             return c;
         }())
         , m_logger_ptr(logger)

--- a/src/realm/object-store/sync/sync_manager.cpp
+++ b/src/realm/object-store/sync/sync_manager.cpp
@@ -40,10 +40,6 @@ SyncClientTimeouts::SyncClientTimeouts()
     , ping_keepalive_period(sync::default_ping_keepalive_period)
     , pong_keepalive_timeout(sync::default_pong_keepalive_timeout)
     , fast_reconnect_limit(sync::default_fast_reconnect_limit)
-    , resumption_delay_interval(sync::default_resumption_delay_interval)
-    , max_resumption_delay_interval(sync::default_max_resumption_delay_interval)
-    , resumption_delay_backoff_multiplier(sync::default_resumption_delay_backoff_multiplier)
-    , resumption_delay_jitter_divisor(sync::default_delay_jitter_divisor)
 {
 }
 

--- a/src/realm/object-store/sync/sync_manager.cpp
+++ b/src/realm/object-store/sync/sync_manager.cpp
@@ -40,6 +40,10 @@ SyncClientTimeouts::SyncClientTimeouts()
     , ping_keepalive_period(sync::default_ping_keepalive_period)
     , pong_keepalive_timeout(sync::default_pong_keepalive_timeout)
     , fast_reconnect_limit(sync::default_fast_reconnect_limit)
+    , resumption_delay_interval(sync::default_resumption_delay_interval)
+    , max_resumption_delay_interval(sync::default_max_resumption_delay_interval)
+    , resumption_delay_backoff_multiplier(sync::default_resumption_delay_backoff_multiplier)
+    , resumption_delay_jitter_divisor(sync::default_delay_jitter_divisor)
 {
 }
 

--- a/src/realm/object-store/sync/sync_manager.cpp
+++ b/src/realm/object-store/sync/sync_manager.cpp
@@ -35,11 +35,11 @@ using namespace realm;
 using namespace realm::_impl;
 
 SyncClientTimeouts::SyncClientTimeouts()
-    : connect_timeout(sync::Client::default_connect_timeout)
-    , connection_linger_time(sync::Client::default_connection_linger_time)
-    , ping_keepalive_period(sync::Client::default_ping_keepalive_period)
-    , pong_keepalive_timeout(sync::Client::default_pong_keepalive_timeout)
-    , fast_reconnect_limit(sync::Client::default_fast_reconnect_limit)
+    : connect_timeout(sync::default_connect_timeout)
+    , connection_linger_time(sync::default_connection_linger_time)
+    , ping_keepalive_period(sync::default_ping_keepalive_period)
+    , pong_keepalive_timeout(sync::default_pong_keepalive_timeout)
+    , fast_reconnect_limit(sync::default_fast_reconnect_limit)
 {
 }
 

--- a/src/realm/object-store/sync/sync_manager.hpp
+++ b/src/realm/object-store/sync/sync_manager.hpp
@@ -61,6 +61,11 @@ struct SyncClientTimeouts {
     uint64_t ping_keepalive_period;
     uint64_t pong_keepalive_timeout;
     uint64_t fast_reconnect_limit;
+    // Used for requesting location metadata at startup and reconnecting sync connections.
+    uint64_t resumption_delay_interval;      // in milliseconds (min 1000)
+    uint64_t max_resumption_delay_interval;  // in milliseconds (min 30000)
+    int resumption_delay_backoff_multiplier; // multiplier applied after each attempt (min 1)
+    uint8_t resumption_delay_jitter_divisor; // fractional divisor to determine jitter (0: disabled)
 };
 
 struct SyncClientConfig {

--- a/src/realm/object-store/sync/sync_manager.hpp
+++ b/src/realm/object-store/sync/sync_manager.hpp
@@ -62,10 +62,7 @@ struct SyncClientTimeouts {
     uint64_t pong_keepalive_timeout;
     uint64_t fast_reconnect_limit;
     // Used for requesting location metadata at startup and reconnecting sync connections.
-    uint64_t resumption_delay_interval;      // in milliseconds (min 1000)
-    uint64_t max_resumption_delay_interval;  // in milliseconds (min 30000)
-    int resumption_delay_backoff_multiplier; // multiplier applied after each attempt (min 1)
-    uint8_t resumption_delay_jitter_divisor; // fractional divisor to determine jitter (0: disabled)
+    sync::ResumptionDelayInfo reconnect_backoff_info;
 };
 
 struct SyncClientConfig {

--- a/src/realm/object-store/sync/sync_manager.hpp
+++ b/src/realm/object-store/sync/sync_manager.hpp
@@ -62,6 +62,7 @@ struct SyncClientTimeouts {
     uint64_t pong_keepalive_timeout;
     uint64_t fast_reconnect_limit;
     // Used for requesting location metadata at startup and reconnecting sync connections.
+    // NOTE: delay_jitter_divisor is not configurable
     sync::ResumptionDelayInfo reconnect_backoff_info;
 };
 

--- a/src/realm/sync/client.hpp
+++ b/src/realm/sync/client.hpp
@@ -23,12 +23,6 @@ class Client {
 public:
     using port_type = sync::port_type;
 
-    static constexpr milliseconds_type default_connect_timeout = sync::default_connect_timeout;
-    static constexpr milliseconds_type default_connection_linger_time = sync::default_connection_linger_time;
-    static constexpr milliseconds_type default_ping_keepalive_period = sync::default_ping_keepalive_period;
-    static constexpr milliseconds_type default_pong_keepalive_timeout = sync::default_pong_keepalive_timeout;
-    static constexpr milliseconds_type default_fast_reconnect_limit = sync::default_fast_reconnect_limit;
-
     using Config = ClientConfig;
 
     /// \throw util::EventLoop::Implementation::NotAvailable if no event loop

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -1296,15 +1296,6 @@ void Connection::receive_error_message(const ProtocolErrorInfo& info, session_id
                 info.message, info.raw_error_code, info.is_fatal, session_ident,
                 info.server_requests_action); // Throws
 
-    if (info.resumption_delay_interval) {
-        logger.debug("                (reconnect backoff info: max_delay=%1ms, initial_delay=%2ms, multiplier=%3, "
-                     "jitter=1/%4)",
-                     info.resumption_delay_interval->max_resumption_delay_interval.count(),
-                     info.resumption_delay_interval->resumption_delay_interval.count(),
-                     info.resumption_delay_interval->resumption_delay_backoff_multiplier,
-                     info.resumption_delay_interval->delay_jitter_divisor);
-    }
-
     bool known_error_code = bool(get_protocol_error_message(info.raw_error_code));
     if (REALM_LIKELY(known_error_code)) {
         ProtocolError error_code = ProtocolError(info.raw_error_code);

--- a/src/realm/sync/protocol.hpp
+++ b/src/realm/sync/protocol.hpp
@@ -240,28 +240,21 @@ struct CompensatingWriteErrorInfo {
     std::string reason;
 };
 
-static constexpr milliseconds_type default_max_resumption_delay_interval = 300000; // 5 minutes
-static constexpr milliseconds_type default_resumption_delay_interval = 1000;       // 1 second
-static constexpr int default_resumption_delay_backoff_multiplier = 2;              // Double after each attempt
-static constexpr uint8_t default_delay_jitter_divisor = 4;                         // 25% jitter
-
 struct ResumptionDelayInfo {
     // This is the maximum delay between trying to resume a session/connection.
-    std::chrono::milliseconds max_resumption_delay_interval =
-        std::chrono::milliseconds{default_max_resumption_delay_interval};
+    std::chrono::milliseconds max_resumption_delay_interval = std::chrono::minutes{5};
     // The initial delay between trying to resume a session/connection.
-    std::chrono::milliseconds resumption_delay_interval =
-        std::chrono::milliseconds{default_resumption_delay_interval};
+    std::chrono::milliseconds resumption_delay_interval = std::chrono::seconds{1};
     // After each failure of the same type, the last delay will be multiplied by this value
     // until it is greater-than-or-equal to the max_resumption_delay_interval.
-    int resumption_delay_backoff_multiplier = default_resumption_delay_backoff_multiplier;
+    int resumption_delay_backoff_multiplier = 2;
     // When calculating a new delay interval, a random value betwen zero and the result off
     // dividing the current delay value by the delay_jitter_divisor will be subtracted from the
     // delay interval. The default is to subtract up to 25% of the current delay interval.
     //
     // This is to reduce the likelyhood of a connection storm if the server goes down and
     // all clients attempt to reconnect at once.
-    int delay_jitter_divisor = default_delay_jitter_divisor;
+    int delay_jitter_divisor = 4;
 };
 
 class IsFatalTag {};

--- a/src/realm/sync/protocol.hpp
+++ b/src/realm/sync/protocol.hpp
@@ -240,21 +240,28 @@ struct CompensatingWriteErrorInfo {
     std::string reason;
 };
 
+static constexpr milliseconds_type default_max_resumption_delay_interval = 300000; // 5 minutes
+static constexpr milliseconds_type default_resumption_delay_interval = 1000;       // 1 second
+static constexpr int default_resumption_delay_backoff_multiplier = 2;              // Double after each attempt
+static constexpr uint8_t default_delay_jitter_divisor = 4;                         // 25% jitter
+
 struct ResumptionDelayInfo {
     // This is the maximum delay between trying to resume a session/connection.
-    std::chrono::milliseconds max_resumption_delay_interval = std::chrono::minutes{5};
+    std::chrono::milliseconds max_resumption_delay_interval =
+        std::chrono::milliseconds{default_max_resumption_delay_interval};
     // The initial delay between trying to resume a session/connection.
-    std::chrono::milliseconds resumption_delay_interval = std::chrono::seconds{1};
+    std::chrono::milliseconds resumption_delay_interval =
+        std::chrono::milliseconds{default_resumption_delay_interval};
     // After each failure of the same type, the last delay will be multiplied by this value
     // until it is greater-than-or-equal to the max_resumption_delay_interval.
-    int resumption_delay_backoff_multiplier = 2;
+    int resumption_delay_backoff_multiplier = default_resumption_delay_backoff_multiplier;
     // When calculating a new delay interval, a random value betwen zero and the result off
     // dividing the current delay value by the delay_jitter_divisor will be subtracted from the
     // delay interval. The default is to subtract up to 25% of the current delay interval.
     //
     // This is to reduce the likelyhood of a connection storm if the server goes down and
     // all clients attempt to reconnect at once.
-    int delay_jitter_divisor = 4;
+    int delay_jitter_divisor = default_delay_jitter_divisor;
 };
 
 class IsFatalTag {};

--- a/test/object-store/c_api/c_api.cpp
+++ b/test/object-store/c_api/c_api.cpp
@@ -578,8 +578,6 @@ TEST_CASE("C API (non-database)", "[c_api]") {
               600024);
         realm_sync_client_config_set_resumption_delay_backoff_multiplier(test_sync_client_config.get(), 1010);
         CHECK(test_sync_client_config->timeouts.reconnect_backoff_info.resumption_delay_backoff_multiplier == 1010);
-        realm_sync_client_config_set_resumption_delay_jitter_divisor(test_sync_client_config.get(), 212);
-        CHECK(test_sync_client_config->timeouts.reconnect_backoff_info.delay_jitter_divisor == 212);
     }
 
     SECTION("realm_app_config_t") {

--- a/test/object-store/c_api/c_api.cpp
+++ b/test/object-store/c_api/c_api.cpp
@@ -572,13 +572,14 @@ TEST_CASE("C API (non-database)", "[c_api]") {
         realm_sync_client_config_set_fast_reconnect_limit(test_sync_client_config.get(), 1099);
         CHECK(test_sync_client_config->timeouts.fast_reconnect_limit == 1099);
         realm_sync_client_config_set_resumption_delay_interval(test_sync_client_config.get(), 1024);
-        CHECK(test_sync_client_config->timeouts.resumption_delay_interval == 1024);
+        CHECK(test_sync_client_config->timeouts.reconnect_backoff_info.resumption_delay_interval.count() == 1024);
         realm_sync_client_config_set_max_resumption_delay_interval(test_sync_client_config.get(), 600024);
-        CHECK(test_sync_client_config->timeouts.max_resumption_delay_interval == 600024);
+        CHECK(test_sync_client_config->timeouts.reconnect_backoff_info.max_resumption_delay_interval.count() ==
+              600024);
         realm_sync_client_config_set_resumption_delay_backoff_multiplier(test_sync_client_config.get(), 1010);
-        CHECK(test_sync_client_config->timeouts.resumption_delay_backoff_multiplier == 1010);
+        CHECK(test_sync_client_config->timeouts.reconnect_backoff_info.resumption_delay_backoff_multiplier == 1010);
         realm_sync_client_config_set_resumption_delay_jitter_divisor(test_sync_client_config.get(), 212);
-        CHECK(test_sync_client_config->timeouts.resumption_delay_jitter_divisor == 212);
+        CHECK(test_sync_client_config->timeouts.reconnect_backoff_info.delay_jitter_divisor == 212);
     }
 
     SECTION("realm_app_config_t") {

--- a/test/object-store/c_api/c_api.cpp
+++ b/test/object-store/c_api/c_api.cpp
@@ -536,6 +536,51 @@ TEST_CASE("C API (non-database)", "[c_api]") {
     }
 
 #if REALM_ENABLE_SYNC
+    SECTION("sync_client_config_t") {
+        auto test_sync_client_config = cptr(realm_sync_client_config_new());
+        realm_sync_client_config_set_base_file_path(test_sync_client_config.get(), "some string");
+        CHECK(test_sync_client_config->base_file_path == "some string");
+        realm_sync_client_config_set_metadata_mode(test_sync_client_config.get(),
+                                                   RLM_SYNC_CLIENT_METADATA_MODE_ENCRYPTED);
+        CHECK(test_sync_client_config->metadata_mode ==
+              static_cast<realm::SyncClientConfig::MetadataMode>(RLM_SYNC_CLIENT_METADATA_MODE_ENCRYPTED));
+        auto enc_key = make_test_encryption_key(123);
+        realm_sync_client_config_set_metadata_encryption_key(test_sync_client_config.get(),
+                                                             reinterpret_cast<uint8_t*>(enc_key.data()));
+        CHECK(test_sync_client_config->custom_encryption_key);
+        CHECK(std::equal(enc_key.begin(), enc_key.end(), test_sync_client_config->custom_encryption_key->begin()));
+        realm_sync_client_config_set_reconnect_mode(test_sync_client_config.get(),
+                                                    RLM_SYNC_CLIENT_RECONNECT_MODE_TESTING);
+        CHECK(test_sync_client_config->reconnect_mode ==
+              static_cast<ReconnectMode>(RLM_SYNC_CLIENT_RECONNECT_MODE_TESTING));
+        realm_sync_client_config_set_multiplex_sessions(test_sync_client_config.get(), true);
+        CHECK(test_sync_client_config->multiplex_sessions);
+        realm_sync_client_config_set_multiplex_sessions(test_sync_client_config.get(), false);
+        CHECK_FALSE(test_sync_client_config->multiplex_sessions);
+        realm_sync_client_config_set_user_agent_binding_info(test_sync_client_config.get(), "some user agent stg");
+        CHECK(test_sync_client_config->user_agent_binding_info == "some user agent stg");
+        realm_sync_client_config_set_user_agent_application_info(test_sync_client_config.get(), "some application");
+        CHECK(test_sync_client_config->user_agent_application_info == "some application");
+        realm_sync_client_config_set_connect_timeout(test_sync_client_config.get(), 666);
+        CHECK(test_sync_client_config->timeouts.connect_timeout == 666);
+        realm_sync_client_config_set_connection_linger_time(test_sync_client_config.get(), 999);
+        CHECK(test_sync_client_config->timeouts.connection_linger_time == 999);
+        realm_sync_client_config_set_ping_keepalive_period(test_sync_client_config.get(), 555);
+        CHECK(test_sync_client_config->timeouts.ping_keepalive_period == 555);
+        realm_sync_client_config_set_pong_keepalive_timeout(test_sync_client_config.get(), 100000);
+        CHECK(test_sync_client_config->timeouts.pong_keepalive_timeout == 100000);
+        realm_sync_client_config_set_fast_reconnect_limit(test_sync_client_config.get(), 1099);
+        CHECK(test_sync_client_config->timeouts.fast_reconnect_limit == 1099);
+        realm_sync_client_config_set_resumption_delay_interval(test_sync_client_config.get(), 1024);
+        CHECK(test_sync_client_config->timeouts.resumption_delay_interval == 1024);
+        realm_sync_client_config_set_max_resumption_delay_interval(test_sync_client_config.get(), 600024);
+        CHECK(test_sync_client_config->timeouts.max_resumption_delay_interval == 600024);
+        realm_sync_client_config_set_resumption_delay_backoff_multiplier(test_sync_client_config.get(), 1010);
+        CHECK(test_sync_client_config->timeouts.resumption_delay_backoff_multiplier == 1010);
+        realm_sync_client_config_set_resumption_delay_jitter_divisor(test_sync_client_config.get(), 212);
+        CHECK(test_sync_client_config->timeouts.resumption_delay_jitter_divisor == 212);
+    }
+
     SECTION("realm_app_config_t") {
         const uint64_t request_timeout = 2500;
         std::string base_url = "https://path/to/app";


### PR DESCRIPTION
## What, How & Why?
Added values to the `SyncClientTimeouts` for configuring the SyncSession resumption delay. This work was pulled from the recommendations posted for PR #7365 and separated out into its own pull request since that design is being reworked.

## ☑️ ToDos
* [x] 📝 Changelog update
* [X] 🚦 Tests (or not relevant)
* [X] C-API, if public C++ API changed
* [X] `bindgen/spec.yml`, if public C++ API changed
