### PR TITLE
Disallow Set inside ArrayMixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Modifying nested collections left the accessor used to make the modification in a stale state, resulting in some unneccesary work being done when making multiple modifications via one accessor ([PR #7470](https://github.com/realm/realm-core/pull/7470), since v14.0.0).
 * Fix depth level for nested collection in debug mode, set it to the same level as release ([#7484](https://github.com/realm/realm-core/issues/7484), since v14.0.0).
 * Fix opening realm with cached user while offline results in fatal error and session does not retry connection. ([#7349](https://github.com/realm/realm-core/issues/7349), since v13.26.0)
+* Fix disallow Sets in ArrayMixed. ([#7502](https://github.com/realm/realm-core/pull/7502), since v14.0.0)
 
 ### Breaking changes
 * Update C-API log callback signature to include the log category, and `realm_set_log_callback` to not take a `realm_log_level_e`. ([PR #7494](https://github.com/realm/realm-core/pull/7494)

--- a/src/realm/array_mixed.cpp
+++ b/src/realm/array_mixed.cpp
@@ -550,7 +550,7 @@ int64_t ArrayMixed::store(const Mixed& value)
             break;
         }
         default:
-            REALM_ASSERT(type == type_List || type == type_Dictionary || type == type_Set);
+            REALM_ASSERT(type == type_List || type == type_Dictionary);
             ensure_ref_array();
             size_t ndx = m_refs.size();
             m_refs.add(value.get_ref());


### PR DESCRIPTION
## What, How & Why?
Working on compressing collections in mixed, I noticed that we allow col type Set to be stored inside a Mixed. 
There should be no way to get into Array Mixed via the API, but better to be safe IMO.  

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed
* [ ] `bindgen/spec.yml`, if public C++ API changed
