### PR TITLE
Inlining main getters for ArrayEncode 

### DIFF
--- a/src/realm/alloc_slab.cpp
+++ b/src/realm/alloc_slab.cpp
@@ -300,7 +300,7 @@ SlabAlloc::FreeBlock* SlabAlloc::pop_freelist_entry(FreeList list)
 
 void SlabAlloc::FreeBlock::unlink()
 {
-    REALM_ASSERT(next != nullptr && prev != nullptr);
+    REALM_ASSERT_DEBUG(next != nullptr && prev != nullptr);
     auto _next = next;
     auto _prev = prev;
     _next->prev = prev;
@@ -364,8 +364,8 @@ void SlabAlloc::mark_allocated(FreeBlock* entry)
     auto bb = bb_before(entry);
     REALM_ASSERT_EX(bb->block_after_size > 0, bb->block_after_size, get_file_path_for_assertions());
     auto bb2 = bb_after(entry);
-    REALM_ASSERT_EX(bb2->block_before_size > 0, bb2->block_before_size, get_file_path_for_assertions());
     bb->block_after_size = 0 - bb->block_after_size;
+    REALM_ASSERT_EX(bb2->block_before_size > 0, bb2->block_before_size, get_file_path_for_assertions());
     bb2->block_before_size = 0 - bb2->block_before_size;
 }
 
@@ -387,6 +387,7 @@ SlabAlloc::FreeBlock* SlabAlloc::allocate_block(int size)
     FreeBlock* remaining = break_block(block, size);
     if (remaining)
         push_freelist_entry(remaining);
+    REALM_ASSERT_EX(size_from_block(block) >= size, size_from_block(block), size, get_file_path_for_assertions());
     auto block_before = bb_before(block);
     REALM_ASSERT_EX(block_before && block_before->block_after_size >= size, block_before,
                     get_file_path_for_assertions());

--- a/src/realm/array.cpp
+++ b/src/realm/array.cpp
@@ -745,12 +745,17 @@ bool Array::try_decode()
 
 int64_t Array::get_encoded(size_t ndx) const noexcept
 {
-    return m_encoder.get(*this, ndx);
+    return m_encoder.get(ndx);
 }
 
 void Array::set_encoded(size_t ndx, int64_t val)
 {
-    m_encoder.set_direct(*this, ndx, val);
+    m_encoder.set_direct(ndx, val);
+}
+
+void Array::get_chunk_encoded(size_t ndx, int64_t res[8]) const noexcept
+{
+    m_encoder.get_chunk(ndx, res);
 }
 
 size_t Array::calc_aligned_byte_size(size_t size, int width)
@@ -986,11 +991,6 @@ void Array::get_chunk(size_t ndx, int64_t res[8]) const noexcept
 #endif
 }
 
-void Array::get_chunk_encoded(size_t ndx, int64_t res[8]) const noexcept
-{
-    m_encoder.get_chunk(*this, ndx, res);
-}
-
 template <>
 void Array::get_chunk<0>(size_t ndx, int64_t res[8]) const noexcept
 {
@@ -1159,7 +1159,7 @@ int_fast64_t Array::get(const char* header, size_t ndx) noexcept
     if (wtype_is_extended(header)) {
         static ArrayEncode encoder;
         encoder.init(header);
-        return encoder.get(NodeHeader::get_data_from_header(header), ndx);
+        return encoder.get(ndx);
     }
 
     auto sz = get_size_from_header(header);

--- a/src/realm/array.cpp
+++ b/src/realm/array.cpp
@@ -1142,12 +1142,16 @@ size_t Array::upper_bound_int(int64_t value) const noexcept
 
 size_t Array::lower_bound_int_encoded(int64_t value) const noexcept
 {
-    return lower_bound(m_data, m_size, value, m_encoder);
+    static impl::EncodedFetcher<ArrayEncode> encoder;
+    encoder.ptr = &m_encoder;
+    return lower_bound(m_data, m_size, value, encoder);
 }
 
 size_t Array::upper_bound_int_encoded(int64_t value) const noexcept
 {
-    return upper_bound(m_data, m_size, value, m_encoder);
+    static impl::EncodedFetcher<ArrayEncode> encoder;
+    encoder.ptr = &m_encoder;
+    return upper_bound(m_data, m_size, value, encoder);
 }
 
 int_fast64_t Array::get(const char* header, size_t ndx) noexcept

--- a/src/realm/array_encode.cpp
+++ b/src/realm/array_encode.cpp
@@ -228,7 +228,6 @@ void ArrayEncode::init(const char* h)
         m_v_mask = 1ULL << (m_v_width - 1);
         m_MSBs = populate(m_v_width, m_v_mask);
         m_vtable = &VTableForPacked::vtable;
-        // here init a new iterator
         const auto data = (uint64_t*)NodeHeader::get_data_from_header(h);
         m_data_iterator = bf_iterator(data, 0, m_v_width, m_v_width, 0);
     }
@@ -307,6 +306,28 @@ void ArrayEncode::encode_values(const Array& arr, std::vector<int64_t>& values, 
     }
 #endif
     REALM_ASSERT_DEBUG(indices.size() == sz);
+}
+
+void ArrayEncode::set(char* data, size_t w, size_t ndx, int64_t v) const
+{
+    if (w == 0)
+        realm::set_direct<0>(data, ndx, v);
+    else if (w == 1)
+        realm::set_direct<1>(data, ndx, v);
+    else if (w == 2)
+        realm::set_direct<2>(data, ndx, v);
+    else if (w == 4)
+        realm::set_direct<4>(data, ndx, v);
+    else if (w == 8)
+        realm::set_direct<8>(data, ndx, v);
+    else if (w == 16)
+        realm::set_direct<16>(data, ndx, v);
+    else if (w == 32)
+        realm::set_direct<32>(data, ndx, v);
+    else if (w == 64)
+        realm::set_direct<64>(data, ndx, v);
+    else
+        REALM_UNREACHABLE();
 }
 
 int64_t ArrayEncode::get_packed(size_t ndx) const

--- a/src/realm/array_encode.hpp
+++ b/src/realm/array_encode.hpp
@@ -52,6 +52,8 @@ public:
     inline size_t ndx_field_count() const;
     inline size_t bit_count_per_iteration() const;
     inline size_t ndx_bit_count_per_iteration() const;
+    inline bf_iterator& data_iterator() const;
+    inline bf_iterator& ndx_iterator() const;
 
     // get/set
     inline int64_t get(size_t) const;
@@ -97,7 +99,7 @@ private:
     bool find_all_flex(const Array&, int64_t, size_t, size_t, size_t, QueryStateBase*) const;
 
     // internal impl
-    inline void set(char* data, size_t w, size_t ndx, int64_t v) const;
+    void set(char* data, size_t w, size_t ndx, int64_t v) const;
     size_t flex_encoded_array_size(const std::vector<int64_t>&, const std::vector<size_t>&, size_t&, size_t&) const;
     size_t packed_encoded_array_size(std::vector<int64_t>&, size_t, size_t&) const;
     void encode_values(const Array&, std::vector<int64_t>&, std::vector<size_t>&) const;
@@ -115,6 +117,16 @@ private:
     mutable bf_iterator m_data_iterator;
     mutable bf_iterator m_ndx_iterator;
 };
+
+inline bf_iterator& ArrayEncode::data_iterator() const
+{
+    return m_data_iterator;
+}
+
+inline bf_iterator& ArrayEncode::ndx_iterator() const
+{
+    return m_ndx_iterator;
+}
 
 inline bool ArrayEncode::is_packed() const
 {
@@ -192,28 +204,6 @@ inline uint64_t ArrayEncode::ndx_msb() const
     using Encoding = NodeHeader::Encoding;
     REALM_ASSERT_DEBUG(m_encoding == Encoding::Packed || m_encoding == Encoding::Flex);
     return m_ndx_MSBs;
-}
-
-inline void ArrayEncode::set(char* data, size_t w, size_t ndx, int64_t v) const
-{
-    if (w == 0)
-        realm::set_direct<0>(data, ndx, v);
-    else if (w == 1)
-        realm::set_direct<1>(data, ndx, v);
-    else if (w == 2)
-        realm::set_direct<2>(data, ndx, v);
-    else if (w == 4)
-        realm::set_direct<4>(data, ndx, v);
-    else if (w == 8)
-        realm::set_direct<8>(data, ndx, v);
-    else if (w == 16)
-        realm::set_direct<16>(data, ndx, v);
-    else if (w == 32)
-        realm::set_direct<32>(data, ndx, v);
-    else if (w == 64)
-        realm::set_direct<64>(data, ndx, v);
-    else
-        REALM_UNREACHABLE();
 }
 
 inline int64_t ArrayEncode::get(size_t ndx) const

--- a/src/realm/array_encode.hpp
+++ b/src/realm/array_encode.hpp
@@ -23,6 +23,7 @@
 #include <cstddef>
 #include <vector>
 #include <realm/query_conditions.hpp>
+#include <realm/array_direct.hpp>
 
 namespace realm {
 
@@ -84,7 +85,7 @@ private:
     struct VTableForPacked;
     struct VTableForFlex;
     const VTable* m_vtable = nullptr;
-    Getter m_getter = nullptr;
+    // Getter m_getter = nullptr;
 
     // getting and setting interface specifically for encoding formats
     int64_t get_packed(const Array&, size_t) const;
@@ -116,6 +117,7 @@ private:
     size_t m_v_width = 0, m_v_size = 0, m_ndx_width = 0, m_ndx_size = 0;
     uint64_t m_v_mask = 0, m_ndx_mask = 0;
     uint64_t m_MSBs = 0, m_ndx_MSBs = 0;
+    mutable bf_iterator m_data_iterator;
 };
 
 inline bool ArrayEncode::is_packed() const
@@ -200,8 +202,8 @@ inline int64_t ArrayEncode::get(const Array& arr, size_t ndx) const
 {
     REALM_ASSERT_DEBUG(is_packed() || is_flex());
     REALM_ASSERT_DEBUG(m_vtable->m_getter);
-    return (this->*m_getter)(arr, ndx);
-    // return (this->*(m_vtable->m_getter))(arr, ndx);
+    // return (this->*m_getter)(arr, ndx);
+    return (this->*(m_vtable->m_getter))(arr, ndx);
 }
 
 inline int64_t ArrayEncode::get(const char* data, size_t ndx) const

--- a/src/realm/array_flex.cpp
+++ b/src/realm/array_flex.cpp
@@ -68,64 +68,6 @@ void ArrayFlex::copy_data(const Array& arr, const std::vector<int64_t>& values,
     }
 }
 
-void ArrayFlex::set_direct(const Array& arr, size_t ndx, int64_t value) const
-{
-    const auto v_width = arr.m_encoder.width();
-    const auto v_size = arr.m_encoder.v_size();
-    const auto ndx_width = arr.m_encoder.ndx_width();
-    const auto ndx_size = arr.m_encoder.ndx_size();
-    REALM_ASSERT_DEBUG(ndx < ndx_size);
-    auto data = (uint64_t*)arr.m_data;
-    uint64_t offset = v_size * v_width;
-    bf_iterator it_index{data, static_cast<size_t>(offset + (ndx * ndx_width)), ndx_width, ndx_size, 0};
-    bf_iterator it_value{data, static_cast<size_t>(*it_index * v_width), v_width, v_width, 0};
-    it_value.set_value(value);
-}
-
-int64_t ArrayFlex::get(const Array& arr, size_t ndx) const
-{
-    REALM_ASSERT_DEBUG(arr.is_attached());
-    REALM_ASSERT_DEBUG(arr.is_encoded());
-    return get(arr.m_data, ndx, arr.get_encoder());
-}
-
-int64_t ArrayFlex::get(const char* data, size_t ndx, const ArrayEncode& encoder) const
-{
-    const auto v_width = encoder.width();
-    const auto v_size = encoder.v_size();
-    const auto ndx_width = encoder.ndx_width();
-    const auto ndx_size = encoder.ndx_size();
-    const auto mask = encoder.width_mask();
-    return do_get((uint64_t*)data, ndx, v_width, ndx_width, v_size, ndx_size, mask);
-}
-
-int64_t ArrayFlex::do_get(uint64_t* data, size_t ndx, size_t v_width, size_t ndx_width, size_t v_size,
-                          size_t ndx_size, uint64_t mask) const
-{
-    if (ndx >= ndx_size)
-        return realm::not_found;
-    const uint64_t offset = v_size * v_width;
-    const bf_iterator it_index{data, static_cast<size_t>(offset + (ndx * ndx_width)), ndx_width, ndx_width, 0};
-    const bf_iterator it_value{data, static_cast<size_t>(v_width * it_index.get_value()), v_width, v_width, 0};
-    return sign_extend_field_by_mask(mask, it_value.get_value());
-}
-
-void ArrayFlex::get_chunk(const Array& arr, size_t ndx, int64_t res[8]) const
-{
-    REALM_ASSERT_DEBUG(ndx < arr.m_size);
-    auto sz = 8;
-    std::memset(res, 0, sizeof(int64_t) * sz);
-    auto supposed_end = ndx + sz;
-    size_t i = ndx;
-    size_t index = 0;
-    for (; i < supposed_end; ++i) {
-        res[index++] = get(arr, i);
-    }
-    for (; index < 8; ++index) {
-        res[index++] = get(arr, i++);
-    }
-}
-
 bool ArrayFlex::find_all_match(size_t start, size_t end, size_t baseindex, QueryStateBase* state) const
 {
     REALM_ASSERT_DEBUG(state->match_count() < state->limit());

--- a/src/realm/array_flex.hpp
+++ b/src/realm/array_flex.hpp
@@ -66,7 +66,7 @@ private:
 
 inline int64_t ArrayFlex::get(bf_iterator& data_iterator, bf_iterator& ndx_iterator, size_t ndx, uint64_t mask) const
 {
-    ndx_iterator.move(ndx); //, data_iterator.field_size * v_size);
+    ndx_iterator.move(ndx);
     data_iterator.move(*ndx_iterator);
     return sign_extend_field_by_mask(mask, *data_iterator);
 }
@@ -165,21 +165,17 @@ inline bool ArrayFlex::find_linear(const Array& arr, int64_t value, size_t start
         REALM_UNREACHABLE();
     };
 
-    auto data = (uint64_t*)arr.m_data;
     const auto& encoder = arr.get_encoder();
-    const auto offset = encoder.width() * encoder.v_size();
-    const auto v_width = encoder.width();
-    const auto ndx_width = encoder.ndx_width();
-
-    bf_iterator ndx_it((uint64_t*)data, offset, ndx_width, ndx_width, start);
-    bf_iterator val_it((uint64_t*)data, 0, v_width, v_width, *ndx_it);
+    auto& ndx_it = encoder.ndx_iterator();
+    auto& data_it = encoder.data_iterator();
+    ndx_it.move(start);
     while (start < end) {
-        const auto sv = sign_extend_field_by_mask(encoder.width_mask(), *val_it);
+        data_it.move(*ndx_it);
+        const auto sv = sign_extend_field_by_mask(encoder.width_mask(), *data_it);
         if (cmp(sv, value) && !state->match(start + baseindex))
             return false;
         ++start;
         ++ndx_it;
-        val_it.move(*ndx_it);
     }
     return true;
 }

--- a/src/realm/array_flex.hpp
+++ b/src/realm/array_flex.hpp
@@ -41,9 +41,9 @@ public:
     void init_array(char* h, uint8_t flags, size_t v_width, size_t ndx_width, size_t v_size, size_t ndx_size) const;
     void copy_data(const Array&, const std::vector<int64_t>&, const std::vector<size_t>&) const;
     // getters/setters
-    inline int64_t get(const Array&, size_t) const;
+    inline int64_t get(bf_iterator&, const Array&, size_t) const;
     inline int64_t get(const char*, size_t, const ArrayEncode&) const;
-    inline void get_chunk(const Array& h, size_t ndx, int64_t res[8]) const;
+    inline void get_chunk(bf_iterator&, const Array& h, size_t ndx, int64_t res[8]) const;
     inline void set_direct(const Array&, size_t, int64_t) const;
 
     template <typename Cond>
@@ -66,7 +66,7 @@ private:
     inline bool run_parallel_subscan(size_t, size_t, size_t) const;
 };
 
-inline int64_t ArrayFlex::get(const Array& arr, size_t ndx) const
+inline int64_t ArrayFlex::get(bf_iterator&, const Array& arr, size_t ndx) const
 {
     REALM_ASSERT_DEBUG(arr.is_attached());
     REALM_ASSERT_DEBUG(arr.is_encoded());
@@ -93,7 +93,7 @@ inline int64_t ArrayFlex::do_get(uint64_t* data, size_t ndx, size_t v_width, siz
     return sign_extend_field_by_mask(mask, it_value.get_value());
 }
 
-inline void ArrayFlex::get_chunk(const Array& arr, size_t ndx, int64_t res[8]) const
+inline void ArrayFlex::get_chunk(bf_iterator& it, const Array& arr, size_t ndx, int64_t res[8]) const
 {
     REALM_ASSERT_DEBUG(ndx < arr.m_size);
     auto sz = 8;
@@ -102,10 +102,10 @@ inline void ArrayFlex::get_chunk(const Array& arr, size_t ndx, int64_t res[8]) c
     size_t i = ndx;
     size_t index = 0;
     for (; i < supposed_end; ++i) {
-        res[index++] = get(arr, i);
+        res[index++] = get(it, arr, i);
     }
     for (; index < 8; ++index) {
-        res[index++] = get(arr, i++);
+        res[index++] = get(it, arr, i++);
     }
 }
 

--- a/src/realm/array_packed.cpp
+++ b/src/realm/array_packed.cpp
@@ -56,56 +56,6 @@ void ArrayPacked::copy_data(const Array& origin, Array& arr) const
     }
 }
 
-void ArrayPacked::set_direct(const Array& arr, size_t ndx, int64_t value) const
-{
-    REALM_ASSERT_DEBUG(arr.is_encoded());
-    const auto v_width = arr.m_encoder.width();
-    const auto v_size = arr.m_encoder.size();
-    REALM_ASSERT_DEBUG(ndx < v_size);
-    auto data = (uint64_t*)arr.m_data;
-    bf_iterator it_value{data, static_cast<size_t>(ndx * v_width), v_width, v_width, 0};
-    it_value.set_value(value);
-}
-
-int64_t ArrayPacked::get(const Array& arr, size_t ndx) const
-{
-    REALM_ASSERT_DEBUG(arr.is_attached());
-    REALM_ASSERT_DEBUG(arr.is_encoded());
-    return get(arr.m_data, ndx, arr.get_encoder());
-}
-
-int64_t ArrayPacked::get(const char* data, size_t ndx, const ArrayEncode& encode) const
-{
-    return do_get((uint64_t*)data, ndx, encode.width(), encode.size(), encode.width_mask());
-}
-
-int64_t ArrayPacked::do_get(uint64_t* data, size_t ndx, size_t v_width, size_t v_size, uint64_t mask) const
-{
-    if (ndx >= v_size)
-        return realm::not_found;
-    bf_iterator it{data, 0, v_width, v_width, ndx};
-    const auto value = it.get_value();
-    return sign_extend_field_by_mask(mask, value);
-}
-
-void ArrayPacked::get_chunk(const Array& arr, size_t ndx, int64_t res[8]) const
-{
-    const auto v_size = arr.m_size;
-    REALM_ASSERT_DEBUG(ndx < v_size);
-    auto sz = 8;
-    std::memset(res, 0, sizeof(int64_t) * sz);
-    auto supposed_end = ndx + sz;
-    size_t i = ndx;
-    size_t index = 0;
-    // this can be done better, in one go, retrieve both!!!
-    for (; i < supposed_end; ++i) {
-        res[index++] = get(arr, i);
-    }
-    for (; index < 8; ++index) {
-        res[index++] = get(arr, i++);
-    }
-}
-
 bool ArrayPacked::find_all_match(size_t start, size_t end, size_t baseindex, QueryStateBase* state) const
 {
     REALM_ASSERT_DEBUG(state->match_count() < state->limit());

--- a/src/realm/array_packed.hpp
+++ b/src/realm/array_packed.hpp
@@ -37,16 +37,15 @@ public:
     void init_array(char*, uint8_t, size_t, size_t) const;
     void copy_data(const Array&, Array&) const;
     // get or set
-    inline int64_t get(const Array&, size_t) const;
-    inline int64_t get(const char*, size_t, const ArrayEncode&) const;
-    inline void get_chunk(const Array&, size_t, int64_t res[8]) const;
-    inline void set_direct(const Array&, size_t, int64_t) const;
+    inline int64_t get(bf_iterator& it, size_t, uint64_t) const;
+    inline void get_chunk(bf_iterator& it, size_t, uint64_t, int64_t res[8]) const;
+    inline void set_direct(bf_iterator& it, size_t, int64_t, size_t) const;
 
     template <typename Cond>
     inline bool find_all(const Array&, int64_t, size_t, size_t, size_t, QueryStateBase*) const;
 
 private:
-    inline int64_t do_get(uint64_t*, size_t, size_t, size_t, uint64_t) const;
+    inline int64_t do_get(bf_iterator&, size_t, uint64_t) const;
 
     bool find_all_match(size_t start, size_t end, size_t baseindex, QueryStateBase* state) const;
 
@@ -59,22 +58,14 @@ private:
     inline bool run_parallel_scan(size_t width, size_t range) const;
 };
 
-inline int64_t ArrayPacked::get(const Array& arr, size_t ndx) const
+inline int64_t ArrayPacked::get(bf_iterator& it, size_t ndx, uint64_t mask) const
 {
-    REALM_ASSERT_DEBUG(arr.is_attached());
-    REALM_ASSERT_DEBUG(arr.is_encoded());
-    return get(arr.m_data, ndx, arr.get_encoder());
+    return do_get(it, ndx, mask);
 }
 
-inline int64_t ArrayPacked::get(const char* data, size_t ndx, const ArrayEncode& encode) const
+inline int64_t ArrayPacked::do_get(bf_iterator& it, size_t ndx, uint64_t mask) const
 {
-    return do_get((uint64_t*)data, ndx, encode.width(), encode.size(), encode.width_mask());
-}
-
-inline int64_t ArrayPacked::do_get(uint64_t* data, size_t ndx, size_t v_width, size_t v_size, uint64_t mask) const
-{
-    REALM_ASSERT_DEBUG(ndx < v_size);
-    bf_iterator it{data, 0, v_width, v_width, ndx};
+    it.move(ndx);
     return sign_extend_field_by_mask(mask, *it);
 }
 
@@ -109,21 +100,14 @@ inline bool ArrayPacked::find_all(const Array& arr, int64_t value, size_t start,
     return find_parallel<Cond>(arr, value, start, end, baseindex, state);
 }
 
-inline void ArrayPacked::set_direct(const Array& arr, size_t ndx, int64_t value) const
+inline void ArrayPacked::set_direct(bf_iterator& it, size_t ndx, int64_t value, size_t v_width) const
 {
-    const auto v_width = arr.m_encoder.width();
-    const auto v_size = arr.m_encoder.size();
-    REALM_ASSERT_DEBUG(ndx < v_size);
-    REALM_ASSERT_DEBUG(arr.is_encoded());
-    auto data = (uint64_t*)arr.m_data;
-    bf_iterator it_value{data, static_cast<size_t>(ndx * v_width), v_width, v_width, 0};
-    it_value.set_value(value);
+    it.move(0, ndx * v_width);
+    it.set_value(value);
 }
 
-inline void ArrayPacked::get_chunk(const Array& arr, size_t ndx, int64_t res[8]) const
+inline void ArrayPacked::get_chunk(bf_iterator& it, size_t ndx, uint64_t mask, int64_t res[8]) const
 {
-    const auto v_size = arr.m_size;
-    REALM_ASSERT_DEBUG(ndx < v_size);
     auto sz = 8;
     std::memset(res, 0, sizeof(int64_t) * sz);
     auto supposed_end = ndx + sz;
@@ -131,10 +115,10 @@ inline void ArrayPacked::get_chunk(const Array& arr, size_t ndx, int64_t res[8])
     size_t index = 0;
     // this can be done better, in one go, retrieve both!!!
     for (; i < supposed_end; ++i) {
-        res[index++] = get(arr, i);
+        res[index++] = get(it, i, mask);
     }
     for (; index < 8; ++index) {
-        res[index++] = get(arr, i++);
+        res[index++] = get(it, i++, mask);
     }
 }
 
@@ -197,9 +181,11 @@ inline bool ArrayPacked::find_linear(const Array& arr, int64_t value, size_t sta
         if constexpr (std::is_same_v<Cond, Less>)
             return a < b;
     };
-    bf_iterator it((uint64_t*)arr.m_data, 0, arr.m_width, arr.m_width, start);
+
+    bf_iterator it{(uint64_t*)arr.m_data, 0, arr.m_width, arr.m_width, start};
+    const auto mask = arr.get_encoder().width_mask();
     while (start < end) {
-        const auto sv = sign_extend_field_by_mask(arr.get_encoder().width_mask(), *it);
+        const auto sv = sign_extend_field_by_mask(mask, *it);
         if (compare(sv, value) && !state->match(start + baseindex))
             return false;
         ++start;

--- a/src/realm/array_packed.hpp
+++ b/src/realm/array_packed.hpp
@@ -174,15 +174,15 @@ inline bool ArrayPacked::find_linear(const Array& arr, int64_t value, size_t sta
         if constexpr (std::is_same_v<Cond, Less>)
             return a < b;
     };
-
-    bf_iterator it{(uint64_t*)arr.m_data, 0, arr.m_width, arr.m_width, start};
     const auto mask = arr.get_encoder().width_mask();
+    auto& data_it = arr.get_encoder().data_iterator();
+    data_it.move(start);
     while (start < end) {
-        const auto sv = sign_extend_field_by_mask(mask, *it);
+        const auto sv = sign_extend_field_by_mask(mask, *data_it);
         if (compare(sv, value) && !state->match(start + baseindex))
             return false;
         ++start;
-        ++it;
+        ++data_it;
     }
     return true;
 }

--- a/src/realm/array_packed.hpp
+++ b/src/realm/array_packed.hpp
@@ -39,14 +39,12 @@ public:
     // get or set
     inline int64_t get(bf_iterator& it, size_t, uint64_t) const;
     inline void get_chunk(bf_iterator& it, size_t, uint64_t, int64_t res[8]) const;
-    inline void set_direct(bf_iterator& it, size_t, int64_t, size_t) const;
+    inline void set_direct(bf_iterator& it, size_t, int64_t) const;
 
     template <typename Cond>
     inline bool find_all(const Array&, int64_t, size_t, size_t, size_t, QueryStateBase*) const;
 
 private:
-    inline int64_t do_get(bf_iterator&, size_t, uint64_t) const;
-
     bool find_all_match(size_t start, size_t end, size_t baseindex, QueryStateBase* state) const;
 
     template <typename Cond>
@@ -59,11 +57,6 @@ private:
 };
 
 inline int64_t ArrayPacked::get(bf_iterator& it, size_t ndx, uint64_t mask) const
-{
-    return do_get(it, ndx, mask);
-}
-
-inline int64_t ArrayPacked::do_get(bf_iterator& it, size_t ndx, uint64_t mask) const
 {
     it.move(ndx);
     return sign_extend_field_by_mask(mask, *it);
@@ -100,9 +93,9 @@ inline bool ArrayPacked::find_all(const Array& arr, int64_t value, size_t start,
     return find_parallel<Cond>(arr, value, start, end, baseindex, state);
 }
 
-inline void ArrayPacked::set_direct(bf_iterator& it, size_t ndx, int64_t value, size_t v_width) const
+inline void ArrayPacked::set_direct(bf_iterator& it, size_t ndx, int64_t value) const
 {
-    it.move(0, ndx * v_width);
+    it.move(ndx);
     it.set_value(value);
 }
 

--- a/src/realm/utilities.hpp
+++ b/src/realm/utilities.hpp
@@ -69,8 +69,8 @@ typedef SSIZE_T ssize_t;
 
 
 #if defined(REALM_PTR_64) && defined(REALM_X86_OR_X64) && !REALM_WATCHOS
-// #define REALM_COMPILER_SSE // Compiler supports SSE 4.2 through __builtin_ accessors or back-end assembler
-// #define REALM_COMPILER_AVX
+#define REALM_COMPILER_SSE // Compiler supports SSE 4.2 through __builtin_ accessors or back-end assembler
+#define REALM_COMPILER_AVX
 #endif
 
 namespace realm {

--- a/src/realm/utilities.hpp
+++ b/src/realm/utilities.hpp
@@ -69,8 +69,8 @@ typedef SSIZE_T ssize_t;
 
 
 #if defined(REALM_PTR_64) && defined(REALM_X86_OR_X64) && !REALM_WATCHOS
-#define REALM_COMPILER_SSE // Compiler supports SSE 4.2 through __builtin_ accessors or back-end assembler
-#define REALM_COMPILER_AVX
+// #define REALM_COMPILER_SSE // Compiler supports SSE 4.2 through __builtin_ accessors or back-end assembler
+// #define REALM_COMPILER_AVX
 #endif
 
 namespace realm {

--- a/test/test_array.cpp
+++ b/test/test_array.cpp
@@ -1589,7 +1589,7 @@ TEST(DirectBitFields)
         REALM_ASSERT(*it == 0);
         auto it2(it);
         ++it2;
-        *it2 = 127 + 128;
+        it2.set_value(127 + 128);
         REALM_ASSERT(*it == 0);
         ++it;
         REALM_ASSERT(*it == 127);
@@ -1603,7 +1603,7 @@ TEST(DirectBitFields)
         REALM_ASSERT(*it == 127);
         auto it2(it);
         ++it2;
-        *it2 = 42 + 128;
+        it2.set_value(42 + 128);
         REALM_ASSERT(*it == 127);
         ++it;
         REALM_ASSERT(*it == 42);


### PR DESCRIPTION
## What, How & Why?
1. Mainly Inlining array packed and array flex getters and other function table APIs for compressed arrays, marginally better nothing big. 
2. Deleting most of the code related to find_all, adding a single templated function.
3. Adjusted heuristic for flex arrays (width of indices is not really important, it is max 8)
4. Construct the iterators for accessing the data only once (since they will be valid as long as the array is in compressed format)

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed
* [ ] `bindgen/spec.yml`, if public C++ API changed
