### PR TITLE
RCORE-2062 Update App debug statements to show final request URL before sending

### DIFF
--- a/src/realm/object-store/sync/app.cpp
+++ b/src/realm/object-store/sync/app.cpp
@@ -1113,6 +1113,8 @@ void App::update_location_and_resend(Request&& request, UniqueFunction<void(cons
             }
             request.url = self->get_host_url() + comp.get_value().request;
 
+            self->log_debug("App: send_request(after location update): %1 %2", httpmethod_to_string(request.method),
+                            request.url);
             // Retry the original request with the updated url
             self->m_config.transport->send_request_to_server(
                 std::move(request), [self = std::move(self), completion = std::move(completion)](
@@ -1158,6 +1160,7 @@ void App::do_request(Request&& request, UniqueFunction<void(const Response& resp
         }
     }
 
+    log_debug("App: do_request: %1 %2", httpmethod_to_string(request.method), request.url);
     // If location info has already been updated, then send the request directly
     m_config.transport->send_request_to_server(
         std::move(request), [self = shared_from_this(), completion = std::move(completion)](
@@ -1194,7 +1197,6 @@ void App::do_authenticated_request(Request&& request, const std::shared_ptr<Sync
     request.headers = get_request_headers(sync_user, request.uses_refresh_token ? RequestTokenType::RefreshToken
                                                                                 : RequestTokenType::AccessToken);
 
-    log_debug("App: do_authenticated_request: %1 %2", httpmethod_to_string(request.method), request.url);
     auto completion_2 = [completion = std::move(completion), request, sync_user,
                          self = shared_from_this()](const Response& response) mutable {
         if (auto error = AppUtils::check_for_errors(response)) {


### PR DESCRIPTION
## What, How & Why?
As was pointed out by customer help ticket [HELP-57538](https://jira.mongodb.org/browse/HELP-57538), the current app "`do_authenticated_request()`" debug is confusing when the server URL location info needs to be updated. When the app is started, the debug output for first app request will potentially show as being sent to the original base URL value instead of the actual server URL.

Updated the App debug output so the request URL is displayed in the `do_request()` function or before sending the request after the location has been updated.

Original debug example:
```
Debug: App: do_authenticated_request: POST https://realm.mongodb.com/api/client/v2.0/app/securehealth-gtcux/functions/call
Debug: App: request location: https://realm.mongodb.com/api/client/v2.0/app/securehealth-gtcux/location
Debug: App: Location info returned for deployment model: LOCAL(US-VA)
Debug: App: update_hostname: https://us-east-1.aws.realm.mongodb.com | wss://ws.us-east-1.aws.realm.mongodb.com | base URL: https://realm.mongodb.com
```

New debug example:
```
Realm.App - App: register_email: realm_tests_do_autoverifyInPVTzaiCy@BSdEOhECfJ.com
Realm.App - App: request location: http://localhost:9090/api/client/v2.0/app/test-ibrzp/location
Realm.App - App: Location info returned for deployment model: GLOBAL(US-VA)
Realm.App - App: update_hostname: http://localhost:9090 | ws://localhost:9090 | base URL: http://localhost:9090
Realm.App - App: send_request(after location update): POST http://localhost:9090/api/client/v2.0/app/test-ibrzp/auth/providers/local-userpass/register
Realm.App - App: log_in_with_credentials: app_id: test-ibrzp
Realm.App - App: version info: platform: macOS  version: Object Store Platform Version Blah - sdk: An sdk name - sdk version: An sdk version - core version: 14.4.1
Realm.App - App: do_request: POST http://localhost:9090/api/client/v2.0/app/test-ibrzp/auth/providers/local-userpass/login
Realm.App - App: do_request: GET http://localhost:9090/api/client/v2.0/auth/profile
```

Fixes #7538

## ☑️ ToDos
* ~~[ ] 📝 Changelog update~~
* ~~[ ] 🚦 Tests (or not relevant)~~
* ~~[ ] C-API, if public C++ API changed~~
* ~~[ ] `bindgen/spec.yml`, if public C++ API changed~~
