### PR TITLE
RCORE-2008 Bump baas version

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -3,5 +3,5 @@ VERSION: 14.3.0
 OPENSSL_VERSION: 3.2.0
 ZLIB_VERSION: 1.2.13
 # https://github.com/10gen/baas/commits
-# acb71d0 is 2024 Mar 12
-BAAS_VERSION: acb71d0183b33eb304bb496390567efcfb8a6e60
+# 6bf5e1 is 2024 Mar 20
+BAAS_VERSION: 6bf5e111499ba32d04224e2fc10acca3595edb20


### PR DESCRIPTION
## What, How & Why?
Bumping baas version to get the fix for "Test client migration and rollback with recovery" flakeyness.

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed
* [ ] `bindgen/spec.yml`, if public C++ API changed
