### PR TITLE
update release notes with new section and add that to the release script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+# NEXT RELEASE
+
+### Enhancements
+* <New feature description> (PR [#????](https://github.com/realm/realm-core/pull/????))
+* None.
+
+### Fixed
+* <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
+* None.
+
+### Breaking changes
+* None.
+
+### Compatibility
+* Fileformat: Generates files with format v24. Reads and automatically upgrade from fileformat v10. If you want to upgrade from an earlier file format version you will have to use RealmCore v13.x.y or earlier.
+
+-----------
+
+### Internals
+* None.
+
+----------------------------------------------
+
 # 14.5.0 Release notes
 
 ### Enhancements

--- a/tools/release-init.sh
+++ b/tools/release-init.sh
@@ -49,5 +49,6 @@ rm "${project_dir}/Package.swift.bak" || exit 1
 RELEASE_HEADER="# $realm_version Release notes" || exit 1
 sed -i.bak -e "1s/.*/$RELEASE_HEADER/" "${project_dir}/CHANGELOG.md" || exit 1
 rm "${project_dir}/CHANGELOG.md.bak" || exit 1
+cat "${project_dir}/doc/CHANGELOG_template.md" "${project_dir}/CHANGELOG.md" > temp_file.md; mv temp_file.md "${project_dir}/CHANGELOG.md"
 
 echo Ready to make "${realm_version}"


### PR DESCRIPTION
The release [process](https://github.com/realm/realm-wiki/wiki/Releasing-Realm-Core) involves generating a new release notes section, but that was a task that was run through our old Jenkins CI system. Now that the [link](https://ci.realm.io/blue/organizations/jenkins/core_release_notes_next/activity) for this task isn't valid we need an alternative. 

This change puts the new section into the "prepare" step which means that there will be an empty section as part of the tag itself, but it also means we don't need to rely on a bot committer as part of a separate step and there is also one less commit in our history (and one less meaningless commit for realm-core-stable to build and verify). I think the extra efficiency is worth the cost of scrolling down a bit in the changelog.