### PR TITLE
Update the parent's content version when bumping it in a nested collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Modifying nested collections left the accessor used to make the modification in a stale state, resulting in some unneccesary work being done when making multiple modifications via one accessor ([PR #7470](https://github.com/realm/realm-core/pull/7470), since v14.0.0).
 
 ### Breaking changes
 * None.

--- a/src/realm/collection.hpp
+++ b/src/realm/collection.hpp
@@ -57,6 +57,7 @@ public:
     {
         return 0;
     }
+    void update_content_version() const noexcept final {}
 
 protected:
     Obj m_obj;
@@ -688,13 +689,14 @@ protected:
         return status == UpdateStatus::Updated;
     }
 
-    void bump_content_version()
+    void bump_content_version() noexcept
     {
         REALM_ASSERT(m_alloc);
         m_content_version = m_alloc->bump_content_version();
+        m_parent->update_content_version();
     }
 
-    void update_content_version() const
+    void update_content_version() const noexcept
     {
         REALM_ASSERT(m_alloc);
         m_content_version = m_alloc->get_content_version();
@@ -705,6 +707,7 @@ protected:
         REALM_ASSERT(m_alloc);
         m_alloc->bump_content_version();
         m_alloc->bump_storage_version();
+        m_parent->update_content_version();
     }
 
     Replication* get_replication() const

--- a/src/realm/collection_parent.hpp
+++ b/src/realm/collection_parent.hpp
@@ -95,6 +95,9 @@ public:
     virtual size_t find_index(const Index& ndx) const = 0;
     /// Get table of owning object
     virtual TableRef get_table() const noexcept = 0;
+    // Reread the content version from the allocator. Called when a child makes
+    // a write to mark the already up-to-date parent as still being up-to-date.
+    virtual void update_content_version() const noexcept = 0;
 
     static LstBasePtr get_listbase_ptr(ColKey col_key, size_t level);
     static SetBasePtr get_setbase_ptr(ColKey col_key, size_t level);

--- a/src/realm/dictionary.hpp
+++ b/src/realm/dictionary.hpp
@@ -219,6 +219,10 @@ public:
     {
         return m_parent_version;
     }
+    void update_content_version() const noexcept override
+    {
+        Base::update_content_version();
+    }
     ref_type get_collection_ref(Index, CollectionType) const override;
     bool check_collection_ref(Index, CollectionType) const noexcept override;
     void set_collection_ref(Index, ref_type ref, CollectionType) override;

--- a/src/realm/list.hpp
+++ b/src/realm/list.hpp
@@ -490,6 +490,10 @@ public:
     {
         return m_parent_version;
     }
+    void update_content_version() const noexcept override
+    {
+        Base::update_content_version();
+    }
     ref_type get_collection_ref(Index, CollectionType) const override;
     bool check_collection_ref(Index, CollectionType) const noexcept override;
     void set_collection_ref(Index, ref_type ref, CollectionType) override;

--- a/src/realm/obj.hpp
+++ b/src/realm/obj.hpp
@@ -370,7 +370,6 @@ private:
     bool ensure_writeable();
     void sync(Node& arr);
     int_fast64_t bump_content_version();
-    void bump_both_versions();
     template <class T>
     void do_set_null(ColKey col_key);
 
@@ -476,6 +475,10 @@ private:
     void set_collection_ref(Index index, ref_type ref, CollectionType type) override
     {
         Obj::set_collection_ref(index, ref, type);
+    }
+    void update_content_version() const noexcept override
+    {
+        // not applicable to Obj
     }
 };
 
@@ -652,13 +655,6 @@ inline int_fast64_t Obj::bump_content_version()
 {
     Allocator& alloc = get_alloc();
     return alloc.bump_content_version();
-}
-
-inline void Obj::bump_both_versions()
-{
-    Allocator& alloc = get_alloc();
-    alloc.bump_content_version();
-    alloc.bump_storage_version();
 }
 
 } // namespace realm

--- a/test/test_list.cpp
+++ b/test/test_list.cpp
@@ -1135,8 +1135,7 @@ TEST(List_UpdateIfNeeded)
     auto list_4_1 = list_4->get_list(1);
     auto list_4_2 = list_4->get_list(1);
     list_4_1->add(Mixed());
-    // FIXME: this should be NoChange
-    CHECK_EQUAL(list_4_1->update_if_needed(), UpdateStatus::Updated);
+    CHECK_EQUAL(list_4_1->update_if_needed(), UpdateStatus::NoChange);
     CHECK_EQUAL(list_4_2->update_if_needed(), UpdateStatus::Updated);
 
     // Update the row index of the parent object, forcing it to update


### PR DESCRIPTION
The parent of a nested collection will always be up to date after making a modification to the collection as we update it prior to performing the modification and the modification cannot make the parent stale. Failing to update the parent's content version meant that the parent was always considered stale after an update to a child collection, resulting in the child getting updated between each modification even when the modifications were all done via a single accessor.
