### PR TITLE
modify errors_seen under lock to avoid race

### DIFF
--- a/test/util/unit_test.cpp
+++ b/test/util/unit_test.cpp
@@ -718,10 +718,10 @@ void TestList::ThreadContextImpl::run(SharedContextImpl::Entry entry, UniqueLock
     const Test& test = *entry.test;
     TestContext test_context(*this, test.details, entry.test_index, entry.recurrence_index);
     shared_context.reporter.begin(test_context);
-    lock.unlock();
-
     last_line_seen = test.details.line_number;
     errors_seen = false;
+    lock.unlock();
+
     Timer timer;
     try {
         (*test.run_func)(test_context);
@@ -735,10 +735,11 @@ void TestList::ThreadContextImpl::run(SharedContextImpl::Entry entry, UniqueLock
         test_context.test_failed(util::format("Unhandled exception after line %1 of unknown type", last_line_seen));
     }
     double elapsed_time = timer.get_elapsed_time();
+
+    lock.lock();
     if (errors_seen)
         ++num_failed_tests;
 
-    lock.lock();
     shared_context.reporter.end(test_context, elapsed_time);
 }
 


### PR DESCRIPTION
We observed a strange [test run](https://spruce.mongodb.com/task/realm_core_stable_macos_14_arm64_test_on_exfat_patch_bfcc09f8681ed259f43ad946aa44a3f57d37e833_66292e0874d607000726b9fc_24_04_24_16_06_34/logs?execution=0) that logs a test failure, but still marks the suite as successful. 

I think this could be due to a release mode code optimization that runs the check on `errors_seen` before it was changed. Regardless, it should be guarded by the mutex.

```
[2024/04/24 09:12:39.996] Platform: macOS Darwin 23.3.0 Darwin Kernel Version 23.3.0: Wed Dec 20 21:30:27 PST 2023; root:xnu-10002.81.5~7/RELEASE_ARM64_T8103 arm64
[2024/04/24 09:12:39.996] Encryption: Enabled at compile-time (always encrypt = no)
[2024/04/24 09:12:39.996] REALM_MAX_BPNODE_SIZE = 1000
[2024/04/24 09:12:39.996] REALM_MEMDEBUG = Disabled
[2024/04/24 09:12:39.996] sizeof (size_t) * 8 = 64
[2024/04/24 09:12:39.996] Compiler supported SSE (auto detect):       No
[2024/04/24 09:12:39.996] This CPU supports SSE (auto detect):        None
[2024/04/24 09:12:39.996] Compiler supported AVX (auto detect):       No
[2024/04/24 09:12:39.996] This CPU supports AVX (AVX1) (auto detect): No
[2024/04/24 09:12:39.996] UNITTEST_RANDOM_SEED:                       2174763425
[2024/04/24 09:12:39.996] Test path prefix:                           /Volumes/Untitled/
[2024/04/24 09:12:39.996] Test resource path:                         /Users/ec2-user/data/mci/51c5155705ded7a670da0b7bf60087c4/realm-core/build/test/Debug//realm-tests.app/Contents/Resources/
[2024/04/24 09:12:39.996] Number of test threads: 8 (default)
[2024/04/24 09:12:39.996] (Use UNITTEST_THREADS=1 to serialize testing)
[2024/04/24 09:15:51.341] Realm - Thread[4]: /Users/ec2-user/data/mci/51c5155705ded7a670da0b7bf60087c4/realm-core/test/test_file.cpp:600: ERROR in File_GetUniqueID: CHECK_THROW_EX(file1_1.get_unique_id(), FileAccessError, e.what() == expected_1) failed: Did not throw
[2024/04/24 09:15:51.341] Realm - Thread[4]: /Users/ec2-user/data/mci/51c5155705ded7a670da0b7bf60087c4/realm-core/test/test_file.cpp:601: ERROR in File_GetUniqueID: CHECK_THROW_EX(file2_1.get_unique_id(), FileAccessError, e.what() == expected_2) failed: Did not throw
[2024/04/24 09:18:11.205] 100000 rows - random
[2024/04/24 09:18:11.205]    insertion time: 3116 ns/key
[2024/04/24 09:18:11.205]   compaction time: 160 ms
[2024/04/24 09:18:11.205]    lookup obj    : 957 ns/key
[2024/04/24 09:18:11.614]    lookup field  : 1081 ns/key
[2024/04/24 09:18:11.614]    lookup same   : 1188 ns/key
[2024/04/24 09:18:11.614]    update time   : 1821 ns/key
[2024/04/24 09:18:18.404]    erase time    : 66665 ns/key
[2024/04/24 09:18:18.404] 1000 repetitions of find_all
[2024/04/24 09:18:18.404]     time: 12913 ns/rep
[2024/04/24 09:18:34.198] 5000 BPlusTree - sequential
[2024/04/24 09:18:34.198]    insertion time: 203 ns/row
[2024/04/24 09:18:34.198]    lookup time   : 25 ns/row
[2024/04/24 09:18:47.314] Normal: 217249 us
[2024/04/24 09:18:47.314] Compacting: 250824 us
[2024/04/24 09:18:47.314] 1000 values in dictionary
[2024/04/24 09:18:47.314]     insertion: 1644 ns/val
[2024/04/24 09:18:47.314]     lookup: 1151 ns/val
[2024/04/24 09:18:49.373] Establishing scenario seq ins/rnd erase
[2024/04/24 09:18:49.373]   compaction time: 94 ms
[2024/04/24 09:18:49.373] Scenario has 100000 rows. Timing....
[2024/04/24 09:18:49.679]    lookup obj    : 902 ns/key
[2024/04/24 09:18:49.679]    lookup field  : 1025 ns/key
[2024/04/24 09:18:49.679]    lookup same   : 1136 ns/key
[2024/04/24 09:18:50.126] 100000 rows - sequential
[2024/04/24 09:18:50.126]    insertion time: 1951 ns/key
[2024/04/24 09:18:50.126]   compaction time: 125 ms
[2024/04/24 09:18:50.282]    lookup obj    : 411 ns/key
[2024/04/24 09:18:50.282]    lookup field  : 523 ns/key
[2024/04/24 09:18:50.282]    lookup same   : 625 ns/key
[2024/04/24 09:18:59.156]    update time   : 1236 ns/key
[2024/04/24 09:18:59.156]    erase time    : 44131 ns/key
[2024/04/24 09:18:59.156]    insertion time: 3439 ns/key
[2024/04/24 09:18:59.156]    lookup time: 1384 ns/key
[2024/04/24 09:19:25.401] 1000 repetitions in Query_IntPerformance
[2024/04/24 09:19:25.401] Realm - Success: All 1636 tests passed (83872924 checks).
[2024/04/24 09:19:25.401]     time equal: 47635 ns/rep
[2024/04/24 09:19:25.401] Realm - Test time: 6m45s
[2024/04/24 09:19:25.401]     time not_equal: 47149 ns/rep
[2024/04/24 09:19:25.401]     time a == b: 80049 ns/rep
[2024/04/24 09:19:25.401]     time sum: 30748 ns/rep
[2024/04/24 09:19:25.401] Top 5 time usage:
[2024/04/24 09:19:25.401] ----------------------------------------------------------------
[2024/04/24 09:19:25.401] Compaction_Large<std::__1::integral_constant<bool,+true>>  3m33s
[2024/04/24 09:19:25.401] Transactions_ListOfBinary                                  2m37s
[2024/04/24 09:19:25.401] LangBindHelper_ConcurrentLinkViewDeletes                   2m34s
[2024/04/24 09:19:25.401] BPlusTree_FuzzBinary                                       2m14s
[2024/04/24 09:19:25.401] LangBindHelper_HandoverBetweenThreads                       2m8s
```