### PR TITLE
Update 'release-init.sh' script to update git submodules prior to starting the release process

### DIFF
--- a/tools/release-init.sh
+++ b/tools/release-init.sh
@@ -15,7 +15,6 @@ function usage()
     echo "    10.123.1"
     echo "    99.999999.999999"
     echo "    4.5.0-CustDemo"
-    # Default to 0 if exit code not provided
     exit 1
 }
 
@@ -23,6 +22,7 @@ if [[ -z "$1" ]]; then
     usage
 fi
 
+# egrep has been replaced with 'grep -E'
 realm_version=$(echo "$1" | grep -E "${VERSION_GREP}")
 if [ -z "${realm_version}" ]; then
     echo Wrong version format: "$1"

--- a/tools/release-init.sh
+++ b/tools/release-init.sh
@@ -5,11 +5,32 @@
 # Description of release procedure can be found at https://github.com/realm/realm-wiki/wiki/Releasing-Realm-Core
 #
 
-realm_version=$(echo "$1" | egrep '^[0-9]?[0-9].[0-9]+.[0-9]+(-.*)?$')
+VERSION_GREP='^[0-9]?[0-9].[0-9]+.[0-9]+(-.*)?$'
+
+function usage()
+{
+    echo "Usage: release-init.sh VERSION"
+    echo "  VERSION format regex: ${VERSION_GREP}"
+    echo "  Examples:"
+    echo "    10.123.1"
+    echo "    99.999999.999999"
+    echo "    4.5.0-CustDemo"
+    # Default to 0 if exit code not provided
+    exit 1
+}
+
+if [[ -z "$1" ]]; then
+    usage
+fi
+
+realm_version=$(echo "$1" | grep -E "${VERSION_GREP}")
 if [ -z "${realm_version}" ]; then
     echo Wrong version format: "$1"
-    exit 1
+    usage
 fi
+
+# make sure submodules are up to date
+git submodule update --init --recursive
 
 project_dir=$(git rev-parse --show-toplevel)
 


### PR DESCRIPTION
## What, How & Why?
The git submodules had not been updated prior to running the `tools/release-init.sh` script, which lead to a stale version of `external/catch` to be committed to the release.

This update ensures the submodules are initialized and up to date prior to starting the release process. It also adds help text to help with running this script.


## ☑️ ToDos
* ~~[ ] 📝 Changelog update~~
* ~~[ ] 🚦 Tests (or not relevant)~~
* ~~[ ] C-API, if public C++ API changed~~
* ~~[ ] `bindgen/spec.yml`, if public C++ API changed~~
