### PR TITLE
RCORE-1980 Add unit test and changelog entry for replication bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Fix an assertion failure "m_lock_info && m_lock_info->m_file.get_path() == m_filename" that appears to be related to opening a Realm while the file is in the process of being closed on another thread ([Swift #8507](https://github.com/realm/realm-swift/issues/8507)).
-* Fixed diverging history due to a bug in the replication code when setting default null values ([#7536](https://github.com/realm/realm-core/issues/7536)).
+* Fixed diverging history due to a bug in the replication code when setting default null values (embedded objects included) ([#7536](https://github.com/realm/realm-core/issues/7536)).
 
 ### Breaking changes
 * None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Fix an assertion failure "m_lock_info && m_lock_info->m_file.get_path() == m_filename" that appears to be related to opening a Realm while the file is in the process of being closed on another thread ([Swift #8507](https://github.com/realm/realm-swift/issues/8507)).
+* Fixed diverging history due to a bug in the replication code when setting default null values ([#7536](https://github.com/realm/realm-core/issues/7536)).
 
 ### Breaking changes
 * None.

--- a/src/realm/list.hpp
+++ b/src/realm/list.hpp
@@ -928,11 +928,10 @@ inline LnkLst Obj::get_linklist(StringData col_name) const
 template <class T>
 void Lst<T>::clear()
 {
-    auto sz = size();
-    if (Replication* repl = Base::get_replication()) {
-        repl->list_clear(*this);
-    }
-    if (sz > 0) {
+    if (size() > 0) {
+        if (Replication* repl = Base::get_replication()) {
+            repl->list_clear(*this);
+        }
         do_clear();
         bump_content_version();
     }

--- a/test/object-store/object.cpp
+++ b/test/object-store/object.cpp
@@ -2023,10 +2023,10 @@ TEST_CASE("object") {
 
         Obj obj = object1.get_obj();
         REQUIRE(obj.get<Int>("_id") == 7); // pk
-        REQUIRE(obj.get_linklist("array 1").size() == 1);
+        REQUIRE(obj.get_linklist("array 1").size() == 2);
         REQUIRE(obj.get<Int>("int 1") == 1); // non-default from r1
         REQUIRE(obj.get<Int>("int 2") == 2); // non-default from r2
-        REQUIRE(obj.get_linklist("array 2").size() == 1);
+        REQUIRE(obj.get_linklist("array 2").size() == 2);
     }
 #endif
 }


### PR DESCRIPTION
## What, How & Why?
We have a replication bug when setting default null values (embedded objects included). This used to generate two sync instructions, and the first one did **not** take is_default into account. If it is then merged with an instruction with is_default = true, it wins the conflict resolution (default values lose to non-default values) when maybe it shouldn't have (when both are default values, the timestamp is used as a tiebreak).

The bug was fixed in #7523 (among other things), and this PR adds a unit test for it an updates the changelog.

This PR also **reverts** replicating the clear instruction on empty lists (introduced in #7523). There is no need for a changelog entry since it was not released.

## ☑️ ToDos
* [X] 📝 Changelog update
* [X] 🚦 Tests (or not relevant)
* ~~[ ] C-API, if public C++ API changed~~
* ~~[ ] `bindgen/spec.yml`, if public C++ API changed~~
