### PR TITLE
disable warnings in external code

### DIFF
--- a/src/external/IntelRDFPMathLib20U2/CMakeLists.txt
+++ b/src/external/IntelRDFPMathLib20U2/CMakeLists.txt
@@ -26,10 +26,7 @@ if(MSVC)
     target_compile_options(Bid PUBLIC /sdl-)
 endif()
 
-# Note: checking for -Wfoo since unknown -Wno-foo flags are ignored.
-check_cxx_compiler_flag(-Wunused-but-set-variable HAVE-Wunused-but-set-variable)
-if(HAVE-Wunused-but-set-variable)
-    target_compile_options(Bid PRIVATE -Wno-unused-but-set-variable)
-endif()
+# disable warnings in this project
+target_compile_options(Bid PUBLIC -w)
 
 set_target_properties(Bid PROPERTIES CXX_VISIBILITY_PRESET hidden)

--- a/src/external/IntelRDFPMathLib20U2/CMakeLists.txt
+++ b/src/external/IntelRDFPMathLib20U2/CMakeLists.txt
@@ -27,6 +27,12 @@ if(MSVC)
 endif()
 
 # disable warnings in this project
-target_compile_options(Bid PUBLIC -w)
+# warnings should be checked when updating the library code
+if (MSVC)
+  target_compile_options(Bid PUBLIC /W0)
+else()
+  target_compile_options(Bid PUBLIC -w)
+endif()
+
 
 set_target_properties(Bid PROPERTIES CXX_VISIBILITY_PRESET hidden)

--- a/src/external/bson/CMakeLists.txt
+++ b/src/external/bson/CMakeLists.txt
@@ -51,5 +51,7 @@ target_compile_definitions(Bson PRIVATE _GNU_SOURCE _XOPEN_SOURCE=700 BSON_COMPI
 if (CMAKE_SYSTEM_NAME MATCHES "Darwin")
   target_compile_definitions(Bson PRIVATE _DARWIN_C_SOURCE)
 endif()
+# disable warnings in this project
+target_compile_options(Bson PUBLIC -w)
 target_include_directories(Bson PUBLIC .. ${PROJECT_BINARY_DIR}/src/external)
 target_compile_definitions(Bson INTERFACE BSON_STATIC)

--- a/src/external/bson/CMakeLists.txt
+++ b/src/external/bson/CMakeLists.txt
@@ -51,7 +51,14 @@ target_compile_definitions(Bson PRIVATE _GNU_SOURCE _XOPEN_SOURCE=700 BSON_COMPI
 if (CMAKE_SYSTEM_NAME MATCHES "Darwin")
   target_compile_definitions(Bson PRIVATE _DARWIN_C_SOURCE)
 endif()
+
 # disable warnings in this project
-target_compile_options(Bson PUBLIC -w)
+# warnings should be checked when updating the library code
+if (MSVC)
+  target_compile_options(Bson PUBLIC /W0)
+else()
+  target_compile_options(Bson PUBLIC -w)
+endif()
+
 target_include_directories(Bson PUBLIC .. ${PROJECT_BINARY_DIR}/src/external)
 target_compile_definitions(Bson INTERFACE BSON_STATIC)

--- a/src/external/bson/bson-types.h
+++ b/src/external/bson/bson-types.h
@@ -389,7 +389,7 @@ typedef struct {
 BSON_ALIGNED_BEGIN (BSON_ALIGN_OF_PTR)
 typedef struct {
    uint32_t type;
-   /*< private >*/
+   /* < private > */
 } bson_reader_t BSON_ALIGNED_END (BSON_ALIGN_OF_PTR);
 
 


### PR DESCRIPTION
There are a handful of warnings when building core with recent Xcode versions. Instead of fixing them, I suggest we disable warnings in code that we didn't write.