### PR TITLE
RCORE-1984 Upgrade libuv to v1.48.0 for object-store tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 -----------
 
 ### Internals
-* None.
+* Update libuv used in object store tests from v1.35.0 to v1.48.0 ([PR #7508](https://github.com/realm/realm-core/pull/7508)).
 
 ----------------------------------------------
 

--- a/test/object-store/CMakeLists.txt
+++ b/test/object-store/CMakeLists.txt
@@ -203,10 +203,7 @@ if(NOT APPLE AND NOT EMSCRIPTEN AND NOT WINDOWS_STORE AND NOT ANDROID)
     elseif(REALM_FETCH_MISSING_DEPENDENCIES)
         message(STATUS "LibUV not found, building from source with FetchContent")
         include(FetchContent)
-        set(libUV_Git_TAG "v1.35.0")
-        if(MSVC)
-            set(liUV_Git_TAG "v1.43.0")
-        endif()
+        set(libUV_Git_TAG "v1.48.0")
         FetchContent_Declare(
             libuv
             GIT_REPOSITORY https://github.com/libuv/libuv.git


### PR DESCRIPTION
## What, How & Why?
Updates the libuv we use in the object store tests so we get the fixes from https://github.com/libuv/libuv/issues/3683 in our tsan runs.

## ☑️ ToDos
* [x] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed
* [ ] `bindgen/spec.yml`, if public C++ API changed
