### PR TITLE
Work around MSVC arm64 issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Fix an assertion failure "m_lock_info && m_lock_info->m_file.get_path() == m_filename" that appears to be related to opening a Realm while the file is in the process of being closed on another thread ([Swift #8507](https://github.com/realm/realm-swift/issues/8507)).
-* Version 19.39.33523 of MSVC would crash when compiling for arm64 in release mode.
+* Version 19.39.33523 of MSVC would crash when compiling for arm64 in release mode ([PR #7533](https://github.com/realm/realm-core/pull/7533)).
 
 ### Breaking changes
 * None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Fix an assertion failure "m_lock_info && m_lock_info->m_file.get_path() == m_filename" that appears to be related to opening a Realm while the file is in the process of being closed on another thread ([Swift #8507](https://github.com/realm/realm-swift/issues/8507)).
+* Version 19.39.33523 of MSVC would crash when compiling for arm64 in release mode.
 
 ### Breaking changes
 * None.

--- a/src/realm/object-store/index_set.cpp
+++ b/src/realm/object-store/index_set.cpp
@@ -472,11 +472,15 @@ void IndexSet::insert_at(IndexSet const& positions)
     size_t shift = 0;
     while (begin1 != end1 && begin2 != end2) {
         if (*begin1 + shift < *begin2) {
-            builder.push_back(*begin1++ + shift);
+            begin1++;
+            size_t b = *begin1;
+            builder.push_back(b + shift);
         }
         else {
             ++shift;
-            builder.push_back(*begin2++);
+            begin2++;
+            size_t b = *begin2;
+            builder.push_back(b);
         }
     }
     for (; begin1 != end1; ++begin1)
@@ -522,7 +526,9 @@ void IndexSet::shift_for_insert_at(realm::IndexSet const& values)
     size_t shift = 0;
     while (begin1 != end1 && begin2 != end2) {
         if (*begin1 + shift < *begin2) {
-            builder.push_back(*begin1++ + shift);
+            begin1++;
+            size_t b = *begin1;
+            builder.push_back(b + shift);
         }
         else {
             ++shift;
@@ -555,7 +561,9 @@ void IndexSet::erase_at(IndexSet const& positions)
     size_t shift = 0;
     while (begin1 != end1 && begin2 != end2) {
         if (*begin1 < *begin2) {
-            builder.push_back(*begin1++ - shift);
+            begin1++;
+            size_t b = *begin1;
+            builder.push_back(b - shift);
         }
         else if (*begin1 == *begin2) {
             ++shift;

--- a/src/realm/object-store/index_set.cpp
+++ b/src/realm/object-store/index_set.cpp
@@ -472,14 +472,14 @@ void IndexSet::insert_at(IndexSet const& positions)
     size_t shift = 0;
     while (begin1 != end1 && begin2 != end2) {
         if (*begin1 + shift < *begin2) {
-            begin1++;
             size_t b = *begin1;
+            begin1++;
             builder.push_back(b + shift);
         }
         else {
             ++shift;
-            begin2++;
             size_t b = *begin2;
+            begin2++;
             builder.push_back(b);
         }
     }
@@ -526,8 +526,8 @@ void IndexSet::shift_for_insert_at(realm::IndexSet const& values)
     size_t shift = 0;
     while (begin1 != end1 && begin2 != end2) {
         if (*begin1 + shift < *begin2) {
-            begin1++;
             size_t b = *begin1;
+            begin1++;
             builder.push_back(b + shift);
         }
         else {
@@ -561,8 +561,8 @@ void IndexSet::erase_at(IndexSet const& positions)
     size_t shift = 0;
     while (begin1 != end1 && begin2 != end2) {
         if (*begin1 < *begin2) {
-            begin1++;
             size_t b = *begin1;
+            begin1++;
             builder.push_back(b - shift);
         }
         else if (*begin1 == *begin2) {


### PR DESCRIPTION
We've discovered a compiler crash in MSVC version 19.39.33523 when building for arm64 in release mode. The expression `*begin1++` doesn't seem to agree with the compiler and expressing this more verbosely works around it.

## ☑️ ToDos
* [x] 📝 Changelog update
