### PR TITLE
fix accidental use after free

### DIFF
--- a/src/realm/sync/network/network_ssl.cpp
+++ b/src/realm/sync/network/network_ssl.cpp
@@ -206,12 +206,15 @@ std::string SecureTransportErrorCategory::message(int value) const
 {
     const char* message = "Unknown error";
 #if REALM_HAVE_SECURE_TRANSPORT
+    std::unique_ptr<char[]> buffer;
     if (__builtin_available(iOS 11.3, macOS 10.3, tvOS 11.3, watchOS 4.3, *)) {
         auto status = OSStatus(value);
         void* reserved = nullptr;
-        std::unique_ptr<char[]> buffer;
         if (auto cf_message = adoptCF(SecCopyErrorMessageString(status, reserved)))
             message = cfstring_to_cstring(cf_message.get(), buffer);
+    }
+    else {
+        static_cast<void>(buffer);
     }
 #endif // REALM_HAVE_SECURE_TRANSPORT
 


### PR DESCRIPTION
The object store test "sync: error handling" started failing for me locally after pulling in the latest changes. Looks like the buffer was accidentally scoped too narrowly when we added the availability checks.

This seems to be passing on CI, but on my machine I saw the following:
```
-------------------------------------------------------------------------------
sync: error handling
  reports TLS error as handshake failed
-------------------------------------------------------------------------------
/Users/james.stone/Documents/code/realm-core3/test/object-store/sync/session/session.cpp:390
...............................................................................

/Users/james.stone/Documents/code/realm-core3/test/object-store/sync/session/session.cpp:404: FAILED:
  CHECK( error->status.reason() == "TLS handshake failed: SecureTransport error: invalid certificate chain (-9807)" )
with expansion:
  "TLS handshake failed: SecureTransport error: pfl\263\300 (-9807)"
  ==
  "TLS handshake failed: SecureTransport error: invalid certificate chain (-
  9807)"
```