### PR TITLE
Fix encoding enum numbers

### DIFF
--- a/src/realm/node_header.hpp
+++ b/src/realm/node_header.hpp
@@ -86,8 +86,8 @@ public:
         WTypBits = 0, // Corresponds to wtype_Bits
         WTypMult = 1, // Corresponds to wtype_Multiply
         WTypIgn = 2,  // Corresponds to wtype_Ignore
-        Packed = 4,   // wtype is wtype_Extend
-        Flex = 5      // wtype is wtype_Extend
+        Packed = 3,   // wtype is wtype_Extend
+        Flex = 4      // wtype is wtype_Extend
     };
     // * Packed: tightly packed array (any element size <= 64)
     // * WTypBits: less tightly packed. Correspond to wtype_Bits
@@ -753,8 +753,8 @@ static inline void init_header(char* header, realm::NodeHeader::Encoding enc, ui
     REALM_ASSERT_DEBUG(bits_pr_elemB <= 64);
     REALM_ASSERT_DEBUG(num_elemsA < 1024);
     REALM_ASSERT_DEBUG(num_elemsB < 1024);
-    hw[3] = static_cast<uint16_t>(((bits_pr_elemB - 1) << 10) | num_elemsB);
     hw[1] = static_cast<uint16_t>(((bits_pr_elemA - 1) << 10) | num_elemsA);
+    hw[3] = static_cast<uint16_t>(((bits_pr_elemB - 1) << 10) | num_elemsB);
 }
 } // namespace
 


### PR DESCRIPTION
## What, How & Why?
Ops, enum numbers are wrong.

