### PR TITLE
RCORE-2015 Merge rules for Clear instruction

### DIFF
--- a/src/realm/sync/changeset_parser.cpp
+++ b/src/realm/sync/changeset_parser.cpp
@@ -487,7 +487,6 @@ void State::parse_one()
             Instruction::Clear instr;
             read_path_instr(instr);
             instr.collection_type = read_collection_type();
-            // TODO: Add validation for collection_type once BAAS-29262 is done
             m_handler(instr);
             return;
         }

--- a/src/realm/sync/instruction_applier.cpp
+++ b/src/realm/sync/instruction_applier.cpp
@@ -900,7 +900,9 @@ void InstructionApplier::operator()(const Instruction::Clear& instr)
         void on_list(LstBase& list) override
         {
             // list property
-            REALM_ASSERT(!m_collection_type || *m_collection_type == CollectionType::List);
+            if (m_collection_type && *m_collection_type != CollectionType::List) {
+                m_applier->bad_transaction_log("Clear: Not a List");
+            }
             list.clear();
         }
         Status on_list_index(LstBase& list, uint32_t index) override
@@ -931,7 +933,9 @@ void InstructionApplier::operator()(const Instruction::Clear& instr)
         void on_dictionary(Dictionary& dict) override
         {
             // dictionary property
-            REALM_ASSERT(!m_collection_type || *m_collection_type == CollectionType::Dictionary);
+            if (m_collection_type && *m_collection_type != CollectionType::Dictionary) {
+                m_applier->bad_transaction_log("Clear: Not a Dictionary");
+            }
             dict.clear();
         }
         Status on_dictionary_key(Dictionary& dict, Mixed key) override
@@ -956,7 +960,9 @@ void InstructionApplier::operator()(const Instruction::Clear& instr)
         void on_set(SetBase& set) override
         {
             // set property
-            REALM_ASSERT(!m_collection_type || *m_collection_type == CollectionType::Set);
+            if (m_collection_type && *m_collection_type != CollectionType::Set) {
+                m_applier->bad_transaction_log("Clear: Not a Set");
+            }
             set.clear();
         }
         void on_property(Obj& obj, ColKey col_key) override

--- a/src/realm/sync/transform.cpp
+++ b/src/realm/sync/transform.cpp
@@ -1699,6 +1699,7 @@ DEFINE_MERGE(Instruction::Clear, Instruction::Update)
 
     // The two instructions are at the same level of nesting.
     if (same_path(left, right)) {
+        REALM_ASSERT(right.value.type != Type::Set);
         // If both sides are setting/operating on the same type, let them both pass through.
         // It is important that the instruction application rules reflect this.
         // If it is not two lists or dictionaries, then the normal last-writer-wins rules will take effect below.

--- a/test/test_transform_collections_mixed.cpp
+++ b/test/test_transform_collections_mixed.cpp
@@ -1467,10 +1467,6 @@ TEST(Transform_UpdateClearVsUpdateClear)
     std::vector<int> timestamps{1, 2, 3, 4};
 
     do {
-        // Baseline: property 'any' is not set to any type
-        // {id: 1, any: null}
-        TransformTestHarness h(test_context, {}, [](Obj, ColKey) {});
-
         auto t1 = timestamps[0];
         auto t2 = timestamps[1];
         auto t3 = timestamps[2];
@@ -1478,6 +1474,10 @@ TEST(Transform_UpdateClearVsUpdateClear)
 
         if (t1 > t2 || t3 > t4)
             continue;
+
+        // Baseline: property 'any' is not set to any type
+        // {id: 1, any: null}
+        TransformTestHarness h(test_context, {}, [](Obj, ColKey) {});
 
         // Client 1 sets property 'any' to List and inserts one integer in the list
         // {id: 1, any: [1]}
@@ -1521,6 +1521,7 @@ TEST(Transform_UpdateClearVsUpdateClear)
             },
             t4);
 
+        // Check clients converge.
         h.check_merge_result([&](Obj, ColKey) {});
 
     } while (std::next_permutation(timestamps.begin(), timestamps.end()));
@@ -1531,10 +1532,6 @@ TEST(Transform_UpdateClearVsUpdateClear_DifferentTypes)
     std::vector<int> timestamps{1, 2, 3, 4};
 
     do {
-        // Baseline: property 'any' is not set to any type
-        // {id: 1, any: null}
-        TransformTestHarness h(test_context, {}, [](Obj, ColKey) {});
-
         auto t1 = timestamps[0];
         auto t2 = timestamps[1];
         auto t3 = timestamps[2];
@@ -1542,6 +1539,10 @@ TEST(Transform_UpdateClearVsUpdateClear_DifferentTypes)
 
         if (t1 > t2 || t3 > t4)
             continue;
+
+        // Baseline: property 'any' is not set to any type
+        // {id: 1, any: null}
+        TransformTestHarness h(test_context, {}, [](Obj, ColKey) {});
 
         // Client 1 sets property 'any' to List and inserts one integer in the list
         // {id: 1, any: [1]}
@@ -1585,6 +1586,7 @@ TEST(Transform_UpdateClearVsUpdateClear_DifferentTypes)
             },
             t4);
 
+        // Check clients converge.
         h.check_merge_result([&](Obj, ColKey) {});
 
     } while (std::next_permutation(timestamps.begin(), timestamps.end()));
@@ -1661,12 +1663,6 @@ TEST(Transform_UpdateClearVsUpdateAddInteger)
     std::vector<int> timestamps{1, 2, 3, 4};
 
     do {
-        // Baseline: set property 'any' to List
-        // {id: 1, any: []}
-        TransformTestHarness h(test_context, {}, [](Obj obj, ColKey col_any) {
-            obj.set_collection(col_any, CollectionType::List);
-        });
-
         auto t1 = timestamps[0];
         auto t2 = timestamps[1];
         auto t3 = timestamps[2];
@@ -1674,6 +1670,12 @@ TEST(Transform_UpdateClearVsUpdateAddInteger)
 
         if (t1 > t2 || t3 > t4)
             continue;
+
+        // Baseline: set property 'any' to List
+        // {id: 1, any: []}
+        TransformTestHarness h(test_context, {}, [](Obj obj, ColKey col_any) {
+            obj.set_collection(col_any, CollectionType::List);
+        });
 
         // Client 1 sets property 'any' from List to Dictionary and inserts one integer in the dictionary
         // {id: 1, any: {{"key1": 1}}}
@@ -1715,6 +1717,7 @@ TEST(Transform_UpdateClearVsUpdateAddInteger)
             },
             t4);
 
+        // Check clients converge.
         h.check_merge_result([&](Obj, ColKey) {});
 
     } while (std::next_permutation(timestamps.begin(), timestamps.end()));


### PR DESCRIPTION
## What, How & Why?
Given the Clear instruction now has the collection type information, some adjustments have been made to the OT rules:

1. Clear vs Update (same type) => no conflict
2. Clear vs Update (different types) => the tiebreaker is used
3. Clear vs AddInteger => Clear wins


## ☑️ ToDos
* ~~[ ] 📝 Changelog update~~
* [X] 🚦 Tests (or not relevant)
* ~~[ ] C-API, if public C++ API changed~~
* ~~[ ] `bindgen/spec.yml`, if public C++ API changed~~
