### PR TITLE
Use proper constructor when clearing links is nested collections

### DIFF
--- a/src/realm/dictionary.cpp
+++ b/src/realm/dictionary.cpp
@@ -77,7 +77,8 @@ Dictionary::~Dictionary() = default;
 
 Dictionary& Dictionary::operator=(const Dictionary& other)
 {
-    Base::operator=(static_cast<const Base&>(other));
+    Base::operator=(other);
+    CollectionParent::operator=(other);
 
     if (this != &other) {
         // Back to scratch
@@ -437,24 +438,35 @@ void Dictionary::insert_collection(const PathElement& path_elem, CollectionType 
     insert(path_elem.get_key(), Mixed(0, dict_or_list));
 }
 
-DictionaryPtr Dictionary::get_dictionary(const PathElement& path_elem) const
+template <class T>
+inline std::shared_ptr<T> Dictionary::do_get_collection(const PathElement& path_elem)
 {
     update();
-    auto weak = const_cast<Dictionary*>(this)->weak_from_this();
-    auto shared = weak.expired() ? std::make_shared<Dictionary>(*this) : weak.lock();
-    DictionaryPtr ret = std::make_shared<Dictionary>(m_col_key, get_level() + 1);
+    auto get_shared = [&]() -> std::shared_ptr<CollectionParent> {
+        auto weak = weak_from_this();
+
+        if (weak.expired()) {
+            REALM_ASSERT(m_level == 1);
+            return std::make_shared<Dictionary>(*this);
+        }
+
+        return weak.lock();
+    };
+
+    auto shared = get_shared();
+    auto ret = std::make_shared<T>(m_col_key, get_level() + 1);
     ret->set_owner(shared, build_index(path_elem.get_key()));
     return ret;
 }
 
+DictionaryPtr Dictionary::get_dictionary(const PathElement& path_elem) const
+{
+    return const_cast<Dictionary*>(this)->do_get_collection<Dictionary>(path_elem);
+}
+
 std::shared_ptr<Lst<Mixed>> Dictionary::get_list(const PathElement& path_elem) const
 {
-    update();
-    auto weak = const_cast<Dictionary*>(this)->weak_from_this();
-    auto shared = weak.expired() ? std::make_shared<Dictionary>(*this) : weak.lock();
-    std::shared_ptr<Lst<Mixed>> ret = std::make_shared<Lst<Mixed>>(m_col_key, get_level() + 1);
-    ret->set_owner(shared, build_index(path_elem.get_key()));
-    return ret;
+    return const_cast<Dictionary*>(this)->do_get_collection<Lst<Mixed>>(path_elem);
 }
 
 Mixed Dictionary::get(Mixed key) const
@@ -983,12 +995,12 @@ bool Dictionary::clear_backlink(size_t ndx, CascadeState& state) const
         return Base::remove_backlink(m_col_key, value.get_link(), state);
     }
     if (value.is_type(type_Dictionary)) {
-        auto key = do_get_key(ndx);
-        return get_dictionary(key.get_string())->remove_backlinks(state);
+        Dictionary d(*const_cast<Dictionary*>(this), m_values->get_key(ndx));
+        return d.remove_backlinks(state);
     }
     if (value.is_type(type_List)) {
-        auto key = do_get_key(ndx);
-        return get_list(key.get_string())->remove_backlinks(state);
+        Lst<Mixed> l(*const_cast<Dictionary*>(this), m_values->get_key(ndx));
+        return l.remove_backlinks(state);
     }
     return false;
 }

--- a/src/realm/dictionary.cpp
+++ b/src/realm/dictionary.cpp
@@ -77,10 +77,10 @@ Dictionary::~Dictionary() = default;
 
 Dictionary& Dictionary::operator=(const Dictionary& other)
 {
-    Base::operator=(other);
-    CollectionParent::operator=(other);
-
     if (this != &other) {
+        Base::operator=(other);
+        CollectionParent::operator=(other);
+
         // Back to scratch
         m_dictionary_top.reset();
         reset_content_version();
@@ -446,7 +446,7 @@ inline std::shared_ptr<T> Dictionary::do_get_collection(const PathElement& path_
         auto weak = weak_from_this();
 
         if (weak.expired()) {
-            REALM_ASSERT(m_level == 1);
+            REALM_ASSERT_DEBUG(m_level == 1);
             return std::make_shared<Dictionary>(*this);
         }
 
@@ -995,12 +995,12 @@ bool Dictionary::clear_backlink(size_t ndx, CascadeState& state) const
         return Base::remove_backlink(m_col_key, value.get_link(), state);
     }
     if (value.is_type(type_Dictionary)) {
-        Dictionary d(*const_cast<Dictionary*>(this), m_values->get_key(ndx));
-        return d.remove_backlinks(state);
+        Dictionary dict{*const_cast<Dictionary*>(this), m_values->get_key(ndx)};
+        return dict.remove_backlinks(state);
     }
     if (value.is_type(type_List)) {
-        Lst<Mixed> l(*const_cast<Dictionary*>(this), m_values->get_key(ndx));
-        return l.remove_backlinks(state);
+        Lst<Mixed> list{*const_cast<Dictionary*>(this), m_values->get_key(ndx)};
+        return list.remove_backlinks(state);
     }
     return false;
 }

--- a/src/realm/dictionary.hpp
+++ b/src/realm/dictionary.hpp
@@ -277,6 +277,8 @@ private:
     void get_key_type();
 
     UpdateStatus do_update_if_needed(bool allow_create) const;
+    template <class T>
+    std::shared_ptr<T> do_get_collection(const PathElement& path_elem);
 };
 
 class Dictionary::Iterator {

--- a/src/realm/list.cpp
+++ b/src/realm/list.cpp
@@ -347,6 +347,37 @@ void Lst<ObjLink>::do_remove(size_t ndx)
 
 /******************************** Lst<Mixed> *********************************/
 
+Lst<Mixed>& Lst<Mixed>::operator=(const Lst<Mixed>& other)
+{
+    Base::operator=(other);
+    CollectionParent::operator=(other);
+
+    if (this != &other) {
+        // Just reset the pointer and rely on init_from_parent() being called
+        // when the accessor is actually used.
+        m_tree.reset();
+        Base::reset_content_version();
+    }
+
+    return *this;
+}
+
+Lst<Mixed>& Lst<Mixed>::operator=(Lst<Mixed>&& other) noexcept
+{
+    Base::operator=(std::move(other));
+    CollectionParent::operator=(std::move(other));
+
+    if (this != &other) {
+        m_tree = std::exchange(other.m_tree, nullptr);
+        if (m_tree) {
+            m_tree->set_parent(this, 0);
+        }
+    }
+
+    return *this;
+}
+
+
 UpdateStatus Lst<Mixed>::init_from_parent(bool allow_create) const
 {
     Base::update_content_version();
@@ -550,24 +581,35 @@ void Lst<Mixed>::set_collection(const PathElement& path_elem, CollectionType dic
     set(path_elem.get_ndx(), Mixed(0, dict_or_list));
 }
 
-DictionaryPtr Lst<Mixed>::get_dictionary(const PathElement& path_elem) const
+template <class T>
+inline std::shared_ptr<T> Lst<Mixed>::do_get_collection(const PathElement& path_elem)
 {
     update();
-    auto weak = const_cast<Lst<Mixed>*>(this)->weak_from_this();
-    auto shared = weak.expired() ? std::make_shared<Lst<Mixed>>(*this) : weak.lock();
-    DictionaryPtr ret = std::make_shared<Dictionary>(m_col_key, get_level() + 1);
+    auto get_shared = [&]() -> std::shared_ptr<CollectionParent> {
+        auto weak = weak_from_this();
+
+        if (weak.expired()) {
+            REALM_ASSERT(m_level == 1);
+            return std::make_shared<Lst<Mixed>>(*this);
+        }
+
+        return weak.lock();
+    };
+
+    auto shared = get_shared();
+    auto ret = std::make_shared<T>(m_col_key, get_level() + 1);
     ret->set_owner(shared, m_tree->get_key(path_elem.get_ndx()));
     return ret;
 }
 
+DictionaryPtr Lst<Mixed>::get_dictionary(const PathElement& path_elem) const
+{
+    return const_cast<Lst<Mixed>*>(this)->do_get_collection<Dictionary>(path_elem);
+}
+
 std::shared_ptr<Lst<Mixed>> Lst<Mixed>::get_list(const PathElement& path_elem) const
 {
-    update();
-    auto weak = const_cast<Lst<Mixed>*>(this)->weak_from_this();
-    auto shared = weak.expired() ? std::make_shared<Lst<Mixed>>(*this) : weak.lock();
-    std::shared_ptr<Lst<Mixed>> ret = std::make_shared<Lst<Mixed>>(m_col_key, get_level() + 1);
-    ret->set_owner(shared, m_tree->get_key(path_elem.get_ndx()));
-    return ret;
+    return const_cast<Lst<Mixed>*>(this)->do_get_collection<Lst<Mixed>>(path_elem);
 }
 
 void Lst<Mixed>::do_set(size_t ndx, Mixed value)
@@ -838,10 +880,12 @@ bool Lst<Mixed>::clear_backlink(size_t ndx, CascadeState& state) const
             return Base::remove_backlink(m_col_key, link, state);
         }
         else if (value.is_type(type_List)) {
-            return get_list(ndx)->remove_backlinks(state);
+            Lst<Mixed> l(*const_cast<Lst<Mixed>*>(this), m_tree->get_key(ndx));
+            return l.remove_backlinks(state);
         }
         else if (value.is_type(type_Dictionary)) {
-            return get_dictionary(ndx)->remove_backlinks(state);
+            Dictionary d(*const_cast<Lst<Mixed>*>(this), m_tree->get_key(ndx));
+            return d.remove_backlinks(state);
         }
     }
     return false;

--- a/src/realm/list.cpp
+++ b/src/realm/list.cpp
@@ -349,10 +349,10 @@ void Lst<ObjLink>::do_remove(size_t ndx)
 
 Lst<Mixed>& Lst<Mixed>::operator=(const Lst<Mixed>& other)
 {
-    Base::operator=(other);
-    CollectionParent::operator=(other);
-
     if (this != &other) {
+        Base::operator=(other);
+        CollectionParent::operator=(other);
+
         // Just reset the pointer and rely on init_from_parent() being called
         // when the accessor is actually used.
         m_tree.reset();
@@ -364,10 +364,10 @@ Lst<Mixed>& Lst<Mixed>::operator=(const Lst<Mixed>& other)
 
 Lst<Mixed>& Lst<Mixed>::operator=(Lst<Mixed>&& other) noexcept
 {
-    Base::operator=(std::move(other));
-    CollectionParent::operator=(std::move(other));
-
     if (this != &other) {
+        Base::operator=(std::move(other));
+        CollectionParent::operator=(std::move(other));
+
         m_tree = std::exchange(other.m_tree, nullptr);
         if (m_tree) {
             m_tree->set_parent(this, 0);
@@ -589,7 +589,7 @@ inline std::shared_ptr<T> Lst<Mixed>::do_get_collection(const PathElement& path_
         auto weak = weak_from_this();
 
         if (weak.expired()) {
-            REALM_ASSERT(m_level == 1);
+            REALM_ASSERT_DEBUG(m_level == 1);
             return std::make_shared<Lst<Mixed>>(*this);
         }
 
@@ -880,12 +880,12 @@ bool Lst<Mixed>::clear_backlink(size_t ndx, CascadeState& state) const
             return Base::remove_backlink(m_col_key, link, state);
         }
         else if (value.is_type(type_List)) {
-            Lst<Mixed> l(*const_cast<Lst<Mixed>*>(this), m_tree->get_key(ndx));
-            return l.remove_backlinks(state);
+            Lst<Mixed> list{*const_cast<Lst<Mixed>*>(this), m_tree->get_key(ndx)};
+            return list.remove_backlinks(state);
         }
         else if (value.is_type(type_Dictionary)) {
-            Dictionary d(*const_cast<Lst<Mixed>*>(this), m_tree->get_key(ndx));
-            return d.remove_backlinks(state);
+            Dictionary dict{*const_cast<Lst<Mixed>*>(this), m_tree->get_key(ndx)};
+            return dict.remove_backlinks(state);
         }
     }
     return false;

--- a/src/realm/list.hpp
+++ b/src/realm/list.hpp
@@ -541,6 +541,8 @@ private:
         return unresolved_to_null(m_tree->get(ndx));
     }
     bool clear_backlink(size_t ndx, CascadeState& state) const;
+    template <class T>
+    inline std::shared_ptr<T> do_get_collection(const PathElement& path_elem);
 };
 
 // Specialization of Lst<StringData>:


### PR DESCRIPTION
It is only safe to use get_dictionary/get_list on a collection that is either at level 1 or if referenced by a shared pointer. The collection created in instruction_applier is always stack allocated and can be at any level.

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- Link to relevant issue this fixes -->
Fixes #7573

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed
* [ ] `bindgen/spec.yml`, if public C++ API changed
