### PR TITLE
Made `set_default_logger` nullable in `spec.yml`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 -----------
 
 ### Internals
-* None.
+* Made `set_default_logger` nullable in the bindgen spec.yml (PR [#7515](https://github.com/realm/realm-core/pull/7515)).
 
 ----------------------------------------------
 

--- a/bindgen/spec.yml
+++ b/bindgen/spec.yml
@@ -745,7 +745,7 @@ classes:
     properties:
       get_default_logger: SharedLogger
     staticMethods:
-      set_default_logger: '(logger: SharedLogger)'
+      set_default_logger: '(logger: Nullable<SharedLogger>)'
 
   ConstTableRef:
     needsDeref: true


### PR DESCRIPTION
## What, How & Why?

Made `set_default_logger` nullable in `spec.yml` to allow the SDK to remove the default logger entirely.

## ☑️ ToDos
* [x] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed
* [x] `bindgen/spec.yml`, if public C++ API changed
