### PR TITLE
RCORE-2028 fix depth for nested collections set to 4 in debug mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Fix depth level for nested collection in debug mode, set it to the same level as release ([#7484](https://github.com/realm/realm-core/issues/7484), since v14.0.0).
 
 ### Breaking changes
 * None.

--- a/src/realm/collection_parent.hpp
+++ b/src/realm/collection_parent.hpp
@@ -109,11 +109,7 @@ protected:
     friend class CollectionBaseImpl;
     friend class CollectionList;
 
-#ifdef REALM_DEBUG
-    static constexpr size_t s_max_level = 4;
-#else
     static constexpr size_t s_max_level = 100;
-#endif
     uint8_t m_level = 0;
 
     constexpr CollectionParent(uint8_t level = 0)


### PR DESCRIPTION
## What, How & Why?
Fix depth for nested collections in debug mode in order to avoid to break tests in debug mode for SDKs.
Fixes (https://github.com/realm/realm-core/issues/7484)

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed
* [ ] `bindgen/spec.yml`, if public C++ API changed
