### PR TITLE
Follow-up to make #7124 target iPhone 11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Fix an assertion failure "m_lock_info && m_lock_info->m_file.get_path() == m_filename" that appears to be related to opening a Realm while the file is in the process of being closed on another thread ([Swift #8507](https://github.com/realm/realm-swift/issues/8507)).
 * Fixed diverging history due to a bug in the replication code when setting default null values (embedded objects included) ([#7536](https://github.com/realm/realm-core/issues/7536)).
+* Fixed building for iPhone simulators targeting deployment target 11 ([#7554](https://github.com/realm/realm-core/pull/7554)).
 
 ### Breaking changes
 * Updated default base URL to be `https://services.cloud.mongodb.com` to support the new domains (was `https://realm.mongodb.com`). ([PR #7534](https://github.com/realm/realm-core/pull/7534))

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -2365,10 +2365,10 @@ Status Session::receive_download_message(const DownloadMessage& message)
         return Status::OK();
 
     bool is_flx = m_conn.is_flx_sync_connection();
-    int64_t query_version = is_flx ? message.query_version.value() : 0;
+    int64_t query_version = is_flx ? *message.query_version : 0;
 
     // If this is a PBS connection, then every download message is its own complete batch.
-    bool last_in_batch = is_flx ? message.last_in_batch.value() : true;
+    bool last_in_batch = is_flx ? *message.last_in_batch : true;
     auto batch_state = last_in_batch ? sync::DownloadBatchState::LastInBatch : sync::DownloadBatchState::MoreToCome;
     if (is_steady_state_download_message(batch_state, query_version))
         batch_state = DownloadBatchState::SteadyState;


### PR DESCRIPTION
## What, How & Why?

Trying to build Core for an iphone simulator by invoking:
```
./tools/build-apple-device.sh -p iphonesimulator -c Debug -v 14.4.1 -f -DREALM_BUILD_LIB_ONLY=1
```

yields the following error to me:

```
realm-core/src/realm/sync/noinst/client_impl_base.cpp:2368:60: error: 
      'value' is unavailable: introduced in iOS 12.0
    int64_t query_version = is_flx ? message.query_version.value() : 0;
```

## ☑️ ToDos
* [x] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed
* [ ] `bindgen/spec.yml`, if public C++ API changed
