### PR TITLE
Use the "clang-format" provided by the system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Update libuv used in object store tests from v1.35.0 to v1.48.0 ([PR #7508](https://github.com/realm/realm-core/pull/7508)).
 * Made `set_default_logger` nullable in the bindgen spec.yml (PR [#7515](https://github.com/realm/realm-core/pull/7515)).
 * Added `App::default_base_url()` static accessor for SDKs to retrieve the default base URL from Core. ([PR #7534](https://github.com/realm/realm-core/pull/7534))
+* (bindgen) Remove dependency on the `clang-format` package and rely on a binary provided by the system instead.
 
 ----------------------------------------------
 

--- a/bindgen/src/formatter.ts
+++ b/bindgen/src/formatter.ts
@@ -67,4 +67,4 @@ export function format(formatter: Formatter, cwd: string, filePaths: string[]): 
   }
 }
 
-export const clangFormat = createCommandFormatter("clang", ["npx", "clang-format", "-i"]);
+export const clangFormat = createCommandFormatter("clang", ["clang-format", "-i"]);

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "chalk": "^4.1.2",
     "change-case": "^4.1.2",
     "chevrotain": "^10.4.0",
-    "clang-format": "^1.8.0",
     "commander": "^11.1.0",
     "debug": "^4.3.4",
     "typescript-json-schema": "^0.55.0",


### PR DESCRIPTION
## What, How & Why?

The `clang-format` package is unmaintained https://github.com/angular/clang-format/issues/82#issuecomment-1748482685 and it doesn't publish arm64 based binaries. I suggest we remove the dependency and rely on the binary provided by the system instead.

## ☑️ ToDos
* [x] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed
* [ ] `bindgen/spec.yml`, if public C++ API changed
