### PR TITLE
RCORE-2080: Use the correct target conditional

### DIFF
--- a/src/realm/object-store/impl/apple/keychain_helper.cpp
+++ b/src/realm/object-store/impl/apple/keychain_helper.cpp
@@ -205,7 +205,7 @@ std::optional<std::vector<char>> get_existing_metadata_realm_key(std::string_vie
     // in one client is unusual, but when it's done we want each metadata realm to
     // have a separate key.
 
-#if TARGET_OS_OSX
+#if TARGET_OS_MAC
     if (auto service = bundle_service()) {
         if (get_key(cf_app_id.get(), service.get(), {}, key))
             return key;


### PR DESCRIPTION
## What, How & Why?
Current master does not compile for iOS.

Fixed by changing a target conditional in `keychain_helper.cpp`. TARGET_OS_OSX means only mac, where as TARGET_OS_MAC includes iPhone, tvOS, etc. (see `TargetConditionals.h`). Apple works in mysterious ways.

Fixes: #7580 

## ☑️ ToDos
~~📝 Changelog update~~
~~🚦 Tests (or not relevant)~~
~~C-API, if public C++ API changed~~
~~`bindgen/spec.yml`, if public C++ API changed~~
