### PR TITLE
Add missing availability checks for SecCopyErrorMessageString

### DIFF
--- a/src/realm/object-store/impl/apple/keychain_helper.cpp
+++ b/src/realm/object-store/impl/apple/keychain_helper.cpp
@@ -36,17 +36,21 @@ REALM_NORETURN
 REALM_COLD
 void keychain_access_exception(int32_t error_code)
 {
-    if (auto message = adoptCF(SecCopyErrorMessageString(error_code, nullptr))) {
-        if (auto msg = CFStringGetCStringPtr(message.get(), kCFStringEncodingUTF8)) {
-            throw RuntimeError(ErrorCodes::RuntimeError,
-                               util::format("Keychain returned unexpected status code: %1 (%2)", msg, error_code));
-        }
-        auto length = CFStringGetMaximumSizeForEncoding(CFStringGetLength(message.get()), kCFStringEncodingUTF8) + 1;
-        auto buffer = std::make_unique<char[]>(length);
-        if (CFStringGetCString(message.get(), buffer.get(), length, kCFStringEncodingUTF8)) {
-            throw RuntimeError(
-                ErrorCodes::RuntimeError,
-                util::format("Keychain returned unexpected status code: %1 (%2)", buffer.get(), error_code));
+    if (__builtin_available(iOS 11.3, macOS 10.3, tvOS 11.3, watchOS 4.3, *)) {
+        if (auto message = adoptCF(SecCopyErrorMessageString(error_code, nullptr))) {
+            if (auto msg = CFStringGetCStringPtr(message.get(), kCFStringEncodingUTF8)) {
+                throw RuntimeError(
+                    ErrorCodes::RuntimeError,
+                    util::format("Keychain returned unexpected status code: %1 (%2)", msg, error_code));
+            }
+            auto length =
+                CFStringGetMaximumSizeForEncoding(CFStringGetLength(message.get()), kCFStringEncodingUTF8) + 1;
+            auto buffer = std::make_unique<char[]>(length);
+            if (CFStringGetCString(message.get(), buffer.get(), length, kCFStringEncodingUTF8)) {
+                throw RuntimeError(
+                    ErrorCodes::RuntimeError,
+                    util::format("Keychain returned unexpected status code: %1 (%2)", buffer.get(), error_code));
+            }
         }
     }
     throw RuntimeError(ErrorCodes::RuntimeError,

--- a/src/realm/sync/network/network_ssl.cpp
+++ b/src/realm/sync/network/network_ssl.cpp
@@ -206,11 +206,13 @@ std::string SecureTransportErrorCategory::message(int value) const
 {
     const char* message = "Unknown error";
 #if REALM_HAVE_SECURE_TRANSPORT
-    auto status = OSStatus(value);
-    void* reserved = nullptr;
-    std::unique_ptr<char[]> buffer;
-    if (auto cf_message = adoptCF(SecCopyErrorMessageString(status, reserved)))
-        message = cfstring_to_cstring(cf_message.get(), buffer);
+    if (__builtin_available(iOS 11.3, macOS 10.3, tvOS 11.3, watchOS 4.3, *)) {
+        auto status = OSStatus(value);
+        void* reserved = nullptr;
+        std::unique_ptr<char[]> buffer;
+        if (auto cf_message = adoptCF(SecCopyErrorMessageString(status, reserved)))
+            message = cfstring_to_cstring(cf_message.get(), buffer);
+    }
 #endif // REALM_HAVE_SECURE_TRANSPORT
 
     return util::format("SecureTransport error: %1 (%2)", message, value); // Throws


### PR DESCRIPTION
This requires iOS 11.3 and we currently target iOS 11. No changelog entry since this didn't make it into a release.