### PR TITLE
RCOCOA-2301 Remove the emulated InterprocessMutex File cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Fix an assertion failure "m_lock_info && m_lock_info->m_file.get_path() == m_filename" that appears to be related to opening a Realm while the file is in the process of being closed on another thread ([Swift #8507](https://github.com/realm/realm-swift/issues/8507)).
 
 ### Breaking changes
 * None.

--- a/src/realm/util/interprocess_mutex.cpp
+++ b/src/realm/util/interprocess_mutex.cpp
@@ -20,14 +20,6 @@
 
 using namespace realm::util;
 
-#if REALM_ROBUST_MUTEX_EMULATION
-
-std::once_flag InterprocessMutex::s_init_flag;
-std::map<File::UniqueID, std::weak_ptr<InterprocessMutex::LockInfo>>* InterprocessMutex::s_info_map;
-Mutex* InterprocessMutex::s_mutex;
-
-#endif // REALM_ROBUST_MUTEX_EMULATION
-
 #if REALM_PLATFORM_APPLE
 SemaphoreMutex::SemaphoreMutex() noexcept
     : m_semaphore(dispatch_semaphore_create(1))


### PR DESCRIPTION
[This was added to reduce the number of file descriptors used](https://github.com/realm/realm-core/pull/1986/commits/dca07db60e6ee1691ec79c80ccc9f415d8e17b82) back when we opened a separate SharedGroup on each thread. We now normally only ever open one DB per file per process at a time, so sharing files between them is no longer useful and it's been the source of a few bugs.

Fixes https://github.com/realm/realm-swift/issues/8507 by just removing the code containing the assertion entirely.