### PR TITLE
RCORE-2001 Make Scheduler's factory function a function pointer rather than a UniqueFunction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,10 @@
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Fix a spurious crash related to opening a Realm on background thread while the process was in the middle of exiting ([#7420](https://github.com/realm/realm-core/issues/7420jj))
 
 ### Breaking changes
-* None.
+* Remove `realm_scheduler_set_default_factory()` and `realm_scheduler_has_default_factory()`, and change the `Scheduler` factory function to a bare function pointer rather than a `UniqueFunction` so that it does not have a non-trivial destructor.
 
 ### Compatibility
 * Fileformat: Generates files with format v24. Reads and automatically upgrade from fileformat v10. If you want to upgrade from an earlier file format version you will have to use RealmCore v13.x.y or earlier.

--- a/src/realm.h
+++ b/src/realm.h
@@ -954,33 +954,6 @@ RLM_API realm_scheduler_t* realm_scheduler_make_default(void);
 RLM_API const realm_scheduler_t* realm_scheduler_get_frozen(void);
 
 /**
- * Returns true if there is a default scheduler implementation for the current
- * platform, or one has been set with `realm_scheduler_set_default_factory()`.
- *
- * If there is no default factory, and no scheduler is provided in the config,
- * `realm_open()` will fail. Note that `realm_scheduler_get_frozen()` always
- * returns a valid scheduler.
- *
- * This function is thread-safe, and cannot fail.
- */
-RLM_API bool realm_scheduler_has_default_factory(void);
-
-/**
- * For platforms with no default scheduler implementation, register a factory
- * function which can produce custom schedulers. If there is a platform-specific
- * scheduler, this function will fail. If a custom scheduler is desired for
- * platforms that already have a default scheduler implementation, the caller
- * must call `realm_open()` with a config that indicates the desired scheduler.
- *
- * The provided callback may produce a scheduler by calling
- * `realm_scheduler_new()`.
- *
- * This function is thread-safe, but should generally only be called once.
- */
-RLM_API bool realm_scheduler_set_default_factory(realm_userdata_t userdata, realm_free_userdata_func_t userdata_free,
-                                                 realm_scheduler_default_factory_func_t);
-
-/**
  * Open a Realm file.
  *
  * @param config Realm configuration. If the Realm is already opened on another

--- a/src/realm/object-store/util/scheduler.cpp
+++ b/src/realm/object-store/util/scheduler.cpp
@@ -41,7 +41,7 @@
 namespace realm::util {
 namespace {
 
-util::UniqueFunction<std::shared_ptr<Scheduler>()> s_factory = &Scheduler::make_platform_default;
+std::shared_ptr<Scheduler> (*s_factory)() = Scheduler::make_platform_default;
 
 class FrozenScheduler : public util::Scheduler {
 public:
@@ -108,7 +108,7 @@ void InvocationQueue::invoke_all()
 
 Scheduler::~Scheduler() = default;
 
-void Scheduler::set_default_factory(util::UniqueFunction<std::shared_ptr<Scheduler>()> factory)
+void Scheduler::set_default_factory(std::shared_ptr<Scheduler> (*factory)())
 {
     s_factory = std::move(factory);
 }

--- a/src/realm/object-store/util/scheduler.hpp
+++ b/src/realm/object-store/util/scheduler.hpp
@@ -125,8 +125,9 @@ public:
 #endif
 
     /// Register a factory function which can produce custom schedulers when
-    /// `Scheduler::make_default()` is called.
-    static void set_default_factory(util::UniqueFunction<std::shared_ptr<Scheduler>()>);
+    /// `Scheduler::make_default()` is called. This function is not thread-safe
+    /// and must be called before any schedulers are created.
+    static void set_default_factory(std::shared_ptr<Scheduler> (*factory)());
 };
 
 // A thread-safe queue of functions to invoke, used in the implemenation of
@@ -140,7 +141,6 @@ private:
     std::mutex m_mutex;
     std::vector<util::UniqueFunction<void()>> m_functions;
 };
-
 
 } // namespace realm::util
 

--- a/test/object-store/benchmarks/main.cpp
+++ b/test/object-store/benchmarks/main.cpp
@@ -51,7 +51,7 @@ int main(int argc, char** argv)
 #endif
 
 #if TEST_SCHEDULER_UV
-    realm::util::Scheduler::set_default_factory([]() {
+    realm::util::Scheduler::set_default_factory([]() -> std::shared_ptr<realm::util::Scheduler> {
         return std::make_shared<realm::util::UvMainLoopScheduler>();
     });
 #endif

--- a/test/object-store/test_runner.cpp
+++ b/test/object-store/test_runner.cpp
@@ -86,7 +86,7 @@ int run_object_store_tests(int argc, const char** argv)
 #endif
 
 #if TEST_SCHEDULER_UV
-    realm::util::Scheduler::set_default_factory([]() {
+    realm::util::Scheduler::set_default_factory([]() -> std::shared_ptr<realm::util::Scheduler> {
         return std::make_shared<realm::util::UvMainLoopScheduler>();
     });
 #endif


### PR DESCRIPTION
This makes it trivially destructible and so eliminates a spurious crash related to reading the variable on one thread while it's being destroyed on another (due to the application exiting). This breaks the C API for registering a custom default scheduler, but that turns out to be unused and so it can be deleted. All users of the C++ scheduler API work with just a function pointer.

Fixes #7420 assuming that issue actually is just a spurious crash and not some other bug. An alternative solution here would be to heap allocate the UniqueFunction as we do for many globals, but cutting down on our global constructors/destructors is a good thing and we currently don't have anything which needs it to be a UniqueFunction.