### PR TITLE
Demote some assertions inside commit hot path to trigger only in debug mode

### DIFF
--- a/src/realm/array.cpp
+++ b/src/realm/array.cpp
@@ -363,9 +363,9 @@ size_t Array::get_byte_size() const noexcept
 
 ref_type Array::write(_impl::ArrayWriterBase& out, bool deep, bool only_if_modified, bool compress_in_flight) const
 {
-    REALM_ASSERT(is_attached());
+    REALM_ASSERT_DEBUG(is_attached());
     // The default allocator cannot be trusted wrt is_read_only():
-    REALM_ASSERT(!only_if_modified || &m_alloc != &Allocator::get_default());
+    REALM_ASSERT_DEBUG(!only_if_modified || &m_alloc != &Allocator::get_default());
     if (only_if_modified && m_alloc.is_read_only(m_ref))
         return m_ref;
 
@@ -398,7 +398,7 @@ ref_type Array::write(ref_type ref, Allocator& alloc, _impl::ArrayWriterBase& ou
                       bool compress_in_flight)
 {
     // The default allocator cannot be trusted wrt is_read_only():
-    REALM_ASSERT(!only_if_modified || &alloc != &Allocator::get_default());
+    REALM_ASSERT_DEBUG(!only_if_modified || &alloc != &Allocator::get_default());
     if (only_if_modified && alloc.is_read_only(ref))
         return ref;
 

--- a/src/realm/array_encode.cpp
+++ b/src/realm/array_encode.cpp
@@ -148,7 +148,7 @@ bool ArrayEncode::always_encode(const Array& origin, Array& arr, bool packed) co
 bool ArrayEncode::encode(const Array& origin, Array& arr) const
 {
     // return false;
-    // return always_encode(origin, arr, true); // true packed, false flex
+    return always_encode(origin, arr, true); // true packed, false flex
 
     std::vector<int64_t> values;
     std::vector<size_t> indices;

--- a/src/realm/array_encode.cpp
+++ b/src/realm/array_encode.cpp
@@ -148,7 +148,7 @@ bool ArrayEncode::always_encode(const Array& origin, Array& arr, bool packed) co
 bool ArrayEncode::encode(const Array& origin, Array& arr) const
 {
     // return false;
-    return always_encode(origin, arr, true); // true packed, false flex
+    // return always_encode(origin, arr, true); // true packed, false flex
 
     std::vector<int64_t> values;
     std::vector<size_t> indices;

--- a/src/realm/bplustree.cpp
+++ b/src/realm/bplustree.cpp
@@ -841,7 +841,7 @@ ref_type BPlusTreeBase::typed_write(ref_type ref, _impl::ArrayWriterBase& out, A
     Array node(alloc);
     node.init_from_ref(ref);
     if (NodeHeader::get_is_inner_bptree_node_from_header(header)) {
-        REALM_ASSERT(node.has_refs());
+        REALM_ASSERT_DEBUG(node.has_refs());
         Array written_node(Allocator::get_default());
         written_node.create(NodeHeader::type_InnerBptreeNode, false, node.size());
         for (unsigned j = 0; j < node.size(); ++j) {

--- a/src/realm/bplustree.cpp
+++ b/src/realm/bplustree.cpp
@@ -865,33 +865,27 @@ ref_type BPlusTreeBase::typed_write(ref_type ref, _impl::ArrayWriterBase& out, A
         written_node.destroy();
         return written_ref;
     }
-    else {
-        if (node.has_refs()) {
-            // TODO: handle collection in mixed here. This is breaking..
-            Array written_node(Allocator::get_default());
-            written_node.create(NodeHeader::type_InnerBptreeNode, false, node.size());
-            for (unsigned j = 0; j < node.size(); ++j) {
-                RefOrTagged rot = node.get_as_ref_or_tagged(j);
-                if (rot.is_ref() && rot.get_as_ref()) {
-                    // it should/could only be a nested collection
-                    compress = true;
-                    written_node.set_as_ref(j, BPlusTreeBase::typed_write(rot.get_as_ref(), out, alloc, col_type,
-                                                                          deep, only_modified, compress));
-                }
-                else {
-                    Array a(alloc);
-                    a.init_from_ref(rot.get_as_ref());
-                    written_node.set_as_ref(j, a.write(out, deep, only_modified, false));
-                }
+    else if (node.has_refs()) {
+        Array ref_node(Allocator::get_default());
+        ref_node.create(NodeHeader::type_HasRefs, false, node.size());
+        for (size_t j = 0; j < node.size(); ++j) {
+            RefOrTagged rot = node.get_as_ref_or_tagged(j);
+            if (rot.is_ref() && rot.get_as_ref()) {
+                auto btree_ref =
+                    BPlusTreeBase::typed_write(rot.get_as_ref(), out, alloc, col_type, deep, only_modified, true);
+                ref_node.set_as_ref(j, btree_ref);
             }
-            auto written_ref = written_node.write(out, false, false, false);
-            written_node.destroy();
-            return written_ref;
-            // return node.write(out, deep, only_modified, false); // unknown substructure, don't compress
+            else {
+                ref_node.set(j, rot);
+            }
         }
-        else {
-            return node.write(out, false, only_modified, compress); // leaf array - do compress
-        }
+        auto new_ref = ref_node.write(out, false, false, false);
+        ref_node.destroy();
+        return new_ref;
+        // return node.write(out, deep, only_modified, false);
+    }
+    else {
+        return node.write(out, deep, only_modified, true); // leaf array - do compress
     }
 }
 

--- a/src/realm/bplustree.hpp
+++ b/src/realm/bplustree.hpp
@@ -217,7 +217,7 @@ public:
     }
 
     static ref_type typed_write(ref_type ref, _impl::ArrayWriterBase& out, Allocator& alloc, ColumnType col_type,
-                                bool deep, bool only_modified, bool compress);
+                                bool deep, bool only_modified, bool compress, bool collection_in_mixed);
     static void typed_print(std::string prefix, Allocator& alloc, ref_type root, ColumnType col_type);
 
 

--- a/src/realm/cluster.cpp
+++ b/src/realm/cluster.cpp
@@ -1534,11 +1534,11 @@ void Cluster::remove_backlinks(const Table* origin_table, ObjKey origin_key, Col
 ref_type Cluster::typed_write(ref_type ref, _impl::ArrayWriterBase& out, const Table& table, bool deep,
                               bool only_modified, bool compress) const
 {
-    REALM_ASSERT(ref == get_mem().get_ref());
+    REALM_ASSERT_DEBUG(ref == get_mem().get_ref());
     if (only_modified && m_alloc.is_read_only(ref))
         return ref;
-    REALM_ASSERT(!get_is_inner_bptree_node_from_header(get_header()));
-    REALM_ASSERT(!get_context_flag_from_header(get_header()));
+    REALM_ASSERT_DEBUG(!get_is_inner_bptree_node_from_header(get_header()));
+    REALM_ASSERT_DEBUG(!get_context_flag_from_header(get_header()));
     Array written_cluster(Allocator::get_default());
     written_cluster.create(type_HasRefs, false, size());
     for (size_t j = 0; j < size(); ++j) {
@@ -1570,7 +1570,7 @@ ref_type Cluster::typed_write(ref_type ref, _impl::ArrayWriterBase& out, const T
                                 col_type == col_type_TypedLink || col_type == col_type_UUID;
             // First handle true leafs (not collections or complex leafs)
             if (!leaf.has_refs()) {
-                REALM_ASSERT(col_type != col_type_Mixed && col_type != col_type_Timestamp);
+                REALM_ASSERT_DEBUG(col_type != col_type_Mixed && col_type != col_type_Timestamp);
                 written_cluster.set_as_ref(j, leaf.write(out, deep, only_modified, compress && compressible));
                 continue;
             }
@@ -1584,9 +1584,9 @@ ref_type Cluster::typed_write(ref_type ref, _impl::ArrayWriterBase& out, const T
             // leafs and collections (for example: a collection of ints will be of col_type_Int)
             // but have attribute indicating it is a collection. Handling it as a leaf would be
             // an error).
-            REALM_ASSERT(leaf.has_refs());
+            REALM_ASSERT_DEBUG(leaf.has_refs());
             auto wtype = leaf.get_wtype_from_header(leaf.get_header());
-            REALM_ASSERT(wtype == wtype_Bits);
+            REALM_ASSERT_DEBUG(wtype == wtype_Bits);
             Array written_leaf(Allocator::get_default());
             written_leaf.create(type_HasRefs, false, leaf.size());
             if (col_attr.test(col_attr_List) || col_attr.test(col_attr_Set)) {
@@ -1621,7 +1621,7 @@ ref_type Cluster::typed_write(ref_type ref, _impl::ArrayWriterBase& out, const T
                     // got a subtree to handle: (which must be a dict, as indicated by column type)
                     Array dict_top(m_alloc);
                     dict_top.init_from_ref(dict_rot.get_as_ref());
-                    REALM_ASSERT(dict_top.size() == 2);
+                    REALM_ASSERT_DEBUG(dict_top.size() == 2);
                     Array written_dict_top(Allocator::get_default());
                     written_dict_top.create(type_HasRefs, false, dict_top.size());
                     if (dict_top.size() == 2) {
@@ -1642,17 +1642,17 @@ ref_type Cluster::typed_write(ref_type ref, _impl::ArrayWriterBase& out, const T
             else if (col_type == col_type_Timestamp) {
                 // timestamps could be compressed, but the formats we support at the moment are not producing
                 // noticeable gains.
-                REALM_ASSERT(leaf.size() == 2);
+                REALM_ASSERT_DEBUG(leaf.size() == 2);
                 auto rot0 = leaf.get_as_ref_or_tagged(0);
                 auto rot1 = leaf.get_as_ref_or_tagged(1);
-                REALM_ASSERT(rot0.is_ref() && rot0.get_as_ref());
-                REALM_ASSERT(rot1.is_ref() && rot1.get_as_ref());
+                REALM_ASSERT_DEBUG(rot0.is_ref() && rot0.get_as_ref());
+                REALM_ASSERT_DEBUG(rot1.is_ref() && rot1.get_as_ref());
                 written_leaf.set_as_ref(0, Array::write(rot0.get_as_ref(), m_alloc, out, only_modified, false));
                 written_leaf.set_as_ref(1, Array::write(rot1.get_as_ref(), m_alloc, out, only_modified, false));
             }
             else if (col_type == col_type_Mixed) {
                 const auto sz = leaf.size();
-                REALM_ASSERT(sz == 6);
+                REALM_ASSERT_DEBUG(sz == 6);
 
                 /*
                  In order to know how Mixed stores things, we need to take in consideration this enum
@@ -1726,7 +1726,7 @@ ref_type Cluster::typed_write(ref_type ref, _impl::ArrayWriterBase& out, const T
 
 void Cluster::typed_print(std::string prefix, const Table& table) const
 {
-    REALM_ASSERT(!get_is_inner_bptree_node_from_header(get_header()));
+    REALM_ASSERT_DEBUG(!get_is_inner_bptree_node_from_header(get_header()));
     std::cout << "Cluster of size " << size() << " " << header_to_string(get_header()) << std::endl;
     for (unsigned j = 0; j < size(); ++j) {
         RefOrTagged rot = get_as_ref_or_tagged(j);

--- a/src/realm/cluster.cpp
+++ b/src/realm/cluster.cpp
@@ -1678,7 +1678,17 @@ ref_type Cluster::typed_write(ref_type ref, _impl::ArrayWriterBase& out, const T
 
                         const auto do_compress = (i < 3) ? true : false;
                         if (i == 4) {
-                            // TODO: handle collections in mixed
+                            // TODO this is not working...
+                            bool compress = true;
+                            auto bptree_rot = leaf.get_as_ref_or_tagged(i);
+                            if (bptree_rot.is_ref() && bptree_rot.get_as_ref()) {
+                                written_leaf.set_as_ref(i, BPlusTreeBase::typed_write(bptree_rot.get_as_ref(), out,
+                                                                                      m_alloc, col_type, deep,
+                                                                                      only_modified, compress));
+                            }
+                            else {
+                                written_leaf.set(i, bptree_rot);
+                            }
                         }
                         // compress only mixed arrays that are integers. skip all the rest for now.
                         written_leaf.set_as_ref(

--- a/test/test_list.cpp
+++ b/test/test_list.cpp
@@ -633,7 +633,7 @@ TEST(List_AggOps)
     test_lists_numeric_agg<Decimal128>(test_context, sg, type_Decimal, Decimal128(realm::null()), true);
 }
 
-ONLY(Test_Write_List_Nested_InMixed)
+ONLY(Test_Write_List_Nested_In_Mixed)
 {
     SHARED_GROUP_TEST_PATH(path);
     std::string message;
@@ -641,20 +641,31 @@ ONLY(Test_Write_List_Nested_InMixed)
     options.logger = test_context.logger;
     DBRef db = DB::create(make_in_realm_history(), path, options);
     auto tr = db->start_write();
-    auto table = tr->add_table_with_primary_key("table", type_Int, "id");
+    auto table = tr->add_table("table");
     auto col_any = table->add_column(type_Mixed, "something");
 
-    Obj obj = table->create_object_with_primary_key(1);
+    Obj obj = table->create_object();
     obj.set_any(col_any, Mixed{20});
     tr->verify();
     tr->commit_and_continue_writing(); // commit simple mixed
+    tr->verify();
 
     obj.set_collection(col_any, CollectionType::List);
     auto list = obj.get_list_ptr<Mixed>(col_any);
     list->add(Mixed{10});
     list->add(Mixed{11});
     tr->verify();
-    tr->commit(); // commit nested list in mixed
+    tr->commit_and_continue_writing(); // commit nested list in mixed
+    tr->verify();
+
+    // spicy it up a little bit...
+    list->insert_collection(2, CollectionType::List);
+    list->insert_collection(3, CollectionType::List);
+    list->get_list(2)->add(Mixed{20});
+    list->get_list(3)->add(Mixed{21});
+    tr->commit_and_continue_writing();
+    tr->verify();
+    tr->close();
 }
 
 TEST(List_Nested_InMixed)

--- a/test/test_list.cpp
+++ b/test/test_list.cpp
@@ -633,7 +633,7 @@ TEST(List_AggOps)
     test_lists_numeric_agg<Decimal128>(test_context, sg, type_Decimal, Decimal128(realm::null()), true);
 }
 
-ONLY(Test_Write_List_Nested_In_Mixed)
+TEST(Test_Write_List_Nested_In_Mixed)
 {
     SHARED_GROUP_TEST_PATH(path);
     std::string message;


### PR DESCRIPTION
## What, How & Why?
We have added a bunch of assertions in some critical path of the code that are slowing down a bit the commit machinery, and also while reading the file. 
Demoting them to debug, since they are not needed in release mode. 
It depends on https://github.com/realm/realm-core/pull/7501 to be merged. 

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed
* [ ] `bindgen/spec.yml`, if public C++ API changed
