### PR TITLE
RCORE-1969 Fix bundled encrypted Realm regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 * App::all_users() included logged out users only if they were logged out while the App instance existed. It now always includes all logged out users. ([PR #7300](https://github.com/realm/realm-core/pull/7300)).
 * Deleting the active user left the active user unset rather than selecting another logged-in user as the active user like logging out and removing users did. ([PR #7300](https://github.com/realm/realm-core/pull/7300)).
 * Fixed `Assertion failed: new_size % (1ULL << m_page_shift) == 0` when opening an encrypted Realm less than 64Mb that was generated on a platform with a different page size than the current platform (a bundled Realm). ([#7322](https://github.com/realm/realm-core/issues/7322), since v13.17.1)
+* Fixed a `DecryptionFailed` exception thrown when opening a small (<4k of data) Realm generated on a device with a page size of 4k if it was bundled and opened on a device with a larger page size.
+* Fixed an issue during a subsequent open of an encrypted Realm for some rare allocation patterns when the top ref was within ~50 bytes of the end of a page. This could manifest as a DecryptionFailed exception or as an assertion: `encrypted_file_mapping.hpp:183: Assertion failed: local_ndx < m_page_state.size()` for some rare allocation patterns. ([#7319](https://github.com/realm/realm-core/issues/7319))
 
 ### Breaking changes
 * The following things have been renamed or moved as part of moving all of the App Services functionality to the app namespace:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,10 @@
 * SyncUser::all_sessions() included sessions in every state *except* for waiting for access token, which was weirdly inconsistent. It now includes all sessions. ([PR #7300](https://github.com/realm/realm-core/pull/7300)).
 * App::all_users() included logged out users only if they were logged out while the App instance existed. It now always includes all logged out users. ([PR #7300](https://github.com/realm/realm-core/pull/7300)).
 * Deleting the active user left the active user unset rather than selecting another logged-in user as the active user like logging out and removing users did. ([PR #7300](https://github.com/realm/realm-core/pull/7300)).
-* Fixed `Assertion failed: new_size % (1ULL << m_page_shift) == 0` when opening an encrypted Realm less than 64Mb that was generated on a platform with a different page size than the current platform (a bundled Realm). ([#7322](https://github.com/realm/realm-core/issues/7322), since v13.17.1)
-* Fixed a `DecryptionFailed` exception thrown when opening a small (<4k of data) Realm generated on a device with a page size of 4k if it was bundled and opened on a device with a larger page size.
-* Fixed an issue during a subsequent open of an encrypted Realm for some rare allocation patterns when the top ref was within ~50 bytes of the end of a page. This could manifest as a DecryptionFailed exception or as an assertion: `encrypted_file_mapping.hpp:183: Assertion failed: local_ndx < m_page_state.size()` for some rare allocation patterns. ([#7319](https://github.com/realm/realm-core/issues/7319))
+* Fixed several issues around encrypted file portability (copying a "bundled" encrypted Realm from one device to another):
+  * Fixed `Assertion failed: new_size % (1ULL << m_page_shift) == 0` when opening an encrypted Realm less than 64Mb that was generated on a platform with a different page size than the current platform. ([#7322](https://github.com/realm/realm-core/issues/7322), since v13.17.1)
+  * Fixed a `DecryptionFailed` exception thrown when opening a small (<4k of data) Realm generated on a device with a page size of 4k if it was bundled and opened on a device with a larger page size (since the beginning).
+  * Fixed an issue during a subsequent open of an encrypted Realm for some rare allocation patterns when the top ref was within ~50 bytes of the end of a page. This could manifest as a DecryptionFailed exception or as an assertion: `encrypted_file_mapping.hpp:183: Assertion failed: local_ndx < m_page_state.size()`. ([#7319](https://github.com/realm/realm-core/issues/7319))
 
 ### Breaking changes
 * The following things have been renamed or moved as part of moving all of the App Services functionality to the app namespace:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * SyncUser::all_sessions() included sessions in every state *except* for waiting for access token, which was weirdly inconsistent. It now includes all sessions. ([PR #7300](https://github.com/realm/realm-core/pull/7300)).
 * App::all_users() included logged out users only if they were logged out while the App instance existed. It now always includes all logged out users. ([PR #7300](https://github.com/realm/realm-core/pull/7300)).
 * Deleting the active user left the active user unset rather than selecting another logged-in user as the active user like logging out and removing users did. ([PR #7300](https://github.com/realm/realm-core/pull/7300)).
+* Fixed `Assertion failed: new_size % (1ULL << m_page_shift) == 0` when opening an encrypted Realm less than 64Mb that was generated on a platform with a different page size than the current platform (a bundled Realm). ([#7322](https://github.com/realm/realm-core/issues/7322), since v13.17.1)
 
 ### Breaking changes
 * The following things have been renamed or moved as part of moving all of the App Services functionality to the app namespace:

--- a/src/realm/alloc.hpp
+++ b/src/realm/alloc.hpp
@@ -154,7 +154,7 @@ public:
 
     static constexpr size_t section_size() noexcept
     {
-        return 1 << section_shift;
+        return 1UL << section_shift;
     }
 
 protected:

--- a/src/realm/alloc_slab.cpp
+++ b/src/realm/alloc_slab.cpp
@@ -74,7 +74,7 @@ size_t SlabAlloc::get_total_slab_size() noexcept
 
 SlabAlloc::SlabAlloc()
 {
-    m_initial_section_size = 1UL << section_shift; // page_size();
+    m_initial_section_size = section_size();
     m_free_space_state = free_space_Clean;
     m_baseline = 0;
 }
@@ -738,7 +738,6 @@ bool SlabAlloc::align_filesize_for_mmap(ref_type top_ref, Config& cfg)
         detach(true); // keep m_file open
         m_file.resize(expected_size);
         m_file.close();
-        size = expected_size;
         return true;
     }
 
@@ -849,7 +848,7 @@ ref_type SlabAlloc::attach_file(const std::string& path, Config& cfg, util::Writ
         if (REALM_UNLIKELY(cfg.read_only))
             throw InvalidDatabase("Read-only access to empty Realm file", path);
 
-        size_t initial_size = page_size(); // m_initial_section_size;
+        size_t initial_size = page_size();
         // exFAT does not allocate a unique id for the file until it is non-empty. It must be
         // valid at this point because File::get_unique_id() is used to distinguish
         // mappings_for_file in the encryption layer. So the prealloc() is required before

--- a/src/realm/alloc_slab.cpp
+++ b/src/realm/alloc_slab.cpp
@@ -884,7 +884,9 @@ ref_type SlabAlloc::attach_file(const std::string& path, Config& cfg, util::Writ
 
     // the file could have been produced on a device with a different
     // page size than our own so don't expect the size to be aligned
-    size = round_up_to_page_size(size);
+    if (cfg.encryption_key && size != 0 && size != round_up_to_page_size(size)) {
+        size = round_up_to_page_size(size);
+    }
     update_reader_view(size);
     REALM_ASSERT(m_mappings.size());
     m_data = m_mappings[0].primary_mapping.get_addr();

--- a/src/realm/alloc_slab.cpp
+++ b/src/realm/alloc_slab.cpp
@@ -881,6 +881,10 @@ ref_type SlabAlloc::attach_file(const std::string& path, Config& cfg, util::Writ
     DetachGuard dg(*this);
 
     reset_free_space_tracking();
+
+    // the file could have been produced on a device with a different
+    // page size than our own so don't expect the size to be aligned
+    size = round_up_to_page_size(size);
     update_reader_view(size);
     REALM_ASSERT(m_mappings.size());
     m_data = m_mappings[0].primary_mapping.get_addr();

--- a/src/realm/util/encrypted_file_mapping.cpp
+++ b/src/realm/util/encrypted_file_mapping.cpp
@@ -161,6 +161,10 @@ size_t check_read(FileDesc fd, off_t pos, void* dst, size_t len)
 
 } // anonymous namespace
 
+// first block is iv data, second page is data
+static_assert(c_min_encrypted_file_size == 2 * block_size,
+              "chaging the block size breaks encrypted file portability");
+
 AESCryptor::AESCryptor(const uint8_t* key)
     : m_rw_buffer(new char[block_size])
     , m_dst_buffer(new char[block_size])

--- a/src/realm/util/encrypted_file_mapping.cpp
+++ b/src/realm/util/encrypted_file_mapping.cpp
@@ -30,6 +30,7 @@
 #include <cstdlib>
 #include <algorithm>
 #include <chrono>
+#include <sstream>
 #include <stdexcept>
 #include <string_view>
 #include <system_error>
@@ -1099,3 +1100,13 @@ File::SizeType data_size_to_encrypted_size(File::SizeType size) noexcept
 }
 } // namespace realm::util
 #endif // REALM_ENABLE_ENCRYPTION
+
+namespace realm::util {
+std::string DecryptionFailed::get_message_with_bt(std::string_view msg)
+{
+    auto bt = Backtrace::capture();
+    std::stringstream ss;
+    bt.print(ss);
+    return util::format("Decryption failed: %1\n%2\n", msg, ss.str());
+}
+} // namespace realm::util

--- a/src/realm/util/encrypted_file_mapping.cpp
+++ b/src/realm/util/encrypted_file_mapping.cpp
@@ -692,7 +692,9 @@ void EncryptedFileMapping::refresh_page(size_t local_page_ndx, size_t required)
                 memset(addr + actual, 0x55, size - actual);
             }
             else {
-                throw DecryptionFailed();
+                size_t fs = to_size_t(File::get_size_static(m_file.fd));
+                throw DecryptionFailed(
+                    util::format("failed to decrypt block %1 in file of size %2", local_page_ndx + m_first_page, fs));
             }
         }
     }

--- a/src/realm/util/encrypted_file_mapping.hpp
+++ b/src/realm/util/encrypted_file_mapping.hpp
@@ -240,13 +240,14 @@ namespace realm::util {
 /// contain valid encrypted data
 struct DecryptionFailed : FileAccessError {
     DecryptionFailed()
-        : FileAccessError(ErrorCodes::DecryptionFailed, "Decryption failed", std::string(), 0)
+        : FileAccessError(ErrorCodes::DecryptionFailed, get_message_with_bt(""), std::string(), 0)
     {
     }
     DecryptionFailed(const std::string& msg)
-        : FileAccessError(ErrorCodes::DecryptionFailed, util::format("Decryption failed: '%1'", msg), std::string())
+        : FileAccessError(ErrorCodes::DecryptionFailed, get_message_with_bt(msg), std::string())
     {
     }
+    static std::string get_message_with_bt(std::string_view msg);
 };
 } // namespace realm::util
 

--- a/src/realm/util/encrypted_file_mapping.hpp
+++ b/src/realm/util/encrypted_file_mapping.hpp
@@ -170,7 +170,8 @@ private:
 
 inline size_t EncryptedFileMapping::get_offset_of_address(const void* addr) const
 {
-    return reinterpret_cast<size_t>(addr) & ((1 << m_page_shift) - 1);
+    REALM_ASSERT_3(reinterpret_cast<size_t>(addr), >=, reinterpret_cast<size_t>(m_addr));
+    return (reinterpret_cast<size_t>(addr) - reinterpret_cast<size_t>(m_addr)) & ((1ULL << m_page_shift) - 1);
 }
 
 inline size_t EncryptedFileMapping::get_local_index_of_address(const void* addr, size_t offset) const

--- a/src/realm/util/file.cpp
+++ b/src/realm/util/file.cpp
@@ -412,7 +412,7 @@ std::string make_temp_file(const char* prefix)
 
 size_t page_size()
 {
-    return cached_page_size;
+    return cached_page_size.load(std::memory_order::memory_order_relaxed);
 }
 
 OnlyForTestingPageSizeChange::OnlyForTestingPageSizeChange(size_t new_page_size)

--- a/src/realm/util/file.cpp
+++ b/src/realm/util/file.cpp
@@ -49,6 +49,7 @@
 using namespace realm::util;
 
 namespace {
+constexpr size_t c_min_supported_page_size = 4096;
 size_t get_page_size()
 {
 #ifdef _WIN32
@@ -60,7 +61,7 @@ size_t get_page_size()
 #else
     long size = sysconf(_SC_PAGESIZE);
 #endif
-    REALM_ASSERT(size > 0 && size % 4096 == 0);
+    REALM_ASSERT(size > 0 && size % c_min_supported_page_size == 0);
     return static_cast<size_t>(size);
 }
 

--- a/src/realm/util/file.hpp
+++ b/src/realm/util/file.hpp
@@ -114,6 +114,10 @@ std::string make_temp_file(const char* prefix);
 
 size_t page_size();
 
+struct OnlyForTestingPageSizeChange {
+    OnlyForTestingPageSizeChange(size_t new_page_size);
+    ~OnlyForTestingPageSizeChange();
+};
 
 /// This class provides a RAII abstraction over the concept of a file
 /// descriptor (or file handle).

--- a/src/realm/util/file_mapper.cpp
+++ b/src/realm/util/file_mapper.cpp
@@ -48,7 +48,6 @@
 #include <sstream>
 #include <regex>
 #include <thread>
-#include <iostream>
 
 #include <realm/util/file.hpp>
 #include <realm/util/errno.hpp>

--- a/src/realm/util/file_mapper.cpp
+++ b/src/realm/util/file_mapper.cpp
@@ -48,6 +48,7 @@
 #include <sstream>
 #include <regex>
 #include <thread>
+#include <iostream>
 
 #include <realm/util/file.hpp>
 #include <realm/util/errno.hpp>
@@ -484,14 +485,14 @@ SharedFileInfo* get_file_info_for_file(File& file)
         return it->info.get();
 }
 
-
 namespace {
 EncryptedFileMapping* add_mapping(void* addr, size_t size, const FileAttributes& file, size_t file_offset)
 {
     size_t fs = to_size_t(File::get_size_static(file.fd));
-    if (fs > 0 && fs < page_size())
+    if (fs > 0 && fs < c_min_encrypted_file_size)
         throw DecryptionFailed(
-            util::format("file size %1 is less than page size of %2 for '%3'", fs, page_size(), file.path));
+            util::format("file size %1 is less than the minimum encrypted file size of %2 for '%3'", fs,
+                         c_min_encrypted_file_size, file.path));
 
     LockGuard lock(mapping_mutex);
 

--- a/src/realm/util/file_mapper.cpp
+++ b/src/realm/util/file_mapper.cpp
@@ -128,7 +128,6 @@ int64_t fetch_value_in_file(const std::string& fname, const char* scan_pattern)
     return PageReclaimGovernor::no_match;
 }
 
-
 /* Default reclaim governor
  *
  */
@@ -491,7 +490,8 @@ EncryptedFileMapping* add_mapping(void* addr, size_t size, const FileAttributes&
 {
     size_t fs = to_size_t(File::get_size_static(file.fd));
     if (fs > 0 && fs < page_size())
-        throw DecryptionFailed();
+        throw DecryptionFailed(
+            util::format("file size %1 is less than page size of %2 for '%3'", fs, page_size(), file.path));
 
     LockGuard lock(mapping_mutex);
 

--- a/src/realm/util/file_mapper.hpp
+++ b/src/realm/util/file_mapper.hpp
@@ -200,6 +200,7 @@ File::SizeType encrypted_size_to_data_size(File::SizeType size) noexcept;
 File::SizeType data_size_to_encrypted_size(File::SizeType size) noexcept;
 
 size_t round_up_to_page_size(size_t size) noexcept;
+
 } // namespace util
 } // namespace realm
 #endif

--- a/test/test_alloc.cpp
+++ b/test/test_alloc.cpp
@@ -325,6 +325,10 @@ NONCONCURRENT_TEST_IF(Alloc_MapFailureRecovery, _impl::SimulatedFailure::is_enab
     Group().write(path);
 
     SlabAlloc::Config cfg;
+    // mimic a DB initiating a session
+    cfg.is_shared = true;
+    cfg.session_initiator = true;
+
     SlabAlloc alloc;
 
     { // Initial Header mapping fails
@@ -350,19 +354,26 @@ NONCONCURRENT_TEST_IF(Alloc_MapFailureRecovery, _impl::SimulatedFailure::is_enab
         _impl::SimulatedFailure::prime_mmap(nullptr);
         auto top_ref = alloc.attach_file(path, cfg);
         CHECK(alloc.is_attached());
+        // the internal baseline has capacity for a page but it is not entirely backed by a file (yet)
+        CHECK_EQUAL(alloc.get_baseline(), page_size);
         // file has not (yet) been expanded to match:
-        CHECK(alloc.get_baseline() != page_size);
+        CHECK_NOT_EQUAL(alloc.get_file_size(), page_size);
         // convert before aligning file size
         alloc.convert_from_streaming_form(top_ref);
         // file is expanded:
         CHECK(alloc.align_filesize_for_mmap(top_ref, cfg));
+        CHECK(!alloc.is_attached());
         // and consequently needs to be reattached:
         alloc.detach();
         alloc.attach_file(path, cfg);
         alloc.init_mapping_management(1);
+        CHECK(alloc.is_attached());
+        // now both the allocator and the backing file agree on the capacity
+        CHECK_EQUAL(alloc.get_baseline(), page_size);
+        CHECK_EQUAL(alloc.get_file_size(), page_size);
     }
 
-    { // Extendind the first mapping
+    { // Extending the first mapping
         const auto initial_baseline = alloc.get_baseline();
         const auto initial_version = alloc.get_mapping_version();
         const char* initial_translated = alloc.translate(1000);

--- a/test/test_alloc.cpp
+++ b/test/test_alloc.cpp
@@ -354,8 +354,13 @@ NONCONCURRENT_TEST_IF(Alloc_MapFailureRecovery, _impl::SimulatedFailure::is_enab
         _impl::SimulatedFailure::prime_mmap(nullptr);
         auto top_ref = alloc.attach_file(path, cfg);
         CHECK(alloc.is_attached());
-        // the internal baseline has capacity for a page but it is not entirely backed by a file (yet)
-        CHECK_EQUAL(alloc.get_baseline(), page_size);
+        if (cfg.encryption_key) {
+            // the internal baseline has capacity for a page but it is not entirely backed by a file (yet)
+            CHECK_EQUAL(alloc.get_baseline(), page_size);
+        }
+        else {
+            CHECK_NOT_EQUAL(alloc.get_baseline(), page_size);
+        }
         // file has not (yet) been expanded to match:
         CHECK_NOT_EQUAL(alloc.get_file_size(), page_size);
         // convert before aligning file size

--- a/test/test_encrypted_file_mapping.cpp
+++ b/test/test_encrypted_file_mapping.cpp
@@ -324,6 +324,7 @@ TEST(EncryptedFile_IVRefreshing)
 NONCONCURRENT_TEST(EncryptedFile_Portablility)
 {
     TEST_PATH(path);
+    // FIXME: test num_entries= 1. DecryptionFailed() if the file size is less than page_size()
     constexpr size_t num_entries = 5000;
     const char* key = test_util::crypt_key(true);
 

--- a/test/test_encrypted_file_mapping.cpp
+++ b/test/test_encrypted_file_mapping.cpp
@@ -341,7 +341,7 @@ static void check_attach_and_read(const char* key, const std::string& path, size
 
 // This test changes the global page_size() and should not run with other tests.
 // It checks that an encrypted Realm is portable between systems with a different page size
-/*NONCONCURRENT_TEST*/ ONLY(EncryptedFile_Portablility)
+NONCONCURRENT_TEST(EncryptedFile_Portablility)
 {
     const char* key = test_util::crypt_key(true);
     // The idea here is to incrementally increase the allocations in the Realm

--- a/test/test_encrypted_file_mapping.cpp
+++ b/test/test_encrypted_file_mapping.cpp
@@ -348,7 +348,7 @@ NONCONCURRENT_TEST(EncryptedFile_Portablility)
     // such that the top ref written eventually crosses over the block_size and
     // page_size() thresholds. This has caught faulty top_ref + size calculations.
     std::vector<size_t> test_sizes;
-#if false && TEST_DURATION == 0
+#if TEST_DURATION == 0
     test_sizes.resize(100);
     std::iota(test_sizes.begin(), test_sizes.end(), 500);
     // The allocations are not controlled, but at the time of writing this test

--- a/test/test_shared.cpp
+++ b/test/test_shared.cpp
@@ -600,7 +600,6 @@ TEST(Shared_ReadOverRead2)
     CHECK_EQUAL(table2->get_object(0).get<int64_t>("col"), 1);
 }
 
-// FIXME: test more sizes before compact
 TEST(Shared_EncryptedRemap)
 {
     // Attempts to trigger code coverage in util::mremap() for the case where the file is encrypted.

--- a/test/test_shared.cpp
+++ b/test/test_shared.cpp
@@ -600,7 +600,7 @@ TEST(Shared_ReadOverRead2)
     CHECK_EQUAL(table2->get_object(0).get<int64_t>("col"), 1);
 }
 
-
+// FIXME: test more sizes before compact
 TEST(Shared_EncryptedRemap)
 {
     // Attempts to trigger code coverage in util::mremap() for the case where the file is encrypted.


### PR DESCRIPTION
Fixes https://github.com/realm/realm-core/issues/7322

This is also suspected to fix:  https://github.com/realm/realm-core/issues/7252, https://github.com/realm/realm-core/issues/7319, https://github.com/realm/realm-core/issues/6752

There was a regression due to the changes in https://github.com/realm/realm-core/pull/6807. Those changes moved the file expansion out of `SlabAlloc::attach_file` but this had the side effect that the actual file size is used when updating the reader view rather than using a multiple of the page_size(). 

Users reported this regression since swift [v10.42.0](https://github.com/realm/realm-swift/blob/master/CHANGELOG.md#10420-release-notes-2023-07-30) which matches the release of the change in core version v13.17.1.

I had originally thought that we did not support encrypted bundled Realms across devices of different page size, but that does not seem to be a limitation that we have, as the encrypted file layout is actually not reliant on the page size. The page size only affects the in-memory buffers. I'm marking this as a "fix" because users reported that shipping bundled encrypted Realms used to work, though I don't know that we ever actually committed to supporting that. We certainly didn't have any tests for it, and the test that I added turned up a few other related issues.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [x] C-API, if public C++ API changed
* [x] `bindgen/spec.yml`, if public C++ API changed
