### PR TITLE
RCORE-1816 Ensure group is set to client history prior to update

### DIFF
--- a/src/realm/transaction.hpp
+++ b/src/realm/transaction.hpp
@@ -495,6 +495,7 @@ inline bool Transaction::internal_advance_read(O* observer, VersionID version_id
     update_allocator_wrappers(writable);
     using gf = _impl::GroupFriend;
     ref_type hist_ref = gf::get_history_ref(alloc, new_top_ref);
+    hist.set_group(this);
     hist.update_from_ref_and_version(hist_ref, new_version);
 
     if (observer) {


### PR DESCRIPTION
## What, How & Why?

Ensure that the Group is set on ClientHistory before updating it when advancing to latest available version during the transaction when the new version was committed during preparing to write

Fixes #7041

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed
* [ ] `bindgen/spec.yml`, if public C++ API changed
