### PR TITLE
RCORE-2010 Update default base URL to new domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * None.
 
 ### Breaking changes
-* None.
+* Updated default `App::Config::base_url` to be `https://services.cloud.mongodb.com`. ([PR #]())
 
 ### Compatibility
 * Fileformat: Generates files with format v24. Reads and automatically upgrade from fileformat v10. If you want to upgrade from an earlier file format version you will have to use RealmCore v13.x.y or earlier.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * None.
 
 ### Breaking changes
-* Updated default `App::Config::base_url` to be `https://services.cloud.mongodb.com`. ([PR #]())
+* Updated default `App::Config::base_url` to be `https://services.cloud.mongodb.com`. ([PR #7534](https://github.com/realm/realm-core/pull/7534))
 
 ### Compatibility
 * Fileformat: Generates files with format v24. Reads and automatically upgrade from fileformat v10. If you want to upgrade from an earlier file format version you will have to use RealmCore v13.x.y or earlier.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * Fix an assertion failure "m_lock_info && m_lock_info->m_file.get_path() == m_filename" that appears to be related to opening a Realm while the file is in the process of being closed on another thread ([Swift #8507](https://github.com/realm/realm-swift/issues/8507)).
 
 ### Breaking changes
-* Updated default `App::Config::base_url` to be `https://services.cloud.mongodb.com`. ([PR #7534](https://github.com/realm/realm-core/pull/7534))
+* Updated default base URL to be `https://services.cloud.mongodb.com` to support the new domains (was `https://realm.mongodb.com`). ([PR #7534](https://github.com/realm/realm-core/pull/7534))
 
 ### Compatibility
 * Fileformat: Generates files with format v24. Reads and automatically upgrade from fileformat v10. If you want to upgrade from an earlier file format version you will have to use RealmCore v13.x.y or earlier.
@@ -18,6 +18,7 @@
 ### Internals
 * Update libuv used in object store tests from v1.35.0 to v1.48.0 ([PR #7508](https://github.com/realm/realm-core/pull/7508)).
 * Made `set_default_logger` nullable in the bindgen spec.yml (PR [#7515](https://github.com/realm/realm-core/pull/7515)).
+* Added `App::default_base_url()` static accessor for SDKs to retrieve the default base URL from Core. ([PR #7534](https://github.com/realm/realm-core/pull/7534))
 
 ----------------------------------------------
 

--- a/bindgen/spec.yml
+++ b/bindgen/spec.yml
@@ -1244,6 +1244,7 @@ classes:
       all_users: std::vector<SharedSyncUser>
       sync_manager: SharedSyncManager
       subscribers_count: count_t
+      default_base_url: std::string_view
     staticMethods:
       get_app: '(mode: AppCacheMode, config: AppConfig, sync_client_config: SyncClientConfig) -> SharedApp'
       get_cached_app: '(app_id: const std::string&) -> SharedApp'

--- a/bindgen/spec.yml
+++ b/bindgen/spec.yml
@@ -1244,7 +1244,6 @@ classes:
       all_users: std::vector<SharedSyncUser>
       sync_manager: SharedSyncManager
       subscribers_count: count_t
-      default_base_url: std::string_view
     staticMethods:
       get_app: '(mode: AppCacheMode, config: AppConfig, sync_client_config: SyncClientConfig) -> SharedApp'
       get_cached_app: '(app_id: const std::string&) -> SharedApp'

--- a/src/realm/object-store/c_api/app.cpp
+++ b/src/realm/object-store/c_api/app.cpp
@@ -127,7 +127,7 @@ static inline bson::BsonArray parse_ejson_array(const char* serialized)
 
 RLM_API const char* realm_app_get_default_base_url(void) noexcept
 {
-    return app::App::default_base_url.data();
+    return app::App::default_base_url().data();
 }
 
 RLM_API realm_app_credentials_t* realm_app_credentials_new_anonymous(bool reuse_credentials) noexcept

--- a/src/realm/object-store/sync/app.cpp
+++ b/src/realm/object-store/sync/app.cpp
@@ -183,7 +183,7 @@ std::mutex s_apps_mutex;
 namespace realm {
 namespace app {
 
-std::string_view App::default_base_url = "https://realm.mongodb.com";
+std::string_view App::default_base_url = "https://services.cloud.mongodb.com";
 
 App::Config::DeviceInfo::DeviceInfo()
     : platform(util::get_library_platform())
@@ -395,7 +395,7 @@ void App::configure_route(const std::string& host_url, const std::optional<std::
         m_ws_host_url = App::create_ws_host_url(m_host_url);
     }
 
-    // host_url is the url to the server: e.g., https://realm.mongodb.com or https://localhost:9090
+    // host_url is the url to the server: e.g., https://services.cloud.mongodb.com or https://localhost:9090
     // base_route is the baseline client api path: e.g. <host_url>/api/client/v2.0
     m_base_route = util::format("%1%2", m_host_url, s_base_path);
     // app_route is the cloud app URL: <host_url>/api/client/v2.0/app/<app_id>
@@ -412,7 +412,7 @@ void App::configure_route(const std::string& host_url, const std::optional<std::
 // All others => http[s]://<host-url> => ws[s]://<host-url>
 std::string App::create_ws_host_url(const std::string_view host_url)
 {
-    constexpr static std::string_view orig_base_domain = "realm.mongodb.com";
+    constexpr static std::string_view old_base_domain = "realm.mongodb.com";
     constexpr static std::string_view new_base_domain = "services.cloud.mongodb.com";
     const size_t base_len = std::char_traits<char>::length("http://");
 
@@ -428,7 +428,7 @@ std::string App::create_ws_host_url(const std::string_view host_url)
 
     // http[s]://[<region-prefix>]realm.mongodb.com[/<path>] =>
     //     ws[s]://ws.[<region-prefix>]realm.mongodb.com[/<path>]
-    if (host_url.find(orig_base_domain) != std::string_view::npos) {
+    if (host_url.find(old_base_domain) != std::string_view::npos) {
         return util::format("%1ws.%2", prefix, host_url.substr(prefix_len));
     }
     // http[s]://[<region-prefix>]services.cloud.mongodb.com[/<path>] =>

--- a/src/realm/object-store/sync/app.hpp
+++ b/src/realm/object-store/sync/app.hpp
@@ -90,7 +90,8 @@ public:
         DeviceInfo device_info;
     };
 
-    static std::string_view default_base_url;
+    // Returns the default base_url for SDKs to use instead of defining their own
+    static std::string_view default_base_url();
 
     // `enable_shared_from_this` is unsafe with public constructors;
     // use `App::get_app()` instead

--- a/src/realm/object-store/sync/app.hpp
+++ b/src/realm/object-store/sync/app.hpp
@@ -444,18 +444,18 @@ private:
     // The following variables hold the different paths to Atlas, depending on the
     // request being performed
     // Base hostname from config.base_url or update_base_url() for querying location info
-    // (e.g. "https://realm.mongodb.com")
+    // (e.g. "https://services.cloud.mongodb.com")
     std::string m_base_url GUARDED_BY(m_route_mutex);
     // Baseline URL for AppServices and Device Sync requests
-    // (e.g. "https://us-east-1.aws.realm.mongodb.com/api/client/v2.0" or
-    // "wss://ws.us-east-1.aws.realm.mongodb.com/api/client/v2.0")
+    // (e.g. "https://us-east-1.aws.services.cloud.mongodb.com/api/client/v2.0" or
+    // "wss://us-east-1.aws.ws.services.cloud.mongodb.com/api/client/v2.0")
     std::string m_base_route GUARDED_BY(m_route_mutex);
     // URL for app-based AppServices and Device Sync requests using config.app_id
-    // (e.g. "https://us-east-1.aws.realm.mongodb.com/api/client/v2.0/app/<app_id>"
-    // or "wss://ws.us-east-1.aws.realm.mongodb.com/api/client/v2.0/app/<app_id>")
+    // (e.g. "https://us-east-1.aws.services.cloud.mongodb.com/api/client/v2.0/app/<app_id>"
+    // or "wss://us-east-1.aws.ws.services.cloud.mongodb.com/api/client/v2.0/app/<app_id>")
     std::string m_app_route GUARDED_BY(m_route_mutex);
     // URL for app-based AppServices authentication requests (e.g. email/password)
-    // (e.g. "https://us-east-1.aws.realm.mongodb.com/api/client/v2.0/app/<app_id>/auth")
+    // (e.g. "https://us-east-1.aws.services.cloud.mongodb.com/api/client/v2.0/app/<app_id>/auth")
     std::string m_auth_route GUARDED_BY(m_route_mutex);
     // If false, the location info will be updated upon the next AppServices request
     bool m_location_updated GUARDED_BY(m_route_mutex);

--- a/test/object-store/c_api/c_api.cpp
+++ b/test/object-store/c_api/c_api.cpp
@@ -605,7 +605,7 @@ TEST_CASE("C API (non-database)", "[c_api]") {
         CHECK(app_config->app_id == "app_id_123");
         CHECK(app_config->transport == transport);
 
-        CHECK(realm_app_get_default_base_url() == app::App::default_base_url);
+        CHECK(realm_app_get_default_base_url() == app::App::default_base_url());
 
         CHECK(!app_config->base_url);
         realm_app_config_set_base_url(app_config.get(), base_url.c_str());
@@ -695,13 +695,13 @@ TEST_CASE("C API (non-database)", "[c_api]") {
         check_base_url(base_url);
 
         // Reset to the default base url using nullptr
-        update_and_check_base_url(nullptr, app::App::default_base_url);
+        update_and_check_base_url(nullptr, app::App::default_base_url());
 
         // Set to some other base url
         update_and_check_base_url(base_url2.c_str(), base_url2);
 
         // Reset to default base url using empty string
-        update_and_check_base_url("", app::App::default_base_url);
+        update_and_check_base_url("", app::App::default_base_url());
 
         realm_release(sync_user);
         realm_release(token);

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -3992,21 +3992,21 @@ TEST_CASE("app: base_url", "[sync][app][base_url]") {
 
     SECTION("Test app config baseurl") {
         {
-            redir_transport->reset(App::default_base_url);
+            redir_transport->reset(App::default_base_url());
 
             // First time through, base_url is empty; https://services.cloud.mongodb.com is expected
             auto app = app::App::get_app(app::App::CacheMode::Disabled, app_config, sc_config);
             // Location is not requested until first app services request
             CHECK(!redir_transport->location_requested);
             // Initial hostname and ws hostname use base url, but aren't used until location is updated
-            CHECK(app->get_host_url() == App::default_base_url);
-            CHECK(app->get_ws_host_url() == App::create_ws_host_url(App::default_base_url));
+            CHECK(app->get_host_url() == App::default_base_url());
+            CHECK(app->get_ws_host_url() == App::create_ws_host_url(App::default_base_url()));
 
             do_login(app);
             CHECK(redir_transport->location_requested);
-            CHECK(app->get_base_url() == App::default_base_url);
-            CHECK(app->get_host_url() == App::default_base_url);
-            CHECK(app->get_ws_host_url() == App::create_ws_host_url(App::default_base_url));
+            CHECK(app->get_base_url() == App::default_base_url());
+            CHECK(app->get_host_url() == App::default_base_url());
+            CHECK(app->get_ws_host_url() == App::create_ws_host_url(App::default_base_url()));
         }
         {
             // Second time through, base_url is set to https://alternate.someurl.fake is expected
@@ -4030,8 +4030,8 @@ TEST_CASE("app: base_url", "[sync][app][base_url]") {
             // Third time through, base_url is not set, expect https://services.cloud.mongodb.com,
             // since metadata is no longer used
             app_config.base_url = util::none;
-            std::string expected_url = std::string(App::default_base_url);
-            std::string expected_wsurl = App::create_ws_host_url(App::default_base_url);
+            std::string expected_url = std::string(App::default_base_url());
+            std::string expected_wsurl = App::create_ws_host_url(App::default_base_url());
             redir_transport->reset(expected_url);
 
             auto app = app::App::get_app(app::App::CacheMode::Disabled, app_config, sc_config);
@@ -4084,16 +4084,16 @@ TEST_CASE("app: base_url", "[sync][app][base_url]") {
             CHECK(app->get_host_url() == "https://alternate.someurl.fake");
             CHECK(app->get_ws_host_url() == "wss://alternate.someurl.fake");
 
-            redir_transport->reset(App::default_base_url);
+            redir_transport->reset(App::default_base_url());
 
             // Revert the base URL to the default URL value using std::nullopt
             app->update_base_url(std::nullopt, [](util::Optional<app::AppError> error) {
                 CHECK(!error);
             });
             CHECK(redir_transport->location_requested);
-            CHECK(app->get_base_url() == App::default_base_url);
-            CHECK(app->get_host_url() == App::default_base_url);
-            CHECK(app->get_ws_host_url() == App::create_ws_host_url(App::default_base_url));
+            CHECK(app->get_base_url() == App::default_base_url());
+            CHECK(app->get_host_url() == App::default_base_url());
+            CHECK(app->get_ws_host_url() == App::create_ws_host_url(App::default_base_url()));
             // Expected URL is still App::default_base_url
             do_login(app);
 
@@ -4108,16 +4108,16 @@ TEST_CASE("app: base_url", "[sync][app][base_url]") {
             // Expected URL is still "http://some-other.url.fake"
             do_login(app);
 
-            redir_transport->reset(App::default_base_url);
+            redir_transport->reset(App::default_base_url());
 
             // Revert the base URL to the default URL value using the empty string
             app->update_base_url("", [](util::Optional<app::AppError> error) {
                 CHECK(!error);
             });
             CHECK(redir_transport->location_requested);
-            CHECK(app->get_base_url() == App::default_base_url);
-            CHECK(app->get_host_url() == App::default_base_url);
-            CHECK(app->get_ws_host_url() == App::create_ws_host_url(App::default_base_url));
+            CHECK(app->get_base_url() == App::default_base_url());
+            CHECK(app->get_host_url() == App::default_base_url());
+            CHECK(app->get_ws_host_url() == App::create_ws_host_url(App::default_base_url()));
             // Expected URL is still App::default_base_url
             do_login(app);
         }
@@ -5806,7 +5806,7 @@ TEST_CASE("app: shared instances", "[sync][app]") {
 
     auto config2 = base_config;
     config2.app_id = "app1";
-    config2.base_url = std::string(App::default_base_url);
+    config2.base_url = std::string(App::default_base_url());
 
     auto config3 = base_config;
     config3.app_id = "app2";

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -3962,6 +3962,7 @@ TEST_CASE("app: base_url", "[sync][app][base_url]") {
         CHECK(result == "ws://172.0.0.1:9090");
         result = App::create_ws_host_url("https://172.0.0.1:9090");
         CHECK(result == "wss://172.0.0.1:9090");
+        // Old default base url
         result = App::create_ws_host_url("http://realm.mongodb.com");
         CHECK(result == "ws://ws.realm.mongodb.com");
         result = App::create_ws_host_url("https://realm.mongodb.com");
@@ -3974,6 +3975,7 @@ TEST_CASE("app: base_url", "[sync][app][base_url]") {
         CHECK(result == "wss://ws.us-east-1.aws.realm.mongodb.com");
         result = App::create_ws_host_url("https://us-east-1.aws.realm.mongodb.com/some/extra/stuff");
         CHECK(result == "wss://ws.us-east-1.aws.realm.mongodb.com/some/extra/stuff");
+        // New default base url
         result = App::create_ws_host_url("http://services.cloud.mongodb.com");
         CHECK(result == "ws://ws.services.cloud.mongodb.com");
         result = App::create_ws_host_url("https://services.cloud.mongodb.com");
@@ -3992,7 +3994,7 @@ TEST_CASE("app: base_url", "[sync][app][base_url]") {
         {
             redir_transport->reset(App::default_base_url);
 
-            // First time through, base_url is empty; https://realm.mongodb.com is expected
+            // First time through, base_url is empty; https://services.cloud.mongodb.com is expected
             auto app = app::App::get_app(app::App::CacheMode::Disabled, app_config, sc_config);
             // Location is not requested until first app services request
             CHECK(!redir_transport->location_requested);
@@ -4025,8 +4027,8 @@ TEST_CASE("app: base_url", "[sync][app][base_url]") {
             CHECK(app->get_ws_host_url() == "wss://alternate.someurl.fake");
         }
         {
-            // Third time through, base_url is not set, expect https://realm.mongodb.com, since metadata
-            // is no longer used
+            // Third time through, base_url is not set, expect https://services.cloud.mongodb.com,
+            // since metadata is no longer used
             app_config.base_url = util::none;
             std::string expected_url = std::string(App::default_base_url);
             std::string expected_wsurl = App::create_ws_host_url(App::default_base_url);


### PR DESCRIPTION
## What, How & Why?
Updated default base url to `https://services.cloud.mongodb.com`.
The default base url string value can be retrieved using `App::default_base_url()` static accessor or the `realm_app_get_default_base_url()` C_API function.

Fixes #7449

## ☑️ ToDos
* [X] 📝 Changelog update
* [X] 🚦 Tests (or not relevant)
* ~~[ ] C-API, if public C++ API changed~~
* ~~[ ] `bindgen/spec.yml`, if public C++ API changed~~
