### PR TITLE
Set the minimum buffer size in Group::write() to be equal to the page size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Enhancements
 * <New feature description> (PR [#????](https://github.com/realm/realm-core/pull/????))
-* None.
+* Improve file compaction performance on platforms with page sizes greater than 4k (for example arm64 Apple platforms) for files less than 256 pages in size ([PR #7492](https://github.com/realm/realm-core/pull/7492)).
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)

--- a/src/realm/group.cpp
+++ b/src/realm/group.cpp
@@ -995,7 +995,7 @@ void Group::write(File& file, const char* encryption_key, uint_fast64_t version_
     // The aim is that the buffer size should be at least 1/256 of needed size but less than 64 Mb
     constexpr size_t upper_bound = 64 * 1024 * 1024;
     size_t min_space = std::min(get_used_space() >> 8, upper_bound);
-    size_t buffer_size = 4096;
+    size_t buffer_size = page_size();
     while (buffer_size < min_space) {
         buffer_size <<= 1;
     }


### PR DESCRIPTION
For encrypted files we always write data in page sized increments, so using a buffer smaller than the page size results in writing the same page multiple times. On arm64 Apple platforms, this was a problem for files between 16 KB and 4 MB.
