### PR TITLE
RCORE-2059 Truncate the metadata realm in-place rather than deleting and recreating it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### Internals
 * Update libuv used in object store tests from v1.35.0 to v1.48.0 ([PR #7508](https://github.com/realm/realm-core/pull/7508)).
 * Made `set_default_logger` nullable in the bindgen spec.yml (PR [#7515](https://github.com/realm/realm-core/pull/7515)).
+* Recreating the sync metadata Realm when the encryption key changes is now done in a multi-process safe manner ([PR #7526](https://github.com/realm/realm-core/pull/7526)).
 
 ----------------------------------------------
 

--- a/src/realm/alloc_slab.cpp
+++ b/src/realm/alloc_slab.cpp
@@ -818,12 +818,30 @@ ref_type SlabAlloc::attach_file(const std::string& path, Config& cfg, util::Writ
     // size_t.
     if (REALM_UNLIKELY(int_cast_with_overflow_detect(m_file.get_size(), size)))
         throw InvalidDatabase("Realm file too large", path);
-    if (cfg.encryption_key && size == 0 && physical_file_size != 0) {
+    if (cfg.clear_file_on_error && cfg.session_initiator) {
+        if (size == 0 && physical_file_size != 0) {
+            cfg.clear_file = true;
+        }
+        else if (size > 0) {
+            try {
+                read_and_validate_header(m_file, path, size, cfg.session_initiator, m_write_observer);
+            }
+            catch (const InvalidDatabase&) {
+                cfg.clear_file = true;
+            }
+        }
+    }
+    if (cfg.clear_file) {
+        m_file.resize(0);
+        size = 0;
+        physical_file_size = 0;
+    }
+    else if (cfg.encryption_key && !cfg.clear_file && size == 0 && physical_file_size != 0) {
         // The opened file holds data, but is so small it cannot have
         // been created with encryption
         throw InvalidDatabase("Attempt to open unencrypted file with encryption key", path);
     }
-    if (size == 0 || cfg.clear_file) {
+    if (size == 0) {
         if (REALM_UNLIKELY(cfg.read_only))
             throw InvalidDatabase("Read-only access to empty Realm file", path);
 
@@ -847,65 +865,13 @@ ref_type SlabAlloc::attach_file(const std::string& path, Config& cfg, util::Writ
 
         size = initial_size;
     }
-    ref_type top_ref;
     note_reader_start(this);
     util::ScopeExit reader_end_guard([this]() noexcept {
         note_reader_end(this);
     });
 
-    try {
-        // we'll read header and (potentially) footer
-        File::Map<char> map_header(m_file, File::access_ReadOnly, sizeof(Header), 0, m_write_observer);
-        realm::util::encryption_read_barrier(map_header, 0, sizeof(Header));
-        auto header = reinterpret_cast<const Header*>(map_header.get_addr());
-
-        File::Map<char> map_footer;
-        const StreamingFooter* footer = nullptr;
-        if (is_file_on_streaming_form(*header) && size >= sizeof(StreamingFooter) + sizeof(Header)) {
-            size_t footer_ref = size - sizeof(StreamingFooter);
-            size_t footer_page_base = footer_ref & ~(page_size() - 1);
-            size_t footer_offset = footer_ref - footer_page_base;
-            map_footer = File::Map<char>(m_file, footer_page_base, File::access_ReadOnly,
-                                         sizeof(StreamingFooter) + footer_offset, 0, m_write_observer);
-            realm::util::encryption_read_barrier(map_footer, footer_offset, sizeof(StreamingFooter));
-            footer = reinterpret_cast<const StreamingFooter*>(map_footer.get_addr() + footer_offset);
-        }
-
-        top_ref = validate_header(header, footer, size, path, cfg.encryption_key != nullptr); // Throws
-        m_attach_mode = cfg.is_shared ? attach_SharedFile : attach_UnsharedFile;
-        m_data = map_header.get_addr(); // <-- needed below
-
-        if (cfg.session_initiator && is_file_on_streaming_form(*header)) {
-            // Don't compare file format version fields as they are allowed to differ.
-            // Also don't compare reserved fields.
-            REALM_ASSERT_EX(header->m_flags == 0, header->m_flags, get_file_path_for_assertions());
-            REALM_ASSERT_EX(header->m_mnemonic[0] == uint8_t('T'), header->m_mnemonic[0],
-                            get_file_path_for_assertions());
-            REALM_ASSERT_EX(header->m_mnemonic[1] == uint8_t('-'), header->m_mnemonic[1],
-                            get_file_path_for_assertions());
-            REALM_ASSERT_EX(header->m_mnemonic[2] == uint8_t('D'), header->m_mnemonic[2],
-                            get_file_path_for_assertions());
-            REALM_ASSERT_EX(header->m_mnemonic[3] == uint8_t('B'), header->m_mnemonic[3],
-                            get_file_path_for_assertions());
-            REALM_ASSERT_EX(header->m_top_ref[0] == 0xFFFFFFFFFFFFFFFFULL, header->m_top_ref[0],
-                            get_file_path_for_assertions());
-            REALM_ASSERT_EX(header->m_top_ref[1] == 0, header->m_top_ref[1], get_file_path_for_assertions());
-            REALM_ASSERT_EX(footer->m_magic_cookie == footer_magic_cookie, footer->m_magic_cookie,
-                            get_file_path_for_assertions());
-        }
-    }
-    catch (const InvalidDatabase&) {
-        throw;
-    }
-    catch (const DecryptionFailed& e) {
-        throw InvalidDatabase(util::format("Realm file decryption failed (%1)", e.what()), path);
-    }
-    catch (const std::exception& e) {
-        throw InvalidDatabase(e.what(), path);
-    }
-    catch (...) {
-        throw InvalidDatabase("unknown error", path);
-    }
+    ref_type top_ref = read_and_validate_header(m_file, path, size, cfg.session_initiator, m_write_observer);
+    m_attach_mode = cfg.is_shared ? attach_SharedFile : attach_UnsharedFile;
     // m_data not valid at this point!
     m_baseline = 0;
     // make sure that any call to begin_read cause any slab to be placed in free
@@ -1038,6 +1004,57 @@ void SlabAlloc::attach_empty()
     m_baseline = size;
     m_translation_table_size = 1;
     m_ref_translation_ptr = new RefTranslation[1];
+}
+
+ref_type SlabAlloc::read_and_validate_header(util::File& file, const std::string& path, size_t size,
+                                             bool session_initiator, util::WriteObserver* write_observer)
+{
+    try {
+        // we'll read header and (potentially) footer
+        File::Map<char> map_header(file, File::access_ReadOnly, sizeof(Header), 0, write_observer);
+        realm::util::encryption_read_barrier(map_header, 0, sizeof(Header));
+        auto header = reinterpret_cast<const Header*>(map_header.get_addr());
+
+        File::Map<char> map_footer;
+        const StreamingFooter* footer = nullptr;
+        if (is_file_on_streaming_form(*header) && size >= sizeof(StreamingFooter) + sizeof(Header)) {
+            size_t footer_ref = size - sizeof(StreamingFooter);
+            size_t footer_page_base = footer_ref & ~(page_size() - 1);
+            size_t footer_offset = footer_ref - footer_page_base;
+            map_footer = File::Map<char>(file, footer_page_base, File::access_ReadOnly,
+                                         sizeof(StreamingFooter) + footer_offset, 0, write_observer);
+            realm::util::encryption_read_barrier(map_footer, footer_offset, sizeof(StreamingFooter));
+            footer = reinterpret_cast<const StreamingFooter*>(map_footer.get_addr() + footer_offset);
+        }
+
+        auto top_ref = validate_header(header, footer, size, path, file.get_encryption_key() != nullptr); // Throws
+
+        if (session_initiator && is_file_on_streaming_form(*header)) {
+            // Don't compare file format version fields as they are allowed to differ.
+            // Also don't compare reserved fields.
+            REALM_ASSERT_EX(header->m_flags == 0, header->m_flags, path);
+            REALM_ASSERT_EX(header->m_mnemonic[0] == uint8_t('T'), header->m_mnemonic[0], path);
+            REALM_ASSERT_EX(header->m_mnemonic[1] == uint8_t('-'), header->m_mnemonic[1], path);
+            REALM_ASSERT_EX(header->m_mnemonic[2] == uint8_t('D'), header->m_mnemonic[2], path);
+            REALM_ASSERT_EX(header->m_mnemonic[3] == uint8_t('B'), header->m_mnemonic[3], path);
+            REALM_ASSERT_EX(header->m_top_ref[0] == 0xFFFFFFFFFFFFFFFFULL, header->m_top_ref[0], path);
+            REALM_ASSERT_EX(header->m_top_ref[1] == 0, header->m_top_ref[1], path);
+            REALM_ASSERT_EX(footer->m_magic_cookie == footer_magic_cookie, footer->m_magic_cookie, path);
+        }
+        return top_ref;
+    }
+    catch (const InvalidDatabase&) {
+        throw;
+    }
+    catch (const DecryptionFailed& e) {
+        throw InvalidDatabase(util::format("Realm file decryption failed (%1)", e.what()), path);
+    }
+    catch (const std::exception& e) {
+        throw InvalidDatabase(e.what(), path);
+    }
+    catch (...) {
+        throw InvalidDatabase("unknown error", path);
+    }
 }
 
 void SlabAlloc::throw_header_exception(std::string msg, const Header& header, const std::string& path)

--- a/src/realm/db.hpp
+++ b/src/realm/db.hpp
@@ -128,7 +128,7 @@ public:
     // calling DB::close(), but after that no new association can be established. To reopen the
     // file (or another file), a new DB object is needed. The specified Replication instance, if
     // any, must remain in existence for as long as the DB.
-    static DBRef create(const std::string& file, bool no_create = false, const DBOptions& options = DBOptions());
+    static DBRef create(const std::string& file, const DBOptions& options = DBOptions());
     static DBRef create(Replication& repl, const std::string& file, const DBOptions& options = DBOptions());
     static DBRef create(std::unique_ptr<Replication> repl, const std::string& file,
                         const DBOptions& options = DBOptions());
@@ -534,10 +534,6 @@ private:
     ///
     /// \param file Filesystem path to a Realm database file.
     ///
-    /// \param no_create If the database file does not already exist, it will be
-    /// created (unless this is set to true.) When multiple threads are involved,
-    /// it is safe to let the first thread, that gets to it, create the file.
-    ///
     /// \param options See DBOptions for details of each option.
     /// Sensible defaults are provided if this parameter is left out.
     ///
@@ -553,13 +549,12 @@ private:
     /// \throw UnsupportedFileFormatVersion if the file format version or
     /// history schema version is one which this version of Realm does not know
     /// how to migrate from.
-    void open(const std::string& file, bool no_create = false, const DBOptions& options = DBOptions())
-        REQUIRES(!m_mutex);
+    void open(const std::string& file, const DBOptions& options = DBOptions()) REQUIRES(!m_mutex);
     void open(BinaryData, bool take_ownership = true) REQUIRES(!m_mutex);
     void open(Replication&, const std::string& file, const DBOptions& options = DBOptions()) REQUIRES(!m_mutex);
-    void open(Replication& repl, const DBOptions options = DBOptions()) REQUIRES(!m_mutex);
+    void open(Replication& repl, const DBOptions& options = DBOptions()) REQUIRES(!m_mutex);
 
-    void do_open(const std::string& file, bool no_create, const DBOptions& options);
+    void do_open(const std::string& file, const DBOptions& options);
 
     Replication* const* get_repl() const noexcept
     {

--- a/src/realm/db_options.hpp
+++ b/src/realm/db_options.hpp
@@ -88,6 +88,9 @@ struct DBOptions {
     /// Disable automatic backup at file format upgrade by setting to false
     bool backup_at_file_format_change = true;
 
+    /// Disable creating new files if the DB to open does not already exist.
+    bool no_create = false;
+
     /// List of versions we can upgrade from
     BackupHandler::VersionList accepted_versions = BackupHandler::accepted_versions_;
 
@@ -98,6 +101,10 @@ struct DBOptions {
     /// this will make *all* writes async and then wait on the result, which has
     /// a performance impact.
     bool enable_async_writes = false;
+
+    /// If set, opening a file which is not a Realm file or cannot be decrypted
+    /// will clear and reinitialize the file.
+    bool clear_on_invalid_file = false;
 
     /// sys_tmp_dir will be used if the temp_dir is empty when creating DBOptions.
     /// It must be writable and allowed to create pipe/fifo file on it.

--- a/src/realm/object-store/impl/realm_coordinator.cpp
+++ b/src/realm/object-store/impl/realm_coordinator.cpp
@@ -479,6 +479,7 @@ bool RealmCoordinator::open_db()
         }
         options.encryption_key = m_config.encryption_key.data();
         options.allow_file_format_upgrade = !m_config.disable_format_upgrade && !schema_mode_reset_file;
+        options.clear_on_invalid_file = m_config.clear_on_invalid_file;
         if (history) {
             options.backup_at_file_format_change = m_config.backup_at_file_format_change;
 #ifdef __EMSCRIPTEN__
@@ -496,7 +497,8 @@ bool RealmCoordinator::open_db()
 #endif
         }
         else {
-            m_db = DB::create(m_config.path, true, options);
+            options.no_create = true;
+            m_db = DB::create(m_config.path, options);
         }
     }
     catch (realm::FileFormatUpgradeRequired const&) {

--- a/src/realm/object-store/shared_realm.hpp
+++ b/src/realm/object-store/shared_realm.hpp
@@ -184,6 +184,13 @@ struct RealmConfig {
     // everything can be done deterministically on one thread, and
     // speeds up tests that don't need notifications.
     bool automatic_change_notifications = true;
+
+    // For internal use and should not be exposed by SDKs.
+    //
+    // If the file is invalid or can't be decrypted with the given encryption
+    // key, clear it and reinitialize it as a new file. This is used for the
+    // sync metadata realm which is automatically deleted if it can't be used.
+    bool clear_on_invalid_file = false;
 };
 
 class Realm : public std::enable_shared_from_this<Realm> {

--- a/src/realm/object-store/sync/impl/sync_metadata.cpp
+++ b/src/realm/object-store/sync/impl/sync_metadata.cpp
@@ -527,12 +527,7 @@ std::shared_ptr<Realm> SyncMetadataManager::try_get_realm() const
 std::shared_ptr<Realm> SyncMetadataManager::open_realm(bool should_encrypt, bool caller_supplied_key)
 {
     if (caller_supplied_key || !should_encrypt || !REALM_PLATFORM_APPLE) {
-        if (auto realm = try_get_realm())
-            return realm;
-
-        // Encryption key changed, so delete the existing metadata realm and
-        // recreate it
-        util::File::remove(m_metadata_config.path);
+        m_metadata_config.clear_on_invalid_file = true;
         return get_realm();
     }
 
@@ -560,8 +555,8 @@ std::shared_ptr<Realm> SyncMetadataManager::open_realm(bool should_encrypt, bool
             return realm;
 
         // We weren't able to open the existing file with either the stored key
-        // or no key, so just delete it.
-        util::File::remove(m_metadata_config.path);
+        // or no key, so just recreate it
+        m_metadata_config.clear_on_invalid_file = true;
     }
 
     // We now have no metadata Realm. If we don't have an existing stored key,

--- a/test/benchmark-common-tasks/main.cpp
+++ b/test/benchmark-common-tasks/main.cpp
@@ -2021,7 +2021,7 @@ struct BenchmarkNonInitiatorOpen : Benchmark {
 
     DBRef do_open()
     {
-        return DB::create(*path, false, DBOptions(m_durability, m_encryption_key));
+        return DB::create(*path, DBOptions(m_durability, m_encryption_key));
     }
 
     void before_all(DBRef)
@@ -2502,7 +2502,7 @@ void run_benchmark(BenchmarkResults& results, bool force_full = false)
         realm::test_util::DBTestPathGuard realm_path(
             test_util::get_test_path("benchmark_common_tasks_" + ident, ".realm"));
         DBRef group;
-        group = DB::create(realm_path, false, DBOptions(level, key));
+        group = DB::create(realm_path, DBOptions(level, key));
         benchmark.before_all(group);
 
         // Warm-up and initial measuring:

--- a/test/test_client_reset.cpp
+++ b/test/test_client_reset.cpp
@@ -975,7 +975,8 @@ TEST(ClientReset_NoChanges)
     db->write_copy(path_backup, nullptr);
     DBOptions options;
     options.is_immutable = true;
-    auto backup_db = DB::create(path_backup, true, options);
+    options.no_create = true;
+    auto backup_db = DB::create(path_backup, options);
 
     const ClientResyncMode modes[] = {ClientResyncMode::Recover, ClientResyncMode::DiscardLocal,
                                       ClientResyncMode::RecoverOrDiscard};

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -5195,7 +5195,7 @@ TEST(LangBindHelper_SessionHistoryConsistency)
     // session participants must still agree
     {
         // No history
-        DBRef sg = DB::create(path, false, DBOptions(crypt_key()));
+        DBRef sg = DB::create(path, DBOptions(crypt_key()));
 
         // Out-of-Realm history
         std::unique_ptr<Replication> hist = realm::make_in_realm_history();
@@ -5224,7 +5224,7 @@ TEST(LangBindHelper_InRealmHistory_Upgrade)
     SHARED_GROUP_TEST_PATH(path_2);
     {
         // No history
-        DBRef sg = DB::create(path_2, false, DBOptions(crypt_key()));
+        DBRef sg = DB::create(path_2, DBOptions(crypt_key()));
         WriteTransaction wt(sg);
         wt.commit();
     }
@@ -5249,7 +5249,7 @@ TEST(LangBindHelper_InRealmHistory_Downgrade)
     }
     {
         // No history
-        CHECK_THROW(DB::create(path, false, DBOptions(crypt_key())), IncompatibleHistories);
+        CHECK_THROW(DB::create(path, DBOptions(crypt_key())), IncompatibleHistories);
     }
 }
 

--- a/test/test_upgrade_database.cpp
+++ b/test/test_upgrade_database.cpp
@@ -83,12 +83,13 @@ TEST_IF(Upgrade_DatabaseWithCallback, REALM_MAX_BPNODE_SIZE == 1000)
 
     bool did_upgrade = false;
     DBOptions options;
+    options.no_create = true;
     options.upgrade_callback = [&](int old_version, int new_version) {
         did_upgrade = true;
         CHECK_EQUAL(old_version, 20);
         CHECK_EQUAL(new_version, Group::get_current_file_format_version());
     };
-    DB::create(temp_copy, true, options);
+    DB::create(temp_copy, options);
     CHECK(did_upgrade);
 }
 
@@ -102,10 +103,11 @@ TEST_IF(Upgrade_DatabaseWithCallbackWithException, REALM_MAX_BPNODE_SIZE == 1000
 
     // Callback that throws should revert the upgrade
     DBOptions options;
+    options.no_create = true;
     options.upgrade_callback = [&](int, int) {
         throw 123;
     };
-    CHECK_THROW(DB::create(temp_copy, true, options), int);
+    CHECK_THROW(DB::create(temp_copy, options), int);
 
     // Callback should be triggered here because the file still needs to be upgraded
     bool did_upgrade = false;
@@ -114,12 +116,12 @@ TEST_IF(Upgrade_DatabaseWithCallbackWithException, REALM_MAX_BPNODE_SIZE == 1000
         CHECK_EQUAL(old_version, 20);
         CHECK_EQUAL(new_version, Group::get_current_file_format_version());
     };
-    DB::create(temp_copy, true, options);
+    DB::create(temp_copy, options);
     CHECK(did_upgrade);
 
     // Callback should not be triggered here because the file is already upgraded
     did_upgrade = false;
-    DB::create(temp_copy, true, options);
+    DB::create(temp_copy, options);
     CHECK_NOT(did_upgrade);
 }
 


### PR DESCRIPTION
This solves some locking problems in multi-process scenarios. The flow of checking if the key is valid, deleting the file if not, and then recreating the file if needed needs to be done with an exclusive lock on the file held. This can't be done with DB::call_with_lock() because there isn't a good way to initialize the new file from within the call_with_lock() callback, and instead needs to be pushed into the file initialization guarded by the control mutex.

This maps and reads from the file before the call to `note_reader_start()`. I think this is fine because it's just validating the header and then unmapping, but I'm not completely sure?