### PR TITLE
RCORE-2037: [bindgen] smaller fixes after 14.4.0

### DIFF
--- a/bindgen/spec.yml
+++ b/bindgen/spec.yml
@@ -555,6 +555,7 @@ records:
       schema_did_change: 'Nullable<util::UniqueFunction<(r: SharedRealm)>>' # new schema available as r.schema
 
   ResumptionDelayInfo:
+    cppName: sync::ResumptionDelayInfo
     fields:
       max_resumption_delay_interval:
         type: std::chrono::milliseconds

--- a/bindgen/spec.yml
+++ b/bindgen/spec.yml
@@ -35,6 +35,7 @@ primitives:
   - void
   - std::string
   - std::string_view
+  - std::chrono::milliseconds
   # TODO: see if we need nullable versions of these. For now null buffers are treated as empty.
   - StringData
   - OwnedBinaryData
@@ -1353,7 +1354,7 @@ classes:
       path: std::string
       user: SharedSyncUser
       config: SyncConfig
-      full_realm_url: std::optional<std::string>
+      full_realm_url: std::string
     methods:
       wait_for_upload_completion: '(callback: AsyncCallback<(err: Status) off_thread>)'
       wait_for_download_completion: '(callback: AsyncCallback<(err: Status) off_thread>)'


### PR DESCRIPTION
## What, How & Why?

* Add std::chrono::milliseconds as primitive type. 
* Update return value of SyncSession::full_realm_url.

Closes #7506 

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed
* [x] `bindgen/spec.yml`, if public C++ API changed
