### PR TITLE
RCORE-1982 Opening realm with cached user while offline results in fatal error and session does not retry connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,7 @@
 * None.
 
 ### Fixed
-* <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Fix Opening realm with cached user while offline results in fatal error and session does not retry connection. ([#7349](https://github.com/realm/realm-core/issues/7349), since v13.26.0)
 
 ### Breaking changes
 * None.
@@ -34,7 +33,6 @@
 * Fix a spurious crash related to opening a Realm on background thread while the process was in the middle of exiting ([#7420](https://github.com/realm/realm-core/issues/7420jj))
 * Fix a data race in change notification delivery when running at debug log level ([PR #7402](https://github.com/realm/realm-core/pull/7402), since v14.0.0).
 * Fix a 10-15% performance regression when reading data from the Realm resulting from Obj being made a non-trivial type ([PR #7402](https://github.com/realm/realm-core/pull/7402), since v14.0.0).
-* Fix Opening realm with cached user while offline results in fatal error and session does not retry connection. ([#7349](https://github.com/realm/realm-core/issues/7349), since v13.26.0)
 
 ### Breaking changes
 * Remove `realm_scheduler_set_default_factory()` and `realm_scheduler_has_default_factory()`, and change the `Scheduler` factory function to a bare function pointer rather than a `UniqueFunction` so that it does not have a non-trivial destructor.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Modifying nested collections left the accessor used to make the modification in a stale state, resulting in some unneccesary work being done when making multiple modifications via one accessor ([PR #7470](https://github.com/realm/realm-core/pull/7470), since v14.0.0).
 * Fix depth level for nested collection in debug mode, set it to the same level as release ([#7484](https://github.com/realm/realm-core/issues/7484), since v14.0.0).
-* Fix Opening realm with cached user while offline results in fatal error and session does not retry connection. ([#7349](https://github.com/realm/realm-core/issues/7349), since v13.26.0)
+* Fix opening realm with cached user while offline results in fatal error and session does not retry connection. ([#7349](https://github.com/realm/realm-core/issues/7349), since v13.26.0)
 
 ### Breaking changes
 * Update C-API log callback signature to include the log category, and `realm_set_log_callback` to not take a `realm_log_level_e`. ([PR #7494](https://github.com/realm/realm-core/pull/7494)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Fix a spurious crash related to opening a Realm on background thread while the process was in the middle of exiting ([#7420](https://github.com/realm/realm-core/issues/7420jj))
 * Fix a data race in change notification delivery when running at debug log level ([PR #7402](https://github.com/realm/realm-core/pull/7402), since v14.0.0).
 * Fix a 10-15% performance regression when reading data from the Realm resulting from Obj being made a non-trivial type ([PR #7402](https://github.com/realm/realm-core/pull/7402), since v14.0.0).
+* Fix Opening realm with cached user while offline results in fatal error and session does not retry connection. ([#7349](https://github.com/realm/realm-core/issues/7349), since v13.26.0)
 
 ### Breaking changes
 * Remove `realm_scheduler_set_default_factory()` and `realm_scheduler_has_default_factory()`, and change the `Scheduler` factory function to a bare function pointer rather than a `UniqueFunction` so that it does not have a non-trivial destructor.

--- a/src/realm.h
+++ b/src/realm.h
@@ -88,6 +88,9 @@ typedef bool (*realm_migration_func_t)(realm_userdata_t userdata, realm_t* old_r
 typedef bool (*realm_data_initialization_func_t)(realm_userdata_t userdata, realm_t* realm);
 typedef bool (*realm_should_compact_on_launch_func_t)(realm_userdata_t userdata, uint64_t total_bytes,
                                                       uint64_t used_bytes);
+
+RLM_API const char* RLM_DEFAULT_BASE_URL;
+
 typedef enum realm_schema_mode {
     RLM_SCHEMA_MODE_AUTOMATIC,
     RLM_SCHEMA_MODE_IMMUTABLE,

--- a/src/realm.h
+++ b/src/realm.h
@@ -89,8 +89,6 @@ typedef bool (*realm_data_initialization_func_t)(realm_userdata_t userdata, real
 typedef bool (*realm_should_compact_on_launch_func_t)(realm_userdata_t userdata, uint64_t total_bytes,
                                                       uint64_t used_bytes);
 
-RLM_API const char* RLM_DEFAULT_BASE_URL;
-
 typedef enum realm_schema_mode {
     RLM_SCHEMA_MODE_AUTOMATIC,
     RLM_SCHEMA_MODE_IMMUTABLE,
@@ -2979,6 +2977,7 @@ RLM_API realm_auth_provider_e realm_auth_credentials_get_provider(realm_app_cred
 RLM_API realm_app_config_t* realm_app_config_new(const char* app_id,
                                                  const realm_http_transport_t* http_transport) RLM_API_NOEXCEPT;
 
+RLM_API const char* realm_app_get_default_base_url(void) RLM_API_NOEXCEPT;
 RLM_API void realm_app_config_set_base_url(realm_app_config_t*, const char*) RLM_API_NOEXCEPT;
 RLM_API void realm_app_config_set_default_request_timeout(realm_app_config_t*, uint64_t ms) RLM_API_NOEXCEPT;
 RLM_API void realm_app_config_set_platform_version(realm_app_config_t*, const char*) RLM_API_NOEXCEPT;

--- a/src/realm/object-store/c_api/app.cpp
+++ b/src/realm/object-store/c_api/app.cpp
@@ -125,7 +125,10 @@ static inline bson::BsonArray parse_ejson_array(const char* serialized)
     }
 }
 
-const char* RLM_DEFAULT_BASE_URL = App::default_base_url.data();
+RLM_API const char* realm_app_get_default_base_url(void) noexcept
+{
+    return app::App::default_base_url.data();
+}
 
 RLM_API realm_app_credentials_t* realm_app_credentials_new_anonymous(bool reuse_credentials) noexcept
 {

--- a/src/realm/object-store/c_api/app.cpp
+++ b/src/realm/object-store/c_api/app.cpp
@@ -125,7 +125,7 @@ static inline bson::BsonArray parse_ejson_array(const char* serialized)
     }
 }
 
-RLM_API const char* RLM_DEFAULT_BASE_URL = App::default_base_url.data();
+const char* RLM_DEFAULT_BASE_URL = App::default_base_url.data();
 
 RLM_API realm_app_credentials_t* realm_app_credentials_new_anonymous(bool reuse_credentials) noexcept
 {

--- a/src/realm/object-store/c_api/app.cpp
+++ b/src/realm/object-store/c_api/app.cpp
@@ -125,6 +125,8 @@ static inline bson::BsonArray parse_ejson_array(const char* serialized)
     }
 }
 
+RLM_API const char* RLM_DEFAULT_BASE_URL = App::default_base_url.data();
+
 RLM_API realm_app_credentials_t* realm_app_credentials_new_anonymous(bool reuse_credentials) noexcept
 {
     return new realm_app_credentials_t(AppCredentials::anonymous(reuse_credentials));

--- a/src/realm/object-store/sync/app.cpp
+++ b/src/realm/object-store/sync/app.cpp
@@ -412,8 +412,8 @@ void App::configure_route(const std::string& host_url, const std::optional<std::
 // All others => http[s]://<host-url> => ws[s]://<host-url>
 std::string App::create_ws_host_url(const std::string_view host_url)
 {
-    constexpr static std::string_view s_orig_base_domain = "realm.mongodb.com";
-    constexpr static std::string_view s_new_base_domain = "services.cloud.mongodb.com";
+    constexpr static std::string_view orig_base_domain = "realm.mongodb.com";
+    constexpr static std::string_view new_base_domain = "services.cloud.mongodb.com";
 
     // Doesn't start with http, just return provided string
     if (host_url.substr(0, 4) != "http") {
@@ -425,11 +425,11 @@ std::string App::create_ws_host_url(const std::string_view host_url)
     std::string_view prefix = https ? "wss://" : "ws://";
 
     // http[s]://[region-prefix]realm.mongodb.com => ws[s]://ws.[region-prefix]realm.mongodb.com
-    if (host_url.find(s_orig_base_domain) != std::string_view::npos) {
+    if (host_url.find(orig_base_domain) != std::string_view::npos) {
         return util::format("%1ws.%2", prefix, host_url.substr(prefix_len));
     }
     // http[s]://[region-prefix]services.cloud.mongodb.com => ws[s]://[region-prefix].ws.services.cloud.mongodb.com
-    if (auto start = host_url.find(s_new_base_domain); start != std::string_view::npos) {
+    if (auto start = host_url.find(new_base_domain); start != std::string_view::npos) {
         return util::format("%1%2ws.%3", prefix, host_url.substr(prefix_len, start - prefix_len),
                             host_url.substr(start));
     }

--- a/src/realm/object-store/sync/app.cpp
+++ b/src/realm/object-store/sync/app.cpp
@@ -410,7 +410,7 @@ void App::configure_route(const std::string& host_url, const std::optional<std::
 // http[s]://[region-prefix]realm.mongodb.com => ws[s]://ws.[region-prefix]realm.mongodb.com
 // http[s]://[region-prefix]services.cloud.mongodb.com => ws[s]://[region-prefix].ws.services.cloud.mongodb.com
 // All others => http[s]://<host-url> => ws[s]://<host-url>
-std::string App::create_ws_host_url(const std::string_view& host_url)
+std::string App::create_ws_host_url(const std::string_view host_url)
 {
     constexpr static std::string_view s_orig_base_domain = "realm.mongodb.com";
     constexpr static std::string_view s_new_base_domain = "services.cloud.mongodb.com";

--- a/src/realm/object-store/sync/app.cpp
+++ b/src/realm/object-store/sync/app.cpp
@@ -183,6 +183,8 @@ std::mutex s_apps_mutex;
 namespace realm {
 namespace app {
 
+std::string_view App::default_base_url = "https://realm.mongodb.com";
+
 App::Config::DeviceInfo::DeviceInfo()
     : platform(util::get_library_platform())
     , cpu_arch(util::get_library_cpu_arch())

--- a/src/realm/object-store/sync/app.cpp
+++ b/src/realm/object-store/sync/app.cpp
@@ -424,17 +424,19 @@ std::string App::create_ws_host_url(const std::string_view host_url)
     size_t prefix_len = std::char_traits<char>::length("http://") + (https ? 1 : 0);
     std::string_view prefix = https ? "wss://" : "ws://";
 
-    // http[s]://[region-prefix]realm.mongodb.com => ws[s]://ws.[region-prefix]realm.mongodb.com
+    // http[s]://[<region-prefix>]realm.mongodb.com[/<path>] =>
+    //     ws[s]://ws.[<region-prefix>]realm.mongodb.com[/<path>]
     if (host_url.find(orig_base_domain) != std::string_view::npos) {
         return util::format("%1ws.%2", prefix, host_url.substr(prefix_len));
     }
-    // http[s]://[region-prefix]services.cloud.mongodb.com => ws[s]://[region-prefix].ws.services.cloud.mongodb.com
+    // http[s]://[<region-prefix>]services.cloud.mongodb.com[/<path>] =>
+    //     ws[s]://[<region-prefix>].ws.services.cloud.mongodb.com[/<path>]
     if (auto start = host_url.find(new_base_domain); start != std::string_view::npos) {
         return util::format("%1%2ws.%3", prefix, host_url.substr(prefix_len, start - prefix_len),
                             host_url.substr(start));
     }
 
-    // All others => http[s]://<host-url> => ws[s]://<host-url>
+    // All others => http[s]://<host-url>[/<path>] => ws[s]://<host-url>[/<path>]
     return util::format("ws%1", host_url.substr(4));
 }
 

--- a/src/realm/object-store/sync/app.cpp
+++ b/src/realm/object-store/sync/app.cpp
@@ -414,14 +414,16 @@ std::string App::create_ws_host_url(const std::string_view host_url)
 {
     constexpr static std::string_view orig_base_domain = "realm.mongodb.com";
     constexpr static std::string_view new_base_domain = "services.cloud.mongodb.com";
+    const size_t base_len = std::char_traits<char>::length("http://");
 
-    // Doesn't start with http, just return provided string
-    if (host_url.substr(0, 4) != "http") {
+    // Doesn't contain 7 or more characters (length of 'http://') or start with http,
+    // just return provided string
+    if (host_url.length() < base_len || host_url.substr(0, 4) != "http") {
         return std::string(host_url);
     }
-    // If it starts with 'https' then ws url will start with wss
+    // If it starts with 'https' then ws url will start with 'wss'
     bool https = host_url[4] == 's';
-    size_t prefix_len = std::char_traits<char>::length("http://") + (https ? 1 : 0);
+    size_t prefix_len = base_len + (https ? 1 : 0);
     std::string_view prefix = https ? "wss://" : "ws://";
 
     // http[s]://[<region-prefix>]realm.mongodb.com[/<path>] =>

--- a/src/realm/object-store/sync/app.hpp
+++ b/src/realm/object-store/sync/app.hpp
@@ -434,7 +434,7 @@ public:
     // Return the base url path used for Sync Session Websocket requests
     std::string get_ws_host_url() REQUIRES(!m_route_mutex);
 
-    static std::string create_ws_host_url(const std::string_view& host_url);
+    static std::string create_ws_host_url(const std::string_view host_url);
 
 private:
     const Config m_config;

--- a/src/realm/object-store/sync/app.hpp
+++ b/src/realm/object-store/sync/app.hpp
@@ -90,7 +90,7 @@ public:
         DeviceInfo device_info;
     };
 
-    constexpr static std::string_view default_base_url = "https://realm.mongodb.com";
+    static std::string_view default_base_url;
 
     // `enable_shared_from_this` is unsafe with public constructors;
     // use `App::get_app()` instead

--- a/src/realm/object-store/sync/app.hpp
+++ b/src/realm/object-store/sync/app.hpp
@@ -90,6 +90,8 @@ public:
         DeviceInfo device_info;
     };
 
+    constexpr static std::string_view default_base_url = "https://realm.mongodb.com";
+
     // `enable_shared_from_this` is unsafe with public constructors;
     // use `App::get_app()` instead
     explicit App(Private, const Config& config);
@@ -431,6 +433,8 @@ public:
 
     // Return the base url path used for Sync Session Websocket requests
     std::string get_ws_host_url() REQUIRES(!m_route_mutex);
+
+    static std::string create_ws_host_url(const std::string_view& host_url);
 
 private:
     const Config m_config;

--- a/src/realm/object-store/sync/sync_manager.cpp
+++ b/src/realm/object-store/sync/sync_manager.cpp
@@ -43,13 +43,13 @@ SyncClientTimeouts::SyncClientTimeouts()
 {
 }
 
-std::shared_ptr<SyncManager> SyncManager::create(std::shared_ptr<app::App> app, std::optional<std::string> sync_route,
+std::shared_ptr<SyncManager> SyncManager::create(std::shared_ptr<app::App> app, std::string sync_route,
                                                  const SyncClientConfig& config, const std::string& app_id)
 {
-    return std::make_shared<SyncManager>(Private(), std::move(app), std::move(sync_route), config, app_id);
+    return std::make_shared<SyncManager>(Private(), std::move(app), sync_route, config, app_id);
 }
 
-SyncManager::SyncManager(Private, std::shared_ptr<app::App> app, std::optional<std::string> sync_route,
+SyncManager::SyncManager(Private, std::shared_ptr<app::App> app, std::string sync_route,
                          const SyncClientConfig& config, const std::string& app_id)
     : m_config(config)
     , m_file_manager(std::make_unique<SyncFileManager>(m_config.base_file_path, app_id))
@@ -150,7 +150,6 @@ void SyncManager::tear_down_for_testing()
         // Destroy the client now that we have no remaining sessions.
         m_sync_client = nullptr;
         m_logger_ptr.reset();
-        m_sync_route.reset();
     }
 
     {

--- a/src/realm/object-store/sync/sync_manager.cpp
+++ b/src/realm/object-store/sync/sync_manager.cpp
@@ -679,17 +679,8 @@ void SyncManager::set_sync_route(std::string sync_route, bool verified, RestartS
         return;
     }
 
-    std::vector<std::shared_ptr<SyncSession>> sessions;
-    {
-        util::CheckedLockGuard lk(m_session_mutex);
-        // Make a copy of the session ptrs
-        sessions.reserve(m_sessions.size());
-        for (auto& session : m_sessions) {
-            sessions.push_back(session.second);
-        }
-    }
-
     // Restart the sessions that are currently active
+    auto sessions = get_all_sessions();
     for (auto& session : sessions) {
         session->restart_session();
     }

--- a/src/realm/object-store/sync/sync_manager.cpp
+++ b/src/realm/object-store/sync/sync_manager.cpp
@@ -665,7 +665,7 @@ void SyncManager::close_all_sessions()
     get_sync_client().wait_for_session_terminations();
 }
 
-void SyncManager::set_sync_route(std::string sync_route, bool verified, RestartSessions restart_sessions)
+void SyncManager::set_sync_route(std::string sync_route, bool verified)
 {
     REALM_ASSERT(!sync_route.empty()); // Cannot be set to empty string
     {
@@ -673,12 +673,10 @@ void SyncManager::set_sync_route(std::string sync_route, bool verified, RestartS
         m_sync_route = sync_route;
         m_sync_route_verified = verified;
     }
+}
 
-    // Bail out early if not restarting the existing sessions
-    if (!restart_sessions) {
-        return;
-    }
-
+void SyncManager::restart_all_sessions()
+{
     // Restart the sessions that are currently active
     auto sessions = get_all_sessions();
     for (auto& session : sessions) {

--- a/src/realm/object-store/sync/sync_manager.cpp
+++ b/src/realm/object-store/sync/sync_manager.cpp
@@ -665,13 +665,18 @@ void SyncManager::close_all_sessions()
     get_sync_client().wait_for_session_terminations();
 }
 
-void SyncManager::set_sync_route(std::string sync_route, bool verified)
+void SyncManager::set_sync_route(std::string sync_route, bool verified, RestartSessions restart_sessions)
 {
     REALM_ASSERT(!sync_route.empty()); // Cannot be set to empty string
     {
         util::CheckedLockGuard lock(m_mutex);
         m_sync_route = sync_route;
         m_sync_route_verified = verified;
+    }
+
+    // Bail out early if not restarting the existing sessions
+    if (!restart_sessions) {
+        return;
     }
 
     std::vector<std::shared_ptr<SyncSession>> sessions;

--- a/src/realm/object-store/sync/sync_manager.hpp
+++ b/src/realm/object-store/sync/sync_manager.hpp
@@ -332,7 +332,7 @@ private:
     std::string m_sync_route GUARDED_BY(m_mutex);
     // If true, then the sync route has been verified by querying the location info or successfully
     // connecting to the server.
-    bool m_sync_route_verified GUARDED_BY(m_mutex);
+    bool m_sync_route_verified GUARDED_BY(m_mutex) = false;
 
     std::weak_ptr<app::App> m_app GUARDED_BY(m_mutex);
     const std::string m_app_id;

--- a/src/realm/object-store/sync/sync_manager.hpp
+++ b/src/realm/object-store/sync/sync_manager.hpp
@@ -222,13 +222,18 @@ public:
     // Immediately closes any open sync sessions for this sync manager
     void close_all_sessions() REQUIRES(!m_mutex, !m_session_mutex);
 
+    struct RestartSessionsTag {};
+
+    using RestartSessions = util::TaggedBool<RestartSessionsTag>;
     // Used by App to update the sync route any time the location info has been refreshed.
     // m_sync_route starts out as a generated value based on the configured base_url when
     // the SyncManager is created by App. If this is incorrect, the websocket connection
     // will fail, resulting in an update to the access token (and the location, if it hasn't
     // been updated yet). If the sync route is being manually set without being validated,
     // then set validated to false.
-    void set_sync_route(std::string sync_route, bool verified = true) REQUIRES(!m_mutex, !m_session_mutex);
+    void set_sync_route(std::string sync_route, bool verified = true,
+                        RestartSessions restart_sessions = RestartSessions{true})
+        REQUIRES(!m_mutex, !m_session_mutex);
 
     std::pair<const std::string, bool> sync_route() REQUIRES(!m_mutex)
     {

--- a/src/realm/object-store/sync/sync_manager.hpp
+++ b/src/realm/object-store/sync/sync_manager.hpp
@@ -225,18 +225,15 @@ public:
     // Immediately closes any open sync sessions for this sync manager
     void close_all_sessions() REQUIRES(!m_mutex, !m_session_mutex);
 
-    struct RestartSessionsTag {};
+    // Force all the active sessions to restart
+    void restart_all_sessions() REQUIRES(!m_mutex, !m_session_mutex);
 
-    using RestartSessions = util::TaggedBool<RestartSessionsTag>;
     // Used by App to update the sync route any time the location info has been refreshed.
     // m_sync_route starts out as a generated value based on the configured base_url when
     // the SyncManager is created by App. If this is incorrect, the websocket connection
     // will fail, resulting in an update to the access token (and the location, if it hasn't
-    // been updated yet). If the sync route is being manually set without being validated,
-    // then set validated to false.
-    void set_sync_route(std::string sync_route, bool verified = true,
-                        RestartSessions restart_sessions = RestartSessions{true})
-        REQUIRES(!m_mutex, !m_session_mutex);
+    // been updated yet).
+    void set_sync_route(std::string sync_route, bool verified = true) REQUIRES(!m_mutex);
 
     std::pair<const std::string, bool> sync_route() REQUIRES(!m_mutex)
     {

--- a/src/realm/object-store/sync/sync_manager.hpp
+++ b/src/realm/object-store/sync/sync_manager.hpp
@@ -223,19 +223,18 @@ public:
     void close_all_sessions() REQUIRES(!m_mutex, !m_session_mutex);
 
     // Used by App to update the sync route any time the location info has been refreshed.
-    // m_sync_route starts out as unset when the SyncManager is created or configured.
-    // It will be updated to a valid value upon the first App AppServices HTTP request or
-    // the access token will be refreshed (forcing a location update) when a SyncSession
-    // is activated and it is still unset. This value is not allowed to be reset to
-    // nullopt once it has a valid value.
-    void set_sync_route(std::string sync_route) REQUIRES(!m_mutex)
+    // m_sync_route starts out as a generated value based on the configured base_url when
+    // the SyncManager is created by App. If this is incorrect, the websocket connection
+    // will fail, resulting in an update to the access token (and the location, if it hasn't
+    // been updated yet).
+    void set_sync_route(std::string sync_route) REQUIRES(!m_mutex, !m_session_mutex)
     {
-        REALM_ASSERT(!sync_route.empty());
+        REALM_ASSERT(!sync_route.empty()); // Cannot be set to empty string
         util::CheckedLockGuard lock(m_mutex);
-        m_sync_route = std::move(sync_route);
+        m_sync_route = sync_route;
     }
 
-    const std::optional<std::string> sync_route() const REQUIRES(!m_mutex)
+    const std::string sync_route() const REQUIRES(!m_mutex)
     {
         util::CheckedLockGuard lock(m_mutex);
         return m_sync_route;
@@ -267,10 +266,10 @@ public:
         static void voluntary_disconnect_all_connections(SyncManager&);
     };
 
-    static std::shared_ptr<SyncManager> create(std::shared_ptr<app::App> app, std::optional<std::string> sync_route,
+    static std::shared_ptr<SyncManager> create(std::shared_ptr<app::App> app, std::string sync_route,
                                                const SyncClientConfig& config, const std::string& app_id);
-    SyncManager(Private, std::shared_ptr<app::App> app, std::optional<std::string> sync_route,
-                const SyncClientConfig& config, const std::string& app_id);
+    SyncManager(Private, std::shared_ptr<app::App> app, std::string sync_route, const SyncClientConfig& config,
+                const std::string& app_id);
 
 private:
     friend class app::App;
@@ -330,7 +329,7 @@ private:
 
     // The sync route URL to connect to the server. This can be initially empty, but should not
     // be cleared once it has been set to a value, except by `tear_down_for_testing()`.
-    std::optional<std::string> m_sync_route GUARDED_BY(m_mutex);
+    std::string m_sync_route GUARDED_BY(m_mutex);
 
     std::weak_ptr<app::App> m_app GUARDED_BY(m_mutex);
     const std::string m_app_id;

--- a/src/realm/object-store/sync/sync_session.hpp
+++ b/src/realm/object-store/sync/sync_session.hpp
@@ -263,7 +263,7 @@ public:
 
     // If the `SyncSession` has been configured, the full remote URL of the Realm
     // this `SyncSession` represents.
-    util::Optional<std::string> full_realm_url() const REQUIRES(!m_config_mutex)
+    std::string full_realm_url() const REQUIRES(!m_config_mutex)
     {
         util::CheckedLockGuard lock(m_config_mutex);
         return m_server_url;
@@ -427,7 +427,7 @@ private:
         REQUIRES(m_state_mutex);
 
     std::string get_appservices_connection_id() const REQUIRES(!m_state_mutex);
-    std::optional<std::string> get_sync_route() const REQUIRES(!m_state_mutex);
+    std::string get_sync_route() const REQUIRES(!m_state_mutex);
 
     util::Future<std::string> send_test_command(std::string body) REQUIRES(!m_state_mutex);
 
@@ -486,7 +486,7 @@ private:
     std::unique_ptr<sync::Session> m_session GUARDED_BY(m_state_mutex);
 
     // The fully-resolved URL of this Realm, including the server and the path.
-    util::Optional<std::string> m_server_url GUARDED_BY(m_config_mutex);
+    std::string m_server_url GUARDED_BY(m_config_mutex);
 
     _impl::SyncProgressNotifier m_progress_notifier;
     ConnectionChangeNotifier m_connection_change_notifier;

--- a/src/realm/object-store/sync/sync_session.hpp
+++ b/src/realm/object-store/sync/sync_session.hpp
@@ -261,14 +261,29 @@ public:
         return *m_config.sync_config;
     }
 
-    // If the `SyncSession` has been configured, the full remote URL of the Realm
-    // this `SyncSession` represents.
+    // When App is created, it will provide a generated websocket sync route when the SyncManager is
+    // created. When the next AppServices HTTP request is made via the App object, the location info
+    // will be requested and a verified websocket sync route will be provided to the SyncManager. If
+    // the SyncSession is started with a cached user, the websocket connection will be initially
+    // established using the generated sync route. If that connection is successful, then the sync
+    // route will be marked verified and used from that point on. If that connection fails, the
+    // SyncSession will update the location via an access token update to retrieve the verified
+    // sync route from the server's location info. The SyncSessio will then be restarted so it
+    // uses the updated sync route value.
+
+    // If the SyncSession is active, this function returns the sync route that is being used
+    // by the current underlying session to connect to the server.
     std::string full_realm_url() const REQUIRES(!m_config_mutex)
     {
         util::CheckedLockGuard lock(m_config_mutex);
         return m_server_url;
     }
 
+    // If the sync route value was returned by querying the location information, or the
+    // SyncSession has successfully connected to the server using the configured sync route,
+    // then the sync route will be marked "verified". Otherwise, the location information will
+    // be requested from the server if the connection fails when trying to open a websocket
+    // to the server.
     bool realm_url_verified() const REQUIRES(!m_config_mutex)
     {
         util::CheckedLockGuard lock(m_config_mutex);

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -147,6 +147,7 @@ private:
     const ProtocolEnvelope m_protocol_envelope;
     const std::string m_server_address;
     const port_type m_server_port;
+    const bool m_server_verified;
     const std::string m_user_id;
     const SyncServerMode m_sync_mode;
     const std::string m_authorization_header_name;
@@ -1150,6 +1151,7 @@ SessionWrapper::SessionWrapper(ClientImpl& client, DBRef db, std::shared_ptr<Sub
     , m_protocol_envelope{config.protocol_envelope}
     , m_server_address{std::move(config.server_address)}
     , m_server_port{config.server_port}
+    , m_server_verified{config.server_verified}
     , m_user_id(std::move(config.user_id))
     , m_sync_mode(flx_sub_store ? SyncServerMode::FLX : SyncServerMode::PBS)
     , m_authorization_header_name{config.authorization_header_name}
@@ -1309,7 +1311,8 @@ SessionWrapper::set_connection_state_change_listener(util::UniqueFunction<Connec
 
 void SessionWrapper::initiate()
 {
-    ServerEndpoint server_endpoint{m_protocol_envelope, m_server_address, m_server_port, m_user_id, m_sync_mode};
+    ServerEndpoint server_endpoint{m_protocol_envelope, m_server_address, m_server_port,
+                                   m_user_id,           m_sync_mode,      m_server_verified};
     m_client.register_unactualized_session_wrapper(this, std::move(server_endpoint)); // Throws
     m_db->add_commit_listener(this);
 }

--- a/src/realm/sync/client.hpp
+++ b/src/realm/sync/client.hpp
@@ -198,6 +198,11 @@ public:
         /// to file system paths, and thus, these restrictions do not apply.
         std::string realm_identifier = "";
 
+        // If the client has successfully contacted the server, then this will be
+        // set to true, otherwise it is false and the sync sessions will attempt
+        // to update the location info if the connection fails.
+        bool server_verified = false;
+
         /// The user id of the logged in user for this sync session. This will be used
         /// along with the server_address/server_port/protocol_envelope to determine
         /// which connection to the server this session will use.

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -584,18 +584,18 @@ bool Connection::websocket_closed_handler(bool was_clean, WebSocketError error_c
             break;
         }
         case WebSocketError::websocket_fatal_error: {
+            // Error is fatal if the sync_route has already been verified
+            SessionErrorInfo error_info(
+                {ErrorCodes::SyncConnectFailed, util::format("Failed to connect to sync: %1", msg)},
+                IsFatal{m_server_endpoint.is_verified});
+            ConnectionTerminationReason reason = ConnectionTerminationReason::http_response_says_fatal_error;
             // If the connection fails/times out and the server has not been contacted yet, refresh the location
             // to make sure the websocket URL is correct
             if (!m_server_endpoint.is_verified) {
-                SessionErrorInfo error_info(
-                    {ErrorCodes::SyncConnectFailed, util::format("Failed to connect to sync: %1", msg)},
-                    IsFatal{false});
                 error_info.server_requests_action = ProtocolErrorInfo::Action::RefreshLocation;
-                involuntary_disconnect(std::move(error_info), ConnectionTerminationReason::connect_operation_failed);
-                break;
+                reason = ConnectionTerminationReason::connect_operation_failed;
             }
-            involuntary_disconnect(SessionErrorInfo({ErrorCodes::ConnectionClosed, msg}, IsFatal{true}),
-                                   ConnectionTerminationReason::http_response_says_fatal_error);
+            involuntary_disconnect(std::move(error_info), reason);
             break;
         }
         case WebSocketError::websocket_forbidden: {

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -584,7 +584,8 @@ bool Connection::websocket_closed_handler(bool was_clean, WebSocketError error_c
             break;
         }
         case WebSocketError::websocket_fatal_error: {
-            // Error is fatal if the sync_route has already been verified
+            // Error is fatal if the sync_route has already been verified - if the sync_route has not
+            // been verified, then use a non-fatal error and try to perform a location update.
             SessionErrorInfo error_info(
                 {ErrorCodes::SyncConnectFailed, util::format("Failed to connect to sync: %1", msg)},
                 IsFatal{m_server_endpoint.is_verified});

--- a/src/realm/sync/noinst/client_impl_base.hpp
+++ b/src/realm/sync/noinst/client_impl_base.hpp
@@ -42,6 +42,7 @@ struct ServerEndpoint {
     network::Endpoint::port_type port;
     std::string user_id;
     SyncServerMode server_mode = SyncServerMode::PBS;
+    bool is_verified = false;
 
 private:
     auto to_tuple() const
@@ -691,7 +692,7 @@ private:
     OutputBuffer m_output_buffer;
 
     const connection_ident_type m_ident;
-    const ServerEndpoint m_server_endpoint;
+    ServerEndpoint m_server_endpoint;
     std::string m_appservices_coid;
 
     /// DEPRECATED - These will be removed in a future release

--- a/test/object-store/c_api/c_api.cpp
+++ b/test/object-store/c_api/c_api.cpp
@@ -561,6 +561,8 @@ TEST_CASE("C API (non-database)", "[c_api]") {
         CHECK(app_config->app_id == "app_id_123");
         CHECK(app_config->transport == transport);
 
+        CHECK(realm_app_get_default_base_url() == app::App::default_base_url);
+
         CHECK(!app_config->base_url);
         realm_app_config_set_base_url(app_config.get(), base_url.c_str());
         CHECK(app_config->base_url == base_url);

--- a/test/object-store/c_api/c_api.cpp
+++ b/test/object-store/c_api/c_api.cpp
@@ -540,7 +540,6 @@ TEST_CASE("C API (non-database)", "[c_api]") {
         const uint64_t request_timeout = 2500;
         std::string base_url = "https://path/to/app";
         std::string base_url2 = "https://some/other/path";
-        std::string default_base_url = "https://realm.mongodb.com";
         auto transport = std::make_shared<UnitTestTransport>(request_timeout);
         transport->set_expected_options({{"device",
                                           {{"appId", "app_id_123"},
@@ -621,14 +620,14 @@ TEST_CASE("C API (non-database)", "[c_api]") {
         auto token =
             realm_sync_user_on_state_change_register_callback(sync_user, user_state, nullptr, user_data_free);
 
-        auto check_base_url = [&](const std::string& expected) {
+        auto check_base_url = [&](const std::string_view expected) {
             CHECK(transport->get_location_called());
             auto app_base_url = realm_app_get_base_url(test_app.get());
             CHECK(app_base_url == expected);
             realm_free(app_base_url);
         };
 
-        auto update_and_check_base_url = [&](const char* new_base_url, const std::string& expected) {
+        auto update_and_check_base_url = [&](const char* new_base_url, const std::string_view expected) {
             transport->set_base_url(expected);
             realm_app_update_base_url(
                 test_app.get(), new_base_url,
@@ -650,13 +649,13 @@ TEST_CASE("C API (non-database)", "[c_api]") {
         check_base_url(base_url);
 
         // Reset to the default base url using nullptr
-        update_and_check_base_url(nullptr, default_base_url);
+        update_and_check_base_url(nullptr, app::App::default_base_url);
 
         // Set to some other base url
         update_and_check_base_url(base_url2.c_str(), base_url2);
 
         // Reset to default base url using empty string
-        update_and_check_base_url("", default_base_url);
+        update_and_check_base_url("", app::App::default_base_url);
 
         realm_release(sync_user);
         realm_release(token);

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -3143,8 +3143,10 @@ TEST_CASE("app: sync integration", "[sync][pbs][app][baas]") {
 
             // Verify session is using the updated server url from the redirect
             auto server_url = sync_session->full_realm_url();
-            logger->trace("FULL_REALM_URL: %1", server_url);
+            auto verified = sync_session->realm_url_verified();
+            logger->trace("FULL_REALM_URL: %1 (%2)", server_url, verified ? "verified" : "not verified");
             REQUIRE((server_url.find(redirect_host) != std::string::npos));
+            REQUIRE(verified);
         }
         SECTION("Websocket redirect logs out user") {
             auto sync_manager = test_session.sync_manager();

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -4225,7 +4225,7 @@ TEST_CASE("app: base_url", "[sync][app][base_url]") {
                 CHECK(verified);
             }
         }
-        // Recreate the app using the cached user and start a sync session, which will is set to fail on connect
+        // Recreate the app using the cached user and start a sync session, which is set to fail on connect
         SECTION("Sync Session fails on connect after updating location") {
             enum class TestState { start, session_started };
             TestingStateMachine<TestState> state(TestState::start);

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -3242,8 +3242,7 @@ TEST_CASE("app: sync integration", "[sync][pbs][app][baas]") {
         SyncTestFile r_config(user, partition, schema);
 
         std::vector<SharedRealm> realms;
-        int i;
-        for (i = 0; i < num_realms; i++) {
+        for (int i = 0; i < num_realms; i++) {
             SyncTestFile r_config(user, partition, schema);
             realms.push_back(Realm::get_shared_realm(r_config));
         }
@@ -4240,7 +4239,7 @@ TEST_CASE("app: base_url", "[sync][app][base_url]") {
             }
 
             socket_provider->endpoint_verify_func = [&use_ssl, &expected_host,
-                                                     &expected_port](sync::WebSocketEndpoint& ep) {
+                                                     &expected_port](const sync::WebSocketEndpoint& ep) {
                 CHECK(ep.address == expected_host);
                 CHECK(ep.port == expected_port);
                 CHECK(ep.is_ssl == use_ssl);
@@ -4289,7 +4288,7 @@ TEST_CASE("app: base_url", "[sync][app][base_url]") {
             }
 
             socket_provider->endpoint_verify_func = [&use_ssl, &initial_host,
-                                                     &initial_port](sync::WebSocketEndpoint& ep) {
+                                                     &initial_port](const sync::WebSocketEndpoint& ep) {
                 CHECK(ep.address == initial_host);
                 CHECK(ep.port == initial_port);
                 CHECK(ep.is_ssl == use_ssl);
@@ -4316,12 +4315,12 @@ TEST_CASE("app: base_url", "[sync][app][base_url]") {
                         // After number of location verify attempts has passed, let the location succeed
                         if (--retry_count <= 0) {
                             redir_transport->reset(init_url, redir_url);
-                            socket_provider->endpoint_verify_func = [&use_ssl, &expected_host,
-                                                                     &expected_port](sync::WebSocketEndpoint& ep) {
-                                CHECK(ep.address == expected_host);
-                                CHECK(ep.port == expected_port);
-                                CHECK(ep.is_ssl == use_ssl);
-                            };
+                            socket_provider->endpoint_verify_func =
+                                [&use_ssl, &expected_host, &expected_port](const sync::WebSocketEndpoint& ep) {
+                                    CHECK(ep.address == expected_host);
+                                    CHECK(ep.port == expected_port);
+                                    CHECK(ep.is_ssl == use_ssl);
+                                };
                             return TestState::location_failed;
                         }
                         redir_transport->location_requested = false;

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -4177,7 +4177,7 @@ TEST_CASE("app: base_url", "[sync][app][base_url]") {
         }
     }
 
-    // Verify new sync session updates location after app created with cached user
+    // Verify new sync session updates location when created with cached user
     SECTION("Verify new sync session updates location") {
         bool use_ssl = GENERATE(true, false);
         std::string initial_host = "alternate.someurl.fake";
@@ -4364,88 +4364,6 @@ TEST_CASE("app: base_url", "[sync][app][base_url]") {
                 CHECK(verified);
             }
         }
-#if 0
-        // Recreate the app using the cached user and start a sync session, which will fail during location update
-        SECTION("Location update fails prior to sync session connect") {
-            enum class TestState { start, location_failed, waiting_for_session, session_started };
-            TestingStateMachine<TestState> state(TestState::start);
-
-            redir_transport->reset(init_url, redir_url);
-            redir_transport->location_returns_error = true;
-
-            socket_provider->force_failure_func = [](bool& was_clean, sync::websocket::WebSocketError& error_code,
-                                                    std::string& message) {
-                was_clean = false;
-                error_code = sync::websocket::WebSocketError::websocket_connection_failed;
-                message = "404 not found";
-                return true;
-            };
-
-            auto app = app::App::get_app(app::App::CacheMode::Disabled, app_config, sc_config);
-            // Verify the default sync route, which has not been verified
-            {
-                auto [sync_route, verified] = app->sync_manager()->sync_route();
-                CHECK(sync_route.find(app::App::create_ws_host_url(init_url)) != std::string::npos);
-                CHECK_FALSE(verified);
-            }
-
-            RealmConfig r_config;
-            r_config.path = sc_config.base_file_path + "/fakerealm.realm";
-            r_config.sync_config = std::make_shared<SyncConfig>(app->current_user(), SyncConfig::FLXSyncEnabled{});
-            r_config.sync_config->error_handler = [&state, &logger](std::shared_ptr<SyncSession>,
-                                                                    SyncError error) mutable {
-                // Expect an error due to location failed or 404 response when creating websocket
-                state.transition_with([&error, &logger](TestState cur_state) -> std::optional<TestState> {
-                    if (cur_state == TestState::start || cur_state == TestState::waiting_for_session) {
-                        logger->debug("Expected error: %1: %2", error.status.code_string(), error.status.reason());
-                        CHECK(!error.status.is_ok());
-                        CHECK(error.status.code() == ErrorCodes::SyncConnectFailed);
-                    }
-                    if (cur_state == TestState::start) {
-                        // The first time through, the location update fails
-                        return TestState::location_failed;
-                    }
-                    else if (cur_state == TestState::waiting_for_session) {
-                        // The second time through, the session start, but the connection is rejected on purpose
-                        return TestState::session_started;
-                    }
-                    return std::nullopt;
-                });
-            };
-            auto realm = Realm::get_shared_realm(r_config);
-            state.wait_for(TestState::location_failed);
-
-            CHECK(redir_transport->location_requested);
-            CHECK(app->get_base_url() == init_url);
-            // Location was never updated
-            CHECK(app->get_host_url() == init_url);
-            CHECK(app->get_ws_host_url() == init_wsurl);
-            {
-                auto [sync_route, verified] = app->sync_manager()->sync_route();
-                CHECK(sync_route.find(app::App::create_ws_host_url(init_url)) != std::string::npos);
-                CHECK_FALSE(verified);
-            }
-
-            // Location request will pass this time, try to reconnect
-            // expecting 404 when websocket connects
-            redir_transport->reset(init_url, redir_url);
-            state.transition_to(TestState::waiting_for_session);
-            auto session = app->sync_manager()->get_existing_session(r_config.path);
-            CHECK(session);
-            session->resume();
-            state.wait_for(TestState::session_started);
-
-            CHECK(redir_transport->location_requested);
-            CHECK(app->get_base_url() == init_url);
-            CHECK(app->get_host_url() == redir_url);
-            CHECK(app->get_ws_host_url() == redir_wsurl);
-            {
-                auto [sync_route, verified] = app->sync_manager()->sync_route();
-                CHECK(sync_route.find(app::App::create_ws_host_url(redir_url)) != std::string::npos);
-                CHECK(verified);
-            }
-        }
-#endif
     }
 }
 

--- a/test/object-store/sync/flx_sync.cpp
+++ b/test/object-store/sync/flx_sync.cpp
@@ -2678,19 +2678,6 @@ TEST_CASE("flx: connect to PBS as FLX returns an error", "[sync][flx][protocol][
 }
 
 TEST_CASE("flx: commit subscription while refreshing the access token", "[sync][flx][token][baas]") {
-    class HookedTransport : public SynchronousTestTransport {
-    public:
-        void send_request_to_server(const Request& request,
-                                    util::UniqueFunction<void(const Response&)>&& completion) override
-        {
-            if (request_hook) {
-                request_hook(request);
-            }
-            SynchronousTestTransport::send_request_to_server(request, std::move(completion));
-        }
-        util::UniqueFunction<void(const Request&)> request_hook;
-    };
-
     auto transport = std::make_shared<HookedTransport>();
     FLXSyncTestHarness harness("flx_wait_access_token2", FLXSyncTestHarness::default_server_schema(), transport);
     auto app = harness.app();
@@ -2721,6 +2708,7 @@ TEST_CASE("flx: commit subscription while refreshing the access token", "[sync][
                 mut_subs.commit();
             }
         }
+        return std::nullopt;
     };
     SyncTestFile config(harness.app()->current_user(), harness.schema(), SyncConfig::FLXSyncEnabled{});
     // This triggers the token refresh.

--- a/test/object-store/util/sync/baas_admin_api.hpp
+++ b/test/object-store/util/sync/baas_admin_api.hpp
@@ -36,7 +36,6 @@
 #include <external/mpark/variant.hpp>
 
 namespace realm {
-app::Response do_http_request(const app::Request& request);
 
 class AdminAPIEndpoint {
 public:
@@ -259,30 +258,6 @@ struct AppSession {
     AppCreateConfig config;
 };
 AppSession create_app(const AppCreateConfig& config);
-
-class SynchronousTestTransport : public app::GenericNetworkTransport {
-public:
-    void send_request_to_server(const app::Request& request,
-                                util::UniqueFunction<void(const app::Response&)>&& completion) override
-    {
-        {
-            std::lock_guard barrier(m_mutex);
-        }
-        completion(do_http_request(request));
-    }
-
-    void block()
-    {
-        m_mutex.lock();
-    }
-    void unblock()
-    {
-        m_mutex.unlock();
-    }
-
-private:
-    std::mutex m_mutex;
-};
 
 // This will create a new test app in the baas server - base_url and admin_url
 // are automatically set

--- a/test/object-store/util/sync/sync_test_utils.cpp
+++ b/test/object-store/util/sync/sync_test_utils.cpp
@@ -260,12 +260,18 @@ AutoVerifiedEmailCredentials create_user_and_log_in(app::SharedApp app)
         creds.email, creds.password, [&](util::Optional<app::AppError> error) {
             REQUIRE(!error);
         });
-    app->log_in_with_credentials(realm::app::AppCredentials::username_password(creds.email, creds.password),
+    log_in_user(app, creds);
+    return creds;
+}
+
+void log_in_user(app::SharedApp app, app::AppCredentials creds)
+{
+    REQUIRE(app);
+    app->log_in_with_credentials(creds,
                                  [&](std::shared_ptr<realm::SyncUser> user, util::Optional<app::AppError> error) {
                                      REQUIRE(user);
                                      REQUIRE(!error);
                                  });
-    return creds;
 }
 
 void wait_for_advance(Realm& realm)

--- a/test/object-store/util/sync/sync_test_utils.hpp
+++ b/test/object-store/util/sync/sync_test_utils.hpp
@@ -257,14 +257,13 @@ struct HookedSocketProvider : public sync::websocket::DefaultSocketProvider {
     std::unique_ptr<sync::WebSocketInterface> connect(std::unique_ptr<sync::WebSocketObserver> observer,
                                                       sync::WebSocketEndpoint&& endpoint) override
     {
-        sync::WebSocketEndpoint ep{std::move(endpoint)};
         std::optional<SocketProviderError> error;
         if (endpoint_verify_func) {
-            endpoint_verify_func(ep);
+            endpoint_verify_func(endpoint);
         }
 
         if (websocket_endpoint_resolver) {
-            ep = websocket_endpoint_resolver(std::move(ep));
+            endpoint = websocket_endpoint_resolver(std::move(endpoint));
         }
 
         if (websocket_connect_func) {
@@ -278,7 +277,7 @@ struct HookedSocketProvider : public sync::websocket::DefaultSocketProvider {
         }
 
         std::unique_ptr<sync::WebSocketInterface> websocket =
-            DefaultSocketProvider::connect(std::move(observer), std::move(ep));
+            DefaultSocketProvider::connect(std::move(observer), std::move(endpoint));
         if (error && error->status_code > 0) {
             auto default_websocket = dynamic_cast<sync::websocket::DefaultWebSocket*>(websocket.get());
             if (default_websocket)
@@ -288,7 +287,7 @@ struct HookedSocketProvider : public sync::websocket::DefaultSocketProvider {
     }
 
     std::function<sync::WebSocketEndpoint(sync::WebSocketEndpoint&&)> websocket_endpoint_resolver;
-    std::function<void(sync::WebSocketEndpoint& endpoint)> endpoint_verify_func;
+    std::function<void(const sync::WebSocketEndpoint&)> endpoint_verify_func;
     std::function<std::optional<SocketProviderError>()> websocket_connect_func;
 };
 

--- a/test/object-store/util/test_file.cpp
+++ b/test/object-store/util/test_file.cpp
@@ -337,11 +337,10 @@ TestAppSession::TestAppSession(AppSession session,
 {
     if (!m_transport)
         m_transport = instance_of<SynchronousTestTransport>;
-    auto app_config = get_config(m_transport, *m_app_session);
+    app_config = get_config(m_transport, *m_app_session);
     set_app_config_defaults(app_config, m_transport);
 
     util::try_make_dir(m_base_file_path);
-    SyncClientConfig sc_config;
     sc_config.base_file_path = m_base_file_path;
     sc_config.metadata_mode = realm::SyncManager::MetadataMode::NoEncryption;
     sc_config.reconnect_mode = reconnect_mode;
@@ -355,23 +354,49 @@ TestAppSession::TestAppSession(AppSession session,
 
     // initialize sync client
     m_app->sync_manager()->get_sync_client();
-    create_user_and_log_in(m_app);
+    user_creds = create_user_and_log_in(m_app);
 }
 
 TestAppSession::~TestAppSession()
 {
-    if (util::File::exists(m_base_file_path)) {
-        try {
-            m_app->sync_manager()->tear_down_for_testing();
-            util::try_remove_dir_recursive(m_base_file_path);
-        }
-        catch (const std::exception& ex) {
-            std::cerr << ex.what() << "\n";
-        }
-        app::App::clear_cached_apps();
-    }
+    close(true);
     if (m_delete_app) {
         m_app_session->admin_api.delete_app(m_app_session->server_app_id);
+    }
+}
+
+void TestAppSession::close(bool remove_dir)
+{
+    try {
+        if (remove_dir && !m_base_file_path.empty() && util::File::exists(m_base_file_path)) {
+            util::try_remove_dir_recursive(m_base_file_path);
+            m_base_file_path.clear();
+        }
+
+        if (m_app) {
+            m_app->sync_manager()->tear_down_for_testing();
+            m_app.reset();
+        }
+    }
+    catch (const std::exception& ex) {
+        std::cerr << "Error tearing down TestAppSession: " << ex.what() << "\n";
+    }
+    // Ensure all cached apps are cleared
+    app::App::clear_cached_apps();
+}
+
+void TestAppSession::reopen(bool log_in)
+{
+    // These are REALM_ASSERTs so the test crashes if this object is in a bad state
+    REALM_ASSERT(!m_base_file_path.empty());
+    // Make sure the current app is closed
+    close(false);
+    m_app = app::App::get_app(app::App::CacheMode::Disabled, app_config, sc_config);
+
+    // initialize sync client
+    m_app->sync_manager()->get_sync_client();
+    if (log_in) {
+        log_in_user(m_app, user_creds);
     }
 }
 

--- a/test/object-store/util/test_file.cpp
+++ b/test/object-store/util/test_file.cpp
@@ -368,11 +368,6 @@ TestAppSession::~TestAppSession()
 void TestAppSession::close(bool tear_down)
 {
     try {
-        if (tear_down && !m_base_file_path.empty() && util::File::exists(m_base_file_path)) {
-            util::try_remove_dir_recursive(m_base_file_path);
-            m_base_file_path.clear();
-        }
-
         if (tear_down) {
             // If tearing down, make sure there's an app to work with
             if (!m_app) {
@@ -387,6 +382,12 @@ void TestAppSession::close(bool tear_down)
             m_app->sync_manager()->close_all_sessions();
         }
         m_app.reset();
+
+        // If tearing down, clean up the test file directory
+        if (tear_down && !m_base_file_path.empty() && util::File::exists(m_base_file_path)) {
+            util::try_remove_dir_recursive(m_base_file_path);
+            m_base_file_path.clear();
+        }
     }
     catch (const std::exception& ex) {
         std::cerr << "Error tearing down TestAppSession: " << ex.what() << "\n";

--- a/test/object-store/util/test_file.hpp
+++ b/test/object-store/util/test_file.hpp
@@ -270,6 +270,7 @@ public:
     }
     const std::shared_ptr<realm::SyncManager>& sync_manager() const
     {
+        REALM_ASSERT(m_app);
         return m_app->sync_manager();
     }
 
@@ -290,8 +291,8 @@ public:
                                                          size_t expected_count) const;
 
 private:
-    // Close the app and remove the base_file_path directory if remove_dir
-    void close(bool remove_dir);
+    // Close the app and, if tear_down, remove the app data and base_file_path directory
+    void close(bool tear_down);
 
     std::shared_ptr<realm::app::App> m_app;
     std::unique_ptr<realm::AppSession> m_app_session;

--- a/test/object-store/util/test_file.hpp
+++ b/test/object-store/util/test_file.hpp
@@ -273,15 +273,32 @@ public:
         return m_app->sync_manager();
     }
 
+    void close()
+    {
+        close(false);
+    }
+
+    // Re-open the app without deleting the dir contents - if close() has not been called
+    // the App will be closed first before recreating the object.
+    // If log_in is true, user will be logged in again once the App instance is created
+    void reopen(bool log_in);
+
+    realm::app::App::Config app_config;
+    realm::SyncClientConfig sc_config;
+
     std::vector<realm::bson::BsonDocument> get_documents(realm::SyncUser& user, const std::string& object_type,
                                                          size_t expected_count) const;
 
 private:
+    // Close the app and remove the base_file_path directory if remove_dir
+    void close(bool remove_dir);
+
     std::shared_ptr<realm::app::App> m_app;
     std::unique_ptr<realm::AppSession> m_app_session;
     std::string m_base_file_path;
     bool m_delete_app = true;
     std::shared_ptr<realm::app::GenericNetworkTransport> m_transport;
+    realm::app::AppCredentials user_creds;
 };
 #endif
 

--- a/test/object-store/util/test_utils.hpp
+++ b/test/object-store/util/test_utils.hpp
@@ -58,11 +58,14 @@ public:
     void transition_with(Func&& func)
     {
         {
-            std::lock_guard lock{m_mutex};
-            std::optional<E> new_state = func(m_cur_state);
+            std::unique_lock lock{m_mutex};
+            E cur_state = m_cur_state;
+            lock.unlock();
+            std::optional<E> new_state = func(cur_state);
             if (!new_state) {
                 return;
             }
+            lock.lock();
             m_cur_state = *new_state;
         }
         m_cv.notify_one();

--- a/test/object-store/util/test_utils.hpp
+++ b/test/object-store/util/test_utils.hpp
@@ -58,14 +58,11 @@ public:
     void transition_with(Func&& func)
     {
         {
-            std::unique_lock lock{m_mutex};
-            E cur_state = m_cur_state;
-            lock.unlock();
-            std::optional<E> new_state = func(cur_state);
+            std::lock_guard lock{m_mutex};
+            std::optional<E> new_state = func(m_cur_state);
             if (!new_state) {
                 return;
             }
-            lock.lock();
             m_cur_state = *new_state;
         }
         m_cv.notify_one();

--- a/test/object-store/util/unit_test_transport.hpp
+++ b/test/object-store/util/unit_test_transport.hpp
@@ -45,9 +45,9 @@ public:
     static const std::string identity_0_id;
     static const std::string identity_1_id;
 
-    void set_base_url(const std::string& base_url)
+    void set_base_url(const std::string_view base_url)
     {
-        m_base_url = base_url;
+        m_base_url = std::string(base_url);
         m_location_called = false;
     }
 


### PR DESCRIPTION
## What, How & Why?
Updated the sync_route provided to then `SyncManager` so it receives a generated initial value that should be correct most of the time. If the websocket fails to connect using this value, the Session will force a location update attempt (via updating the access token) to request the proper websocket address using the current base URL. If that fails, the Session will use the current connection reconnect timer to try again after the usual holdoff.

A "verified" flag was added to determine if the websocket address was either provided via a location request or has been successfully connected to prevent excessively querying the location endpoint.

In addition, when the sync route is updated via a call to `SyncManager::set_sync_route()`, this function will also restart the existing sessions to ensure they are using the updated sync route value.

Fixes #7349

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* ~~[ ] C-API, if public C++ API changed~~
* ~~[ ] `bindgen/spec.yml`, if public C++ API changed~~
