### PR TITLE
Fsa/unify subword search

### DIFF
--- a/src/realm/array_direct.hpp
+++ b/src/realm/array_direct.hpp
@@ -209,6 +209,19 @@ public:
         // note: above shifts in zeroes below the bits we want
         return result;
     }
+    uint64_t get_with_unsafe_prefetch(unsigned num_bits)
+    {
+        auto first_word = m_word_ptr[0];
+        uint64_t result = first_word >> m_in_word_offset;
+        // note: above shifts in zeroes
+        uint64_t last_word_mask = (m_in_word_offset + num_bits <= 64) ? 0 : -1ULL;
+        // if we're here, in_word_offset > 0
+        auto first_word_size = 64 - m_in_word_offset;
+        auto second_word = m_word_ptr[1];
+        result |= (second_word << first_word_size) & last_word_mask;
+        // note: above shifts in zeroes below the bits we want
+        return result;
+    }
     // bump the iterator the specified number of bits
     void bump(unsigned num_bits)
     {
@@ -884,16 +897,36 @@ inline int first_field_marked(int width, uint64_t vector)
 #endif
 
 template <typename VectorCompare>
-size_t parallel_subword_find(VectorCompare vector_compare, const uint64_t* data, size_t offset, size_t width,
-                             uint64_t MSBs, uint64_t search_vector, size_t start, size_t end)
+inline size_t parallel_subword_find(VectorCompare vector_compare, const uint64_t* data, size_t offset, size_t width,
+                                    uint64_t MSBs, uint64_t search_vector, size_t start, size_t end)
 {
     const auto field_count = num_fields_for_width(width);
     const auto bit_count_pr_iteration = num_bits_for_width(width);
+    const auto fast_scan_limit = 4 * bit_count_pr_iteration;
     // use signed to make it easier to ascertain correctness of loop condition below
     signed total_bit_count_left = static_cast<signed>(end - start) * static_cast<signed>(width);
     REALM_ASSERT(total_bit_count_left >= 0);
     unaligned_word_iter it(data, offset + start * width);
     uint64_t found_vector = 0;
+    while (total_bit_count_left >= fast_scan_limit) {
+        // unrolling 2x
+        const auto word0 = it.get_with_unsafe_prefetch(bit_count_pr_iteration);
+        it.bump(bit_count_pr_iteration);
+        const auto word1 = it.get_with_unsafe_prefetch(bit_count_pr_iteration);
+        auto found_vector0 = vector_compare(MSBs, word0, search_vector);
+        auto found_vector1 = vector_compare(MSBs, word1, search_vector);
+        it.bump(bit_count_pr_iteration);
+        if (found_vector0) {
+            int sub_word_index = first_field_marked(width, found_vector0);
+            return start + sub_word_index;
+        }
+        if (found_vector1) {
+            int sub_word_index = first_field_marked(width, found_vector1);
+            return start + field_count + sub_word_index;
+        }
+        total_bit_count_left -= 2 * bit_count_pr_iteration;
+        start += 2 * field_count;
+    }
     while (total_bit_count_left >= bit_count_pr_iteration) {
         const auto word = it.get(bit_count_pr_iteration);
         found_vector = vector_compare(MSBs, word, search_vector);

--- a/src/realm/array_direct.hpp
+++ b/src/realm/array_direct.hpp
@@ -883,6 +883,42 @@ inline int first_field_marked(int width, uint64_t vector)
 }
 #endif
 
+template <typename VectorCompare>
+size_t parallel_subword_find(VectorCompare vector_compare, const uint64_t* data, size_t offset, size_t width,
+                             uint64_t MSBs, uint64_t search_vector, size_t start, size_t end)
+{
+    const auto field_count = num_fields_for_width(width);
+    const auto bit_count_pr_iteration = num_bits_for_width(width);
+    // use signed to make it easier to ascertain correctness of loop condition below
+    signed total_bit_count_left = static_cast<signed>(end - start) * static_cast<signed>(width);
+    REALM_ASSERT(total_bit_count_left >= 0);
+    unaligned_word_iter it(data, offset + start * width);
+    uint64_t found_vector = 0;
+    while (total_bit_count_left >= bit_count_pr_iteration) {
+        const auto word = it.get(bit_count_pr_iteration);
+        found_vector = vector_compare(MSBs, word, search_vector);
+        if (found_vector) {
+            int sub_word_index = first_field_marked(width, found_vector);
+            return start + sub_word_index;
+        }
+        total_bit_count_left -= bit_count_pr_iteration;
+        start += field_count;
+        it.bump(bit_count_pr_iteration);
+    }
+    if (total_bit_count_left) {                         // final subword, may be partial
+        const auto word = it.get(total_bit_count_left); // <-- limit lookahead to avoid touching memory beyond array
+        found_vector = vector_compare(MSBs, word, search_vector);
+        auto last_word_mask = 0xFFFFFFFFFFFFFFFFULL >> (64 - total_bit_count_left);
+        found_vector &= last_word_mask;
+        if (found_vector) {
+            int sub_word_index = first_field_marked(width, found_vector);
+            return start + sub_word_index;
+        }
+    }
+    return end;
+}
+
+
 namespace impl {
 
 // Lower and Upper bound are mainly used in the B+tree implementation,

--- a/src/realm/array_direct.hpp
+++ b/src/realm/array_direct.hpp
@@ -457,13 +457,12 @@ constexpr int num_bits_table[65] = {-1, 64, 64, 63, 64, 60, 60, 63, // 0-7
 
 inline int num_fields_for_width(int width)
 {
-    REALM_ASSERT(width);
-    return 64 / width;
-}
-
-inline uint64_t num_bits(int width)
-{
-    return num_fields_table[width];
+    REALM_ASSERT_DEBUG(width);
+    auto retval = num_fields_table[width];
+#ifdef REALM_DEBUG
+    REALM_ASSERT_DEBUG(retval == 64 / width);
+#endif
+    return retval;
 }
 
 inline int num_bits_for_width(int width)

--- a/src/realm/array_direct.hpp
+++ b/src/realm/array_direct.hpp
@@ -455,7 +455,7 @@ constexpr int num_bits_table[65] = {-1, 64, 64, 63, 64, 60, 60, 63, // 0-7
                                     56, 57, 58, 59, 60, 61, 62, 63, // 56-63
                                     64};
 
-inline int num_fields_for_width(int width)
+inline int num_fields_for_width(size_t width)
 {
     REALM_ASSERT_DEBUG(width);
     auto retval = num_fields_table[width];
@@ -465,7 +465,7 @@ inline int num_fields_for_width(int width)
     return retval;
 }
 
-inline int num_bits_for_width(int width)
+inline int num_bits_for_width(size_t width)
 {
     return num_bits_table[width];
 }
@@ -820,7 +820,7 @@ inline int countr_zero(uint64_t vector)
 #endif
 }
 
-inline int first_field_marked(int width, uint64_t vector)
+inline int first_field_marked(size_t width, uint64_t vector)
 {
     const auto lz = countr_zero(vector);
     int field = (lz * inverse_width[width]) >> 22;

--- a/src/realm/array_direct.hpp
+++ b/src/realm/array_direct.hpp
@@ -484,7 +484,7 @@ bool inline any_field_NE(int width, uint64_t A, uint64_t B)
 
 // Populate all fields in a vector with a given value of a give width.
 // Bits outside of the given field are ignored.
-constexpr uint64_t populate(int width, uint64_t value)
+constexpr uint64_t populate(size_t width, uint64_t value)
 {
     value &= 0xFFFFFFFFFFFFFFFFULL >> (64 - width);
     if (width < 8) {

--- a/src/realm/array_flex.cpp
+++ b/src/realm/array_flex.cpp
@@ -201,7 +201,7 @@ inline size_t ArrayFlex::parallel_subword_find(const Array& arr, uint64_t value,
 {
     const auto MSBs = populate(width, width_mask);
     const auto search_vector = populate(width, value);
-    return ::parallel_subword_find(vector_compare<Cond, v>, (const uint64_t*)arr.m_data, offset, arr.m_width, MSBs,
+    return ::parallel_subword_find(vector_compare<Cond, v>, (const uint64_t*)arr.m_data, offset, width, MSBs,
                                    search_vector, start, end);
 }
 #if 0

--- a/src/realm/array_flex.hpp
+++ b/src/realm/array_flex.hpp
@@ -47,11 +47,6 @@ public:
 private:
     int64_t do_get(uint64_t*, size_t, size_t, size_t, size_t, size_t, uint64_t) const;
     bool find_all_match(size_t start, size_t end, size_t baseindex, QueryStateBase* state) const;
-
-    template <typename Cond, bool = true> // true int64_t, false uint64_t
-    inline size_t parallel_subword_find(const Array&, uint64_t, uint64_t, size_t, uint_least8_t, size_t,
-                                        size_t) const;
-
     bool find_eq(const Array&, int64_t, size_t, size_t, size_t, QueryStateBase*) const;
     bool find_neq(const Array&, int64_t, size_t, size_t, size_t, QueryStateBase*) const;
     bool find_lt(const Array&, int64_t, size_t, size_t, size_t, QueryStateBase*) const;

--- a/src/realm/array_packed.cpp
+++ b/src/realm/array_packed.cpp
@@ -124,7 +124,7 @@ uint64_t vector_compare(uint64_t MSBs, uint64_t a, uint64_t b)
         return find_all_fields_signed_GT(MSBs, a, b);
     if constexpr (std::is_same_v<Cond, Less>)
         return find_all_fields_signed_LT(MSBs, a, b);
-};
+}
 
 template <typename Cond>
 bool ArrayPacked::find_all(const Array& arr, int64_t value, size_t start, size_t end, size_t baseindex,

--- a/src/realm/array_packed.hpp
+++ b/src/realm/array_packed.hpp
@@ -48,9 +48,6 @@ public:
 private:
     int64_t do_get(uint64_t*, size_t, size_t, size_t, uint64_t) const;
     bool find_all_match(size_t start, size_t end, size_t baseindex, QueryStateBase* state) const;
-
-    template <typename Cond>
-    size_t parallel_subword_find(const Array&, int64_t, size_t, size_t) const;
 };
 } // namespace realm
 


### PR DESCRIPTION
Consolidate parallel sub word search into a single method for both Flex and Packed.
That way we can hopefully optimize in one place instead of two.

Eliminated a division during start of search.

Moved generation of MSB and search_vector up, into caller

Unrolled critical loop twice and eliminated a branch. Hope this exposes more ILP.

Performance has not been measured yet.