### PR TITLE
RCORE-1900 Make "next launch" metadata actions multiprocess-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Enhancements
 * <New feature description> (PR [#????](https://github.com/realm/realm-core/pull/????))
-* None.
+* "Next launch" metadata file actions are now performed in a multi-process safe manner ([#7576](https://github.com/realm/realm-core/pull/7576)).
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)

--- a/src/realm/db.cpp
+++ b/src/realm/db.cpp
@@ -2860,20 +2860,27 @@ DBRef DB::create(BinaryData buffer, bool take_ownership) NO_THREAD_SAFETY_ANALYS
     return retval;
 }
 
-void DB::claim_sync_agent()
+bool DB::try_claim_sync_agent()
 {
     REALM_ASSERT(is_attached());
-    std::unique_lock<InterprocessMutex> lock(m_controlmutex);
+    std::lock_guard lock(m_controlmutex);
     if (m_info->sync_agent_present)
-        throw MultipleSyncAgents{};
+        return false;
     m_info->sync_agent_present = 1; // Set to true
     m_is_sync_agent = true;
+    return true;
+}
+
+void DB::claim_sync_agent()
+{
+    if (!try_claim_sync_agent())
+        throw MultipleSyncAgents{};
 }
 
 void DB::release_sync_agent()
 {
     REALM_ASSERT(is_attached());
-    std::unique_lock<InterprocessMutex> lock(m_controlmutex);
+    std::lock_guard lock(m_controlmutex);
     if (!m_is_sync_agent)
         return;
     REALM_ASSERT(m_info->sync_agent_present);

--- a/src/realm/db.hpp
+++ b/src/realm/db.hpp
@@ -432,6 +432,7 @@ public:
     /// Mark this DB as the sync agent for the file.
     /// \throw MultipleSyncAgents if another DB is already the sync agent.
     void claim_sync_agent();
+    bool try_claim_sync_agent();
     void release_sync_agent();
 
     /// Returns true if there are threads waiting to acquire the write lock, false otherwise.

--- a/src/realm/object-store/impl/realm_coordinator.hpp
+++ b/src/realm/object-store/impl/realm_coordinator.hpp
@@ -228,6 +228,11 @@ public:
         return m_audit_context.get();
     }
 
+    bool try_claim_sync_agent()
+    {
+        return m_db->try_claim_sync_agent();
+    }
+
 private:
     friend Realm::Internal;
     Realm::Config m_config;

--- a/src/realm/object-store/sync/async_open_task.cpp
+++ b/src/realm/object-store/sync/async_open_task.cpp
@@ -23,6 +23,7 @@
 #include <realm/object-store/impl/realm_coordinator.hpp>
 #include <realm/object-store/sync/sync_session.hpp>
 #include <realm/object-store/thread_safe_reference.hpp>
+#include <realm/object-store/util/scheduler.hpp>
 
 namespace realm {
 
@@ -126,7 +127,7 @@ void AsyncOpenTask::wait_for_bootstrap_or_complete(AsyncOpenCallback&& callback,
 
     SharedRealm shared_realm;
     try {
-        shared_realm = coordinator->get_realm(nullptr, m_db_first_open);
+        shared_realm = coordinator->get_realm(util::Scheduler::make_dummy(), m_db_first_open);
     }
     catch (...) {
         async_open_complete(std::move(callback), coordinator, exception_to_status());

--- a/src/realm/object-store/sync/impl/app_metadata.hpp
+++ b/src/realm/object-store/sync/impl/app_metadata.hpp
@@ -56,7 +56,7 @@ public:
                              std::string_view device_id) = 0;
 
     // Update the stored data for an existing user
-    virtual void update_user(std::string_view user_id, const UserData& data) = 0;
+    virtual void update_user(std::string_view user_id, util::FunctionRef<void(UserData&)>) = 0;
 
     // Discard the given user's tokens and set its state to the given one (LoggedOut or Removed).
     // If the user was the active user, a new active user is selected from the

--- a/test/object-store/c_api/c_api.cpp
+++ b/test/object-store/c_api/c_api.cpp
@@ -4360,13 +4360,11 @@ TEST_CASE("C API - properties", "[c_api]") {
         auto results = cptr_checked(realm_object_find_all(realm, class_foo.key));
 
         SECTION("wrong thread") {
-            std::thread t{[&]() {
+            JoiningThread{[&] {
                 realm_value_t val;
                 CHECK(!realm_get_value(foo_obj.get(), foo_int_key, &val));
                 CHECK_ERR(RLM_ERR_WRONG_THREAD);
             }};
-
-            t.join();
         }
 
         SECTION("thread-safe references") {
@@ -4378,8 +4376,9 @@ TEST_CASE("C API - properties", "[c_api]") {
             auto results_tsr = cptr_checked(realm_create_thread_safe_reference(results.get()));
 
             SECTION("resolve") {
-                std::thread t{[&]() {
+                JoiningThread{[&] {
                     auto config = make_config(test_file.path.c_str());
+                    config->scheduler = util::Scheduler::make_dummy();
                     auto realm2 = cptr_checked(realm_open(config.get()));
                     auto foo_obj2 =
                         cptr_checked(realm_object_from_thread_safe_reference(realm2.get(), foo_obj_tsr.get()));
@@ -4400,8 +4399,6 @@ TEST_CASE("C API - properties", "[c_api]") {
                     CHECK(realm_results_count(results2.get(), &count));
                     CHECK(count == 1);
                 }};
-
-                t.join();
             }
 
             SECTION("resolve in frozen") {
@@ -6005,7 +6002,7 @@ TEST_CASE("C API - binding callback thread observer", "[sync][c_api]") {
         REQUIRE(observer_ptr->has_handle_error());
         REQUIRE(observer_ptr->test_get_userdata_ptr() == &bcto_user_data);
 
-        auto test_thread = std::thread([&]() {
+        JoiningThread([&] {
             auto bcto_ptr = std::static_pointer_cast<realm::BindingCallbackThreadObserver>(
                 config->default_socket_provider_thread_observer);
             REQUIRE(bcto_ptr);
@@ -6015,9 +6012,6 @@ TEST_CASE("C API - binding callback thread observer", "[sync][c_api]") {
             bcto_ptr->did_create_thread();
             REQUIRE(bcto_ptr->handle_error(MultipleSyncAgents()));
         });
-
-        // Wait for the thread to exit
-        test_thread.join();
 
         REQUIRE(bcto_user_data.thread_create_called);
         REQUIRE(bcto_user_data.thread_on_error_message.find(

--- a/test/object-store/realm.cpp
+++ b/test/object-store/realm.cpp
@@ -943,27 +943,9 @@ TEST_CASE("Get Realm using Async Open", "[sync][pbs][async open]") {
 
     std::mutex mutex;
 
-    auto async_open_realm = [&](const Realm::Config& config) {
-        ThreadSafeReference realm_ref;
-        std::exception_ptr error;
-        auto task = Realm::get_synchronized_realm(config);
-        task->start([&](ThreadSafeReference&& ref, std::exception_ptr e) {
-            std::lock_guard lock(mutex);
-            realm_ref = std::move(ref);
-            error = e;
-        });
-        util::EventLoop::main().run_until([&] {
-            std::lock_guard lock(mutex);
-            return realm_ref || error;
-        });
-        return std::pair(std::move(realm_ref), error);
-    };
-
     SECTION("can open synced Realms that don't already exist") {
-        auto [ref, error] = async_open_realm(config);
-        REQUIRE(ref);
-        REQUIRE_FALSE(error);
-        REQUIRE(Realm::get_shared_realm(std::move(ref))->read_group().get_table("class_object"));
+        auto realm = successfully_async_open_realm(config);
+        REQUIRE(realm->read_group().get_table("class_object"));
     }
 
     SECTION("can write a realm file without client file id") {
@@ -982,11 +964,8 @@ TEST_CASE("Get Realm using Async Open", "[sync][pbs][async open]") {
 
         // Create realm file without client file id
         {
-            auto [ref, error] = async_open_realm(config);
-            REQUIRE(ref);
-            REQUIRE_FALSE(error);
+            auto realm = successfully_async_open_realm(config);
             // Write some data
-            SharedRealm realm = Realm::get_shared_realm(std::move(ref));
             realm->begin_transaction();
             realm->get_class("object").create_object(2);
             realm->commit_transaction();
@@ -1034,10 +1013,8 @@ TEST_CASE("Get Realm using Async Open", "[sync][pbs][async open]") {
             wait_for_upload(*realm);
         }
 
-        auto [ref, error] = async_open_realm(config);
-        REQUIRE(ref);
-        REQUIRE_FALSE(error);
-        REQUIRE(Realm::get_shared_realm(std::move(ref))->read_group().get_table("class_object"));
+        auto realm = successfully_async_open_realm(config);
+        REQUIRE(realm->read_group().get_table("class_object"));
     }
 
     SECTION("progress notifiers of a task are cancelled if the task is cancelled") {
@@ -1112,10 +1089,8 @@ TEST_CASE("Get Realm using Async Open", "[sync][pbs][async open]") {
             wait_for_upload(*realm);
         }
 
-        auto [ref, error] = async_open_realm(config);
-        REQUIRE(ref);
-        REQUIRE_FALSE(error);
-        REQUIRE(Realm::get_shared_realm(std::move(ref))->read_group().get_table("class_object")->size() == 1);
+        auto realm = successfully_async_open_realm(config);
+        REQUIRE(realm->read_group().get_table("class_object")->size() == 1);
     }
 
     SECTION("can download multiple Realms at a time") {
@@ -1261,9 +1236,9 @@ TEST_CASE("Get Realm using Async Open", "[sync][pbs][async open]") {
         app_config.base_file_path = util::make_temp_dir();
         app_config.metadata_mode = app::AppConfig::MetadataMode::NoEncryption;
 
-        auto the_app = app::App::get_app(app::App::CacheMode::Disabled, app_config);
-        create_user_and_log_in(the_app);
-        auto user = the_app->current_user();
+        auto app = app::App::get_app(app::App::CacheMode::Disabled, app_config);
+        create_user_and_log_in(app);
+        auto user = app->current_user();
         // User should be logged in at this point
         REQUIRE(user->is_logged_in());
 
@@ -1274,22 +1249,20 @@ TEST_CASE("Get Realm using Async Open", "[sync][pbs][async open]") {
         TestMode test_mode = GENERATE(expired_at_start, expired_by_websocket, websocket_fails);
         FailureMode failure = GENERATE(location_fails, token_fails, token_not_authorized);
 
-        DYNAMIC_SECTION(txt_test_mode(test_mode) << " - " << txt_failure_mode(failure)) {
-            logger->info("TEST: %1 - %2", txt_test_mode(test_mode), txt_failure_mode(failure));
-            if (test_mode == TestMode::expired_at_start) {
-                // invalidate the user's cached access token
-                auto app_user = the_app->current_user();
-                app_user->update_data_for_testing([&](app::UserData& data) {
-                    data.access_token = RealmJWT(expired_token);
-                });
-            }
-            else if (test_mode == TestMode::expired_by_websocket) {
-                // tell websocket to return not authorized to refresh access token
-                not_authorized = true;
-            }
+        logger->info("TEST: %1 - %2", txt_test_mode(test_mode), txt_failure_mode(failure));
+        if (test_mode == TestMode::expired_at_start) {
+            // invalidate the user's cached access token
+            auto app_user = app->current_user();
+            app_user->update_data_for_testing([&](app::UserData& data) {
+                data.access_token = RealmJWT(expired_token);
+            });
+        }
+        else if (test_mode == TestMode::expired_by_websocket) {
+            // tell websocket to return not authorized to refresh access token
+            not_authorized = true;
         }
 
-        the_app.reset();
+        app.reset();
 
         auto err_handler = [](std::shared_ptr<SyncSession> session, SyncError error) {
             auto logger = util::Logger::get_default_logger();
@@ -1336,8 +1309,8 @@ TEST_CASE("Get Realm using Async Open", "[sync][pbs][async open]") {
                                        "Operation timed out");
         };
 
-        the_app = app::App::get_app(app::App::CacheMode::Disabled, app_config);
-        SyncTestFile config(the_app->current_user(), "realm");
+        app = app::App::get_app(app::App::CacheMode::Disabled, app_config);
+        SyncTestFile config(app->current_user(), "realm");
         config.sync_config->cancel_waits_on_nonfatal_error = true;
         config.sync_config->error_handler = err_handler;
 
@@ -1368,10 +1341,8 @@ TEST_CASE("Get Realm using Async Open", "[sync][pbs][async open]") {
         }
 
         config2.schema_mode = SchemaMode::ReadOnly;
-        auto [ref, error] = async_open_realm(config2);
-        REQUIRE(ref);
-        REQUIRE_FALSE(error);
-        REQUIRE(Realm::get_shared_realm(std::move(ref))->schema_version() == 1);
+        auto realm = successfully_async_open_realm(config2);
+        REQUIRE(realm->schema_version() == 1);
     }
 
     Schema with_added_object = Schema{object_schema,
@@ -1395,10 +1366,7 @@ TEST_CASE("Get Realm using Async Open", "[sync][pbs][async open]") {
 
         // Verify that the table gets added when reopening
         config2.schema_mode = SchemaMode::ReadOnly;
-        auto [ref, error] = async_open_realm(config2);
-        REQUIRE(ref);
-        REQUIRE_FALSE(error);
-        auto realm = Realm::get_shared_realm(std::move(ref));
+        auto realm = successfully_async_open_realm(config2);
         REQUIRE(realm->schema().find("added") != realm->schema().end());
         REQUIRE(realm->read_group().get_table("class_added"));
     }
@@ -1409,10 +1377,7 @@ TEST_CASE("Get Realm using Async Open", "[sync][pbs][async open]") {
 
         config2.schema = with_added_object;
         config2.schema_mode = SchemaMode::ReadOnly;
-        auto [ref, error] = async_open_realm(config2);
-        REQUIRE(ref);
-        REQUIRE_FALSE(error);
-        auto realm = Realm::get_shared_realm(std::move(ref));
+        auto realm = successfully_async_open_realm(config2);
         REQUIRE(realm->schema().find("added") != realm->schema().end());
         REQUIRE_FALSE(realm->read_group().get_table("class_added"));
     }
@@ -1429,10 +1394,10 @@ TEST_CASE("Get Realm using Async Open", "[sync][pbs][async open]") {
                                     {"value2", PropertyType::Int},
                                 }}};
 
-        auto [ref, error] = async_open_realm(config);
-        REQUIRE_FALSE(ref);
-        REQUIRE(error);
-        REQUIRE_THROWS_CONTAINING(std::rethrow_exception(error), "Property 'object.value2' has been added.");
+        auto status = async_open_realm(config);
+        REQUIRE_FALSE(status.is_ok());
+        REQUIRE_THAT(status.get_status().reason(),
+                     Catch::Matchers::ContainsSubstring("Property 'object.value2' has been added."));
     }
 
     SECTION("adding a property to an existing read-only Realm reports an error") {
@@ -1447,10 +1412,10 @@ TEST_CASE("Get Realm using Async Open", "[sync][pbs][async open]") {
                                 }}};
         REQUIRE_THROWS_CONTAINING(Realm::get_shared_realm(config), "Property 'object.value2' has been added.");
 
-        auto [ref, error] = async_open_realm(config);
-        REQUIRE_FALSE(ref);
-        REQUIRE(error);
-        REQUIRE_THROWS_CONTAINING(std::rethrow_exception(error), "Property 'object.value2' has been added.");
+        auto status = async_open_realm(config);
+        REQUIRE_FALSE(status.is_ok());
+        REQUIRE_THAT(status.get_status().reason(),
+                     Catch::Matchers::ContainsSubstring("Property 'object.value2' has been added."));
     }
 
     SECTION("removing a property from a newly downloaded read-only Realm leaves the column in place") {
@@ -1464,13 +1429,8 @@ TEST_CASE("Get Realm using Async Open", "[sync][pbs][async open]") {
                                     {"_id", PropertyType::Int, Property::IsPrimary{true}},
                                 }}};
 
-        auto [ref, error] = async_open_realm(config);
-        REQUIRE(ref);
-        REQUIRE_FALSE(error);
-        REQUIRE(Realm::get_shared_realm(std::move(ref))
-                    ->read_group()
-                    .get_table("class_object")
-                    ->get_column_key("value") != ColKey{});
+        auto realm = successfully_async_open_realm(config);
+        REQUIRE(realm->read_group().get_table("class_object")->get_column_key("value") != ColKey{});
     }
 
     SECTION("removing a property from a existing read-only Realm leaves the column in place") {
@@ -1483,19 +1443,16 @@ TEST_CASE("Get Realm using Async Open", "[sync][pbs][async open]") {
                                     {"_id", PropertyType::Int, Property::IsPrimary{true}},
                                 }}};
 
-        auto [ref, error] = async_open_realm(config);
-        REQUIRE(ref);
-        REQUIRE_FALSE(error);
-        REQUIRE(Realm::get_shared_realm(std::move(ref))
-                    ->read_group()
-                    .get_table("class_object")
-                    ->get_column_key("value") != ColKey{});
+        auto realm = successfully_async_open_realm(config);
+        REQUIRE(realm->read_group().get_table("class_object")->get_column_key("value") != ColKey{});
     }
+
+    _impl::RealmCoordinator::assert_no_open_realms();
 }
 
 #if REALM_ENABLE_AUTH_TESTS
 
-TEST_CASE("Syhcnronized realm: AutoOpen", "[sync][baas][pbs][async open]") {
+TEST_CASE("Synchronized realm: AutoOpen", "[sync][baas][pbs][async open]") {
     const auto partition = random_string(100);
     auto schema = get_default_schema();
     enum TestMode { expired_at_start, expired_by_websocket, websocket_fails };

--- a/test/object-store/results.cpp
+++ b/test/object-store/results.cpp
@@ -1040,9 +1040,9 @@ TEST_CASE("notifications: skip", "[notifications]") {
     SECTION("skipping must be done from the Realm's thread") {
         advance_and_notify(*r);
         r->begin_transaction();
-        std::thread([&] {
+        JoiningThread([&] {
             REQUIRE_EXCEPTION(token1.suppress_next(), WrongThread, "Realm accessed from incorrect thread.");
-        }).join();
+        });
         r->cancel_transaction();
     }
 

--- a/test/object-store/sync/flx_schema_migration.cpp
+++ b/test/object-store/sync/flx_schema_migration.cpp
@@ -29,6 +29,7 @@
 #include <realm/object-store/sync/mongo_client.hpp>
 #include <realm/object-store/sync/mongo_collection.hpp>
 #include <realm/object-store/sync/mongo_database.hpp>
+#include <realm/object-store/util/scheduler.hpp>
 
 #include <realm/sync/noinst/client_history_impl.hpp>
 
@@ -656,35 +657,35 @@ TEST_CASE("An interrupted schema migration can recover on the next session",
     config.schema = schema_v1;
     auto schema_version_changed_count = 0;
     std::shared_ptr<AsyncOpenTask> task;
-    auto [promise, future] = util::make_promise_future<void>();
+    auto pf = util::make_promise_future<void>();
     config.sync_config->subscription_initializer = get_subscription_initializer_callback_for_schema_v1();
-    config.sync_config->on_sync_client_event_hook =
-        [&schema_version_changed_count, &task, promise = util::CopyablePromiseHolder<void>(std::move(promise))](
-            std::weak_ptr<SyncSession>, const SyncClientHookData& data) mutable {
-            if (data.event != SyncClientHookEvent::ErrorMessageReceived) {
-                return SyncClientHookAction::NoAction;
-            }
-
-            auto error_code = sync::ProtocolError(data.error_info->raw_error_code);
-            if (error_code == sync::ProtocolError::initial_sync_not_completed) {
-                return SyncClientHookAction::NoAction;
-            }
-
-            CHECK(error_code == sync::ProtocolError::schema_version_changed);
-            // Cancel the async open task (the sync session closes too) the first time a schema migration is required.
-            if (++schema_version_changed_count == 1) {
-                task->cancel();
-                promise.get_promise().emplace_value();
-            }
+    config.sync_config->on_sync_client_event_hook = [&schema_version_changed_count, &task,
+                                                     &pf](std::weak_ptr<SyncSession>,
+                                                          const SyncClientHookData& data) mutable {
+        if (data.event != SyncClientHookEvent::ErrorMessageReceived) {
             return SyncClientHookAction::NoAction;
-        };
+        }
+
+        auto error_code = sync::ProtocolError(data.error_info->raw_error_code);
+        if (error_code == sync::ProtocolError::initial_sync_not_completed) {
+            return SyncClientHookAction::NoAction;
+        }
+
+        CHECK(error_code == sync::ProtocolError::schema_version_changed);
+        // Cancel the async open task (the sync session closes too) the first time a schema migration is required.
+        if (++schema_version_changed_count == 1) {
+            task->cancel();
+            pf.promise.emplace_value();
+        }
+        return SyncClientHookAction::NoAction;
+    };
 
     {
         task = Realm::get_synchronized_realm(config);
         task->start([](ThreadSafeReference, std::exception_ptr) {
             FAIL();
         });
-        future.get();
+        pf.future.get();
         task.reset();
         check_realm_schema(config.path, schema_v0, 0);
     }
@@ -853,35 +854,35 @@ TEST_CASE("Migrate to new schema version after migration to intermediate version
     config.schema = schema_v1;
     auto schema_version_changed_count = 0;
     std::shared_ptr<AsyncOpenTask> task;
-    auto [promise, future] = util::make_promise_future<void>();
+    auto pf = util::make_promise_future<void>();
     config.sync_config->subscription_initializer = get_subscription_initializer_callback_for_schema_v1();
-    config.sync_config->on_sync_client_event_hook =
-        [&schema_version_changed_count, &task, promise = util::CopyablePromiseHolder<void>(std::move(promise))](
-            std::weak_ptr<SyncSession>, const SyncClientHookData& data) mutable {
-            if (data.event != SyncClientHookEvent::ErrorMessageReceived) {
-                return SyncClientHookAction::NoAction;
-            }
-
-            auto error_code = sync::ProtocolError(data.error_info->raw_error_code);
-            if (error_code == sync::ProtocolError::initial_sync_not_completed) {
-                return SyncClientHookAction::NoAction;
-            }
-
-            CHECK(error_code == sync::ProtocolError::schema_version_changed);
-            // Cancel the async open task (the sync session closes too) the first time a schema migration is required.
-            if (++schema_version_changed_count == 1) {
-                task->cancel();
-                promise.get_promise().emplace_value();
-            }
+    config.sync_config->on_sync_client_event_hook = [&schema_version_changed_count, &task,
+                                                     &pf](std::weak_ptr<SyncSession>,
+                                                          const SyncClientHookData& data) mutable {
+        if (data.event != SyncClientHookEvent::ErrorMessageReceived) {
             return SyncClientHookAction::NoAction;
-        };
+        }
+
+        auto error_code = sync::ProtocolError(data.error_info->raw_error_code);
+        if (error_code == sync::ProtocolError::initial_sync_not_completed) {
+            return SyncClientHookAction::NoAction;
+        }
+
+        CHECK(error_code == sync::ProtocolError::schema_version_changed);
+        // Cancel the async open task (the sync session closes too) the first time a schema migration is required.
+        if (++schema_version_changed_count == 1) {
+            task->cancel();
+            pf.promise.emplace_value();
+        }
+        return SyncClientHookAction::NoAction;
+    };
 
     {
         task = Realm::get_synchronized_realm(config);
         task->start([](ThreadSafeReference, std::exception_ptr) {
             FAIL();
         });
-        future.get();
+        pf.future.get();
         task.reset();
         check_realm_schema(config.path, schema_v0, 0);
     }
@@ -1090,19 +1091,17 @@ TEST_CASE("Multiple async open tasks trigger a schema migration", "[sync][flx][f
 
     auto open_task1_pf = util::make_promise_future<SharedRealm>();
     auto open_task2_pf = util::make_promise_future<SharedRealm>();
-    auto open_callback1 = [promise_holder = util::CopyablePromiseHolder(std::move(open_task1_pf.promise))](
-                              ThreadSafeReference ref, std::exception_ptr err) mutable {
+    auto open_callback1 = [&](ThreadSafeReference ref, std::exception_ptr err) mutable {
         REQUIRE_FALSE(err);
-        auto realm = Realm::get_shared_realm(std::move(ref));
+        auto realm = Realm::get_shared_realm(std::move(ref), util::Scheduler::make_dummy());
         REQUIRE(realm);
-        promise_holder.get_promise().emplace_value(realm);
+        open_task1_pf.promise.emplace_value(realm);
     };
-    auto open_callback2 = [promise_holder = util::CopyablePromiseHolder(std::move(open_task2_pf.promise))](
-                              ThreadSafeReference ref, std::exception_ptr err) mutable {
+    auto open_callback2 = [&](ThreadSafeReference ref, std::exception_ptr err) mutable {
         REQUIRE_FALSE(err);
-        auto realm = Realm::get_shared_realm(std::move(ref));
+        auto realm = Realm::get_shared_realm(std::move(ref), util::Scheduler::make_dummy());
         REQUIRE(realm);
-        promise_holder.get_promise().emplace_value(realm);
+        open_task2_pf.promise.emplace_value(realm);
     };
 
     task1->start(open_callback1);

--- a/test/object-store/sync/flx_schema_migration.cpp
+++ b/test/object-store/sync/flx_schema_migration.cpp
@@ -389,7 +389,7 @@ TEST_CASE("Schema version mismatch between client and server", "[sync][flx][flx 
         realm->sync_session()->shutdown_and_wait();
         check_realm_schema(config.path, schema_v0, 0);
     }
-    _impl::RealmCoordinator::assert_no_open_realms();
+    REQUIRE_FALSE(_impl::RealmCoordinator::get_existing_coordinator(config.path));
 
     SECTION("Realm already on the latest schema version") {
         DBOptions options;
@@ -647,7 +647,7 @@ TEST_CASE("An interrupted schema migration can recover on the next session",
         wait_for_upload(*realm);
         check_realm_schema(config.path, schema_v0, 0);
     }
-    _impl::RealmCoordinator::assert_no_open_realms();
+    REQUIRE_FALSE(_impl::RealmCoordinator::get_existing_coordinator(config.path));
 
     const AppSession& app_session = harness.session().app_session();
     auto schema_v1 = get_schema_v1();
@@ -754,7 +754,7 @@ TEST_CASE("Client reset during schema migration", "[sync][flx][flx schema migrat
             std::any(AnyDict{{"_id", ObjectId::gen()}, {"queryable_int_field", static_cast<int64_t>(42)}}));
         realm->commit_transaction();
     }
-    _impl::RealmCoordinator::assert_no_open_realms();
+    REQUIRE_FALSE(_impl::RealmCoordinator::get_existing_coordinator(config.path));
 
     const AppSession& app_session = harness.session().app_session();
     auto schema_v1 = get_schema_v1();
@@ -842,7 +842,7 @@ TEST_CASE("Migrate to new schema version after migration to intermediate version
         realm->commit_transaction();
         realm->close();
     }
-    _impl::RealmCoordinator::assert_no_open_realms();
+    REQUIRE_FALSE(_impl::RealmCoordinator::get_existing_coordinator(config.path));
 
     const AppSession& app_session = harness.session().app_session();
     auto schema_v1 = get_schema_v1();
@@ -989,7 +989,7 @@ TEST_CASE("Client reset and schema migration", "[sync][flx][flx schema migration
         // Trigger a client reset.
         reset_utils::trigger_client_reset(harness.session().app_session(), *realm->sync_session());
     }
-    _impl::RealmCoordinator::assert_no_open_realms();
+    REQUIRE_FALSE(_impl::RealmCoordinator::get_existing_coordinator(config.path));
 
     const AppSession& app_session = harness.session().app_session();
     auto schema_v1 = get_schema_v1();

--- a/test/object-store/sync/flx_sync.cpp
+++ b/test/object-store/sync/flx_sync.cpp
@@ -1369,7 +1369,7 @@ TEST_CASE("flx: client reset", "[sync][flx][client reset][baas]") {
             realm->sync_session()->shutdown_and_wait();
             realm->close();
         }
-        _impl::RealmCoordinator::assert_no_open_realms();
+        REQUIRE_FALSE(_impl::RealmCoordinator::get_existing_coordinator(config_local.path));
         {
             // ensure that an additional schema change after the successful reset is also accepted by the server
             changed_schema[0].persisted_properties.push_back(
@@ -2311,7 +2311,8 @@ TEST_CASE("flx: interrupted bootstrap restarts/recovers on reconnect", "[sync][f
         realm->sync_session()->shutdown_and_wait();
     }
 
-    _impl::RealmCoordinator::assert_no_open_realms();
+    // Verify that the file was fully closed
+    REQUIRE(DB::call_with_lock(interrupted_realm_config.path, [](auto&) {}));
 
     {
         DBOptions options;
@@ -2840,7 +2841,7 @@ TEST_CASE("flx: bootstrap batching prevents orphan documents", "[sync][flx][boot
             realm->close();
         }
 
-        _impl::RealmCoordinator::assert_no_open_realms();
+        REQUIRE_FALSE(_impl::RealmCoordinator::get_existing_coordinator(interrupted_realm_config.path));
 
         // Open up the realm without the sync client attached and verify that the realm got interrupted in the state
         // we expected it to be in.
@@ -2933,7 +2934,7 @@ TEST_CASE("flx: bootstrap batching prevents orphan documents", "[sync][flx][boot
             realm->close();
         }
 
-        _impl::RealmCoordinator::assert_no_open_realms();
+        REQUIRE_FALSE(_impl::RealmCoordinator::get_existing_coordinator(interrupted_realm_config.path));
 
         // Open up the realm without the sync client attached and verify that the realm got interrupted in the state
         // we expected it to be in.
@@ -3002,7 +3003,7 @@ TEST_CASE("flx: bootstrap batching prevents orphan documents", "[sync][flx][boot
             realm->close();
         }
 
-        _impl::RealmCoordinator::assert_no_open_realms();
+        REQUIRE_FALSE(_impl::RealmCoordinator::get_existing_coordinator(interrupted_realm_config.path));
 
         // Open up the realm without the sync client attached and verify that the realm got interrupted in the state
         // we expected it to be in.
@@ -3079,7 +3080,7 @@ TEST_CASE("flx: bootstrap batching prevents orphan documents", "[sync][flx][boot
             realm->close();
         }
 
-        _impl::RealmCoordinator::assert_no_open_realms();
+        REQUIRE_FALSE(_impl::RealmCoordinator::get_existing_coordinator(interrupted_realm_config.path));
 
         // Open up the realm without the sync client attached and verify that the realm got interrupted in the state
         // we expected it to be in.
@@ -4583,7 +4584,7 @@ TEST_CASE("flx: open realm + register subscription callback while bootstrapping"
                 realm->close();
             }
 
-            _impl::RealmCoordinator::assert_no_open_realms();
+            REQUIRE_FALSE(_impl::RealmCoordinator::get_existing_coordinator(config.path));
 
             // Client 2 uploads data matching Client 1's subscription at version 1
             harness.load_initial_data([&](SharedRealm realm) {
@@ -4742,7 +4743,7 @@ TEST_CASE("flx sync: resend pending subscriptions when reconnecting", "[sync][fl
         realm->close();
     }
 
-    _impl::RealmCoordinator::assert_no_open_realms();
+    REQUIRE_FALSE(_impl::RealmCoordinator::get_existing_coordinator(interrupted_realm_config.path));
 
     // Check at least one subscription set needs to be resent.
     {

--- a/test/object-store/sync/flx_sync.cpp
+++ b/test/object-store/sync/flx_sync.cpp
@@ -4396,15 +4396,14 @@ TEST_CASE("flx: open realm + register subscription callback while bootstrapping"
                     promise.emplace_value(true);
                 };
             auto open_realm_pf = util::make_promise_future<bool>();
-            auto open_realm_completed_callback =
-                [&, promise_holder = util::CopyablePromiseHolder(std::move(open_realm_pf.promise))](
-                    ThreadSafeReference ref, std::exception_ptr err) mutable {
-                    auto promise = promise_holder.get_promise();
-                    if (err)
-                        promise.emplace_value(false);
-                    else
-                        promise.emplace_value(verify_subscription(Realm::get_shared_realm(std::move(ref))));
-                };
+            auto open_realm_completed_callback = [&](ThreadSafeReference ref, std::exception_ptr err) mutable {
+                bool result = false;
+                if (!err) {
+                    result =
+                        verify_subscription(Realm::get_shared_realm(std::move(ref), util::Scheduler::make_dummy()));
+                }
+                open_realm_pf.promise.emplace_value(result);
+            };
 
             config.sync_config->subscription_initializer = init_subscription_asyc_callback;
             config.sync_config->rerun_init_subscription_on_open = true;
@@ -4423,15 +4422,14 @@ TEST_CASE("flx: open realm + register subscription callback while bootstrapping"
         SECTION("Initial async open with no rerun on open set") {
             // subscription will be run since this is the first time we are opening the realm file.
             auto open_realm_pf = util::make_promise_future<bool>();
-            auto open_realm_completed_callback =
-                [&, promise_holder = util::CopyablePromiseHolder(std::move(open_realm_pf.promise))](
-                    ThreadSafeReference ref, std::exception_ptr err) mutable {
-                    auto promise = promise_holder.get_promise();
-                    if (err)
-                        promise.emplace_value(false);
-                    else
-                        promise.emplace_value(verify_subscription(Realm::get_shared_realm(std::move(ref))));
-                };
+            auto open_realm_completed_callback = [&](ThreadSafeReference ref, std::exception_ptr err) mutable {
+                bool result = false;
+                if (!err) {
+                    result =
+                        verify_subscription(Realm::get_shared_realm(std::move(ref), util::Scheduler::make_dummy()));
+                }
+                open_realm_pf.promise.emplace_value(result);
+            };
 
             config.sync_config->subscription_initializer = init_subscription_callback_with_promise;
             auto async_open = Realm::get_synchronized_realm(config);
@@ -4443,13 +4441,11 @@ TEST_CASE("flx: open realm + register subscription callback while bootstrapping"
                 subscription_invoked = false;
                 auto async_open = Realm::get_synchronized_realm(config);
                 auto open_realm_pf = util::make_promise_future<bool>();
-                auto open_realm_completed_callback =
-                    [promise_holder = util::CopyablePromiseHolder(std::move(open_realm_pf.promise))](
-                        ThreadSafeReference, std::exception_ptr) mutable {
-                        // no need to verify if the subscription has changed the db, since it has not run as we test
-                        // below
-                        promise_holder.get_promise().emplace_value(true);
-                    };
+                auto open_realm_completed_callback = [&](ThreadSafeReference, std::exception_ptr e) mutable {
+                    // no need to verify if the subscription has changed the db, since it has not run as we test
+                    // below
+                    open_realm_pf.promise.emplace_value(!e);
+                };
                 async_open->start(open_realm_completed_callback);
                 REQUIRE(open_realm_pf.future.get());
                 REQUIRE_FALSE(subscription_invoked.load());
@@ -4472,13 +4468,11 @@ TEST_CASE("flx: open realm + register subscription callback while bootstrapping"
                 config.sync_config->subscription_initializer = init_subscription;
                 auto async_open = Realm::get_synchronized_realm(config);
                 auto open_realm_pf = util::make_promise_future<bool>();
-                auto open_realm_completed_callback =
-                    [promise_holder = util::CopyablePromiseHolder(std::move(open_realm_pf.promise))](
-                        ThreadSafeReference, std::exception_ptr) mutable {
-                        // no need to verify if the subscription has changed the db, since it has not run as we test
-                        // below
-                        promise_holder.get_promise().emplace_value(true);
-                    };
+                auto open_realm_completed_callback = [&](ThreadSafeReference, std::exception_ptr e) mutable {
+                    // no need to verify if the subscription has changed the db, since it has not run as we test
+                    // below
+                    open_realm_pf.promise.emplace_value(!e);
+                };
                 async_open->start(open_realm_completed_callback);
                 REQUIRE(open_realm_pf.future.get());
                 REQUIRE_FALSE(subscription_invoked.load());
@@ -4500,19 +4494,15 @@ TEST_CASE("flx: open realm + register subscription callback while bootstrapping"
 
             auto open_task1_pf = util::make_promise_future<SharedRealm>();
             auto open_task2_pf = util::make_promise_future<SharedRealm>();
-            auto open_callback1 = [promise_holder = util::CopyablePromiseHolder(std::move(open_task1_pf.promise))](
-                                      ThreadSafeReference ref, std::exception_ptr err) mutable {
+            auto open_callback1 = [&](ThreadSafeReference ref, std::exception_ptr err) mutable {
                 REQUIRE_FALSE(err);
-                auto realm = Realm::get_shared_realm(std::move(ref));
-                REQUIRE(realm);
-                promise_holder.get_promise().emplace_value(realm);
+                open_task1_pf.promise.emplace_value(
+                    Realm::get_shared_realm(std::move(ref), util::Scheduler::make_dummy()));
             };
-            auto open_callback2 = [promise_holder = util::CopyablePromiseHolder(std::move(open_task2_pf.promise))](
-                                      ThreadSafeReference ref, std::exception_ptr err) mutable {
+            auto open_callback2 = [&](ThreadSafeReference ref, std::exception_ptr err) mutable {
                 REQUIRE_FALSE(err);
-                auto realm = Realm::get_shared_realm(std::move(ref));
-                REQUIRE(realm);
-                promise_holder.get_promise().emplace_value(realm);
+                open_task2_pf.promise.emplace_value(
+                    Realm::get_shared_realm(std::move(ref), util::Scheduler::make_dummy()));
             };
 
             config.sync_config->rerun_init_subscription_on_open = true;
@@ -4607,25 +4597,11 @@ TEST_CASE("flx: open realm + register subscription callback while bootstrapping"
 
             // Client 1 opens the realm asynchronously and expects the task to complete
             // when the subscription at version 2 finishes bootstrapping.
-            auto async_open = Realm::get_synchronized_realm(config);
-            auto open_task_pf = util::make_promise_future<bool>();
-            int64_t latest_version, active_version;
-            auto open_realm_completed_callback =
-                [promise_holder = util::CopyablePromiseHolder(std::move(open_task_pf.promise)), &latest_version,
-                 &active_version](ThreadSafeReference ref, std::exception_ptr err) mutable {
-                    REQUIRE_FALSE(err);
-                    auto realm = Realm::get_shared_realm(std::move(ref));
-                    REQUIRE(realm);
-                    latest_version = realm->get_latest_subscription_set().version();
-                    active_version = realm->get_active_subscription_set().version();
-                    promise_holder.get_promise().emplace_value(true);
-                };
-            async_open->start(open_realm_completed_callback);
-            CHECK(open_task_pf.future.get());
+            auto realm = successfully_async_open_realm(config);
 
             // Check subscription at version 2 is marked Complete.
-            CHECK(active_version == 2);
-            CHECK(latest_version == active_version);
+            CHECK(realm->get_latest_subscription_set().version() == 2);
+            CHECK(realm->get_active_subscription_set().version() == 2);
         }
     }
 }
@@ -4702,7 +4678,7 @@ TEST_CASE("flx sync: Client reset during async open", "[sync][flx][client reset]
             if (ex) {
                 std::rethrow_exception(ex);
             }
-            promise.emplace_value(Realm::get_shared_realm(std::move(ref)));
+            promise.emplace_value(Realm::get_shared_realm(std::move(ref), util::Scheduler::make_dummy()));
         }
         catch (...) {
             promise.set_error(exception_to_status());

--- a/test/object-store/sync/metadata.cpp
+++ b/test/object-store/sync/metadata.cpp
@@ -613,6 +613,83 @@ TEST_CASE("app metadata: persisted", "[sync][metadata]") {
     }
 }
 
+TEST_CASE("app metadata: multiple stores", "[sync][metadata]") {
+    test_util::TestDirGuard test_dir(base_path);
+
+    AppConfig config;
+    config.app_id = "app id";
+    config.metadata_mode = AppConfig::MetadataMode::NoEncryption;
+    config.base_file_path = base_path;
+    SyncFileManager file_manager(config);
+
+    auto store_1 = create_metadata_store(config, file_manager);
+    auto store_2 = create_metadata_store(config, file_manager);
+    REQUIRE(store_1 != store_2);
+
+    SECTION("create user in one store then read from the other") {
+        store_1->create_user(user_id, refresh_token, access_token, device_id);
+        auto user = store_2->get_user(user_id);
+        REQUIRE(user);
+    }
+
+    SECTION("update existing user in one store then read from the other") {
+        store_1->create_user(user_id, refresh_token, access_token, device_id);
+        auto user_1 = store_1->get_user(user_id);
+
+        std::vector<UserIdentity> identities{{"identity", "provider"}};
+        store_2->update_user(user_id, [&](UserData& data) {
+            data.identities = identities;
+        });
+
+        auto user_2 = store_1->get_user(user_id);
+        CHECK(user_1->identities.empty());
+        CHECK(user_2->identities == identities);
+    }
+
+    SECTION("non-conflicting writes from multiple stores") {
+        store_1->create_user(user_id, refresh_token, access_token, device_id);
+        auto user_1 = store_1->get_user(user_id);
+        auto user_2 = store_2->get_user(user_id);
+
+        UserProfile profile = bson::BsonDocument{{"name", "user's name"}, {"email", "user's email"}};
+        std::vector<UserIdentity> identities{{"identity", "provider"}};
+        store_1->update_user(user_id, [&](UserData& data) {
+            data.identities = identities;
+        });
+        store_2->update_user(user_id, [&](UserData& data) {
+            data.profile = profile;
+        });
+
+        // The second write should not have discarded the change made by the first store
+        user_1 = store_1->get_user(user_id);
+        user_2 = store_2->get_user(user_id);
+        REQUIRE(user_1->identities == user_2->identities);
+        REQUIRE(user_1->identities == identities);
+        REQUIRE(user_1->profile.data() == user_2->profile.data());
+        REQUIRE(user_1->profile.data() == profile.data());
+    }
+
+    SECTION("file actions are not performed on open if there is already a live store") {
+        auto path = util::make_temp_file("file_to_delete");
+        store_1->create_user(user_id, refresh_token, access_token, device_id);
+        store_1->add_realm_path(user_id, path);
+        store_1->log_out(user_id, SyncUser::State::Removed);
+
+        create_metadata_store(config, file_manager);
+        REQUIRE(File::exists(path));
+
+        store_1.reset();
+
+        create_metadata_store(config, file_manager);
+        REQUIRE(File::exists(path));
+
+        store_2.reset();
+
+        create_metadata_store(config, file_manager);
+        REQUIRE_FALSE(File::exists(path));
+    }
+}
+
 #if REALM_ENABLE_ENCRYPTION
 TEST_CASE("app metadata: encryption", "[sync][metadata]") {
     test_util::TestDirGuard test_dir(base_path);
@@ -739,7 +816,7 @@ TEST_CASE("app metadata: encryption", "[sync][metadata]") {
 #endif // REALM_PLATFORM_APPLE
 }
 
-#endif
+#endif // REALM_ENABLE_ENCRYPTION
 
 #ifndef SWIFT_PACKAGE // The SPM build currently doesn't copy resource files
 TEST_CASE("sync metadata: can open old metadata realms", "[sync][metadata]") {

--- a/test/object-store/test_runner.cpp
+++ b/test/object-store/test_runner.cpp
@@ -38,6 +38,7 @@
 #include <fstream>
 #include <iostream>
 #include <limits.h>
+#include <thread>
 
 #ifndef TEST_ENABLE_LOGGING
 #define TEST_ENABLE_LOGGING 0 // change to 1 to enable trace-level logging
@@ -157,7 +158,10 @@ int run_object_store_tests(int argc, const char** argv)
 #endif
 
 #if TEST_SCHEDULER_UV
+    static std::thread::id s_main_thread_id = std::this_thread::get_id();
     realm::util::Scheduler::set_default_factory([]() -> std::shared_ptr<realm::util::Scheduler> {
+        // The libuv scheduler can only be constructed from the main thread
+        REALM_ASSERT_RELEASE(std::this_thread::get_id() == s_main_thread_id);
         return std::make_shared<realm::util::UvMainLoopScheduler>();
     });
 #endif

--- a/test/object-store/thread_safe_reference.cpp
+++ b/test/object-store/thread_safe_reference.cpp
@@ -332,6 +332,7 @@ TEST_CASE("thread safe reference") {
             SECTION("read-only `ThreadSafeReference` to `Results`") {
                 auto thread_safe_results = ThreadSafeReference(results);
                 JoiningThread([&thread_safe_results, &config, int_obj_col]() mutable {
+                    config.scheduler = util::Scheduler::make_dummy();
                     SharedRealm realm_in_thread = Realm::get_shared_realm(config);
                     Results resolved_results = thread_safe_results.resolve<Results>(realm_in_thread);
                     REQUIRE(resolved_results.size() == 1);
@@ -343,6 +344,7 @@ TEST_CASE("thread safe reference") {
                 Object object(read_only_realm, results.get(0));
                 auto thread_safe_object = ThreadSafeReference(object);
                 JoiningThread([&thread_safe_object, &config, int_obj_col]() mutable {
+                    config.scheduler = util::Scheduler::make_dummy();
                     SharedRealm realm_in_thread = Realm::get_shared_realm(config);
                     auto resolved_object = thread_safe_object.resolve<Object>(realm_in_thread);
                     REQUIRE(resolved_object.is_valid());

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -6544,8 +6544,6 @@ TEST(Sync_BundledRealmFile)
     fixtures::ClientServerFixture fixture{dir, test_context};
     fixture.start();
 
-    Session session = fixture.make_bound_session(db);
-
     write_transaction(db, [](WriteTransaction& tr) {
         auto foos = tr.get_group().add_table_with_primary_key("class_Foo", type_Int, "id");
         foos->create_object_with_primary_key(123);
@@ -6554,6 +6552,7 @@ TEST(Sync_BundledRealmFile)
     // We cannot write out file if changes are not synced to server
     CHECK_THROW_ANY(db->write_copy(path.c_str(), nullptr));
 
+    Session session = fixture.make_bound_session(db);
     session.wait_for_upload_complete_or_client_stopped();
     session.wait_for_download_complete_or_client_stopped();
 


### PR DESCRIPTION
File actions are performed on "next launch" since that's a time where we know it's safe to delete or move Realm files which may have been in use. This previously meant when the metadata store was next constructed, which was incorrect when multiple processes are sharing a metadata file. Instead, it tries to claim the sync agent flag on the metadata Realm file, and only performs the launch actions if it's able to.

There is still a race condition here: process 1 could initialize the metadata realm, claim the flag, then get suspended. Process 2 initializes, opens a Realm, and then removes the user. Process 1 then unsuspends and proceeds to run file actions, deleting the Realm process 2 has open. This is probably not actually a problem but I'll continue to try to find a fix.

Keeping the metadata Realm open is required for this to work, for change notification to work (a future change), and greatly improves performance of metadata operations. It slightly increases memory usage but the metadata realm is typically very small.

update_user() could previously overwrite data with stale data previously read. It was very difficult for this to actually happen with where and when we called it, but better to fix the problem.

------------------------

There's two groups of not directly related updates to the tests. There were some spots where we called `assert_no_open_realms()` where the sync metadata Realm now should be open. These now check for the specific file that we're expecting to be closed instead. To help track down some scheduler-related problems, I added an assertion to verify that the libuv scheduler is only created on the main thread, as it doesn't support background threads. This turned out to reveal a bunch of places where we were creating them on background threads, which I then fixed.