### PR TITLE
Revert sync protocol version

### DIFF
--- a/src/realm/sync/protocol.hpp
+++ b/src/realm/sync/protocol.hpp
@@ -57,8 +57,6 @@ namespace sync {
 //      Server replaces 'downloadable_bytes' (which was always zero prior this version)
 //      with an estimated progress value (double from 0.0 to 1.0) for flx sessions
 //
-//   13 Support for syncing collections (lists and dictionaries) in Mixed columns
-//
 //  XX Changes:
 //     - TBD
 //
@@ -66,7 +64,7 @@ constexpr int get_current_protocol_version() noexcept
 {
     // Also update the current protocol version test in flx_sync.cpp when
     // updating this value
-    return 13;
+    return 12;
 }
 
 constexpr std::string_view get_pbs_websocket_protocol_prefix() noexcept

--- a/test/object-store/sync/flx_sync.cpp
+++ b/test/object-store/sync/flx_sync.cpp
@@ -2583,7 +2583,7 @@ TEST_CASE("flx: writes work without waiting for sync", "[sync][flx][baas]") {
 TEST_CASE("flx: verify websocket protocol number and prefixes", "[sync][protocol]") {
     // Update the expected value whenever the protocol version is updated - this ensures
     // that the current protocol version does not change unexpectedly.
-    REQUIRE(13 == sync::get_current_protocol_version());
+    REQUIRE(12 == sync::get_current_protocol_version());
     // This was updated in Protocol V8 to use '#' instead of '/' to support the Web SDK
     REQUIRE("com.mongodb.realm-sync#" == sync::get_pbs_websocket_protocol_prefix());
     REQUIRE("com.mongodb.realm-query-sync#" == sync::get_flx_websocket_protocol_prefix());


### PR DESCRIPTION
## What, How & Why?
We're reverting the sync protocol version until we have fixed client reset with recovery.

## ☑️ ToDos
* ~~[ ] 📝 Changelog update~~
* ~~[ ] 🚦 Tests (or not relevant)~~
* ~~[ ] C-API, if public C++ API changed~~
* ~~[ ] `bindgen/spec.yml`, if public C++ API changed~~
