### PR TITLE
RCORE-2100: Restore ability to create test users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * <New feature description> (PR [#????](https://github.com/realm/realm-core/pull/????))
 * Add `SyncClientConfig::security_access_group` which allows specifying the access group to use for the sync metadata Realm's encryption key. Setting this is required when sharing the metadata Realm between apps on Apple platforms ([#7552](https://github.com/realm/realm-core/pull/7552)).
 * When connecting to multiple server apps, a unique encryption key is used for each of the metadata Realms rather than sharing one between them ([#7552](https://github.com/realm/realm-core/pull/7552)).
-* Introduce the new `SyncUser` interface which can be implemented by SDKs to use sync without the core App Services implementation (or just for greater control over user behavior in tests). ([PR #7300](https://github.com/realm/realm-core/pull/7300).
+* Introduce the new `SyncUser` interface which can be implemented by SDKs to use sync without the core App Services implementation (or just for greater control over user behavior in tests). ([PR #7300](https://github.com/realm/realm-core/pull/7300)).
 * Improve perfomance of "chained OR equality" queries for UUID/ObjectId types and RQL parsed "IN" queries on string/int/uuid/objectid types. ([.Net #3566](https://github.com/realm/realm-dotnet/issues/3566), since the introduction of these types)
 * Introducing `Query::in()` which allows SDKs to take advantage of improved performance when building equality conditions against many constants. ([#7582](https://github.com/realm/realm-core/pull/7582))
 
@@ -34,12 +34,13 @@
   - SyncUser::all_sessions() -> SyncManager::get_all_sessions_for(User&)
   - SyncManager::immediately_run_file_actions() -> App::immediately_run_file_actions()
   - realm_sync_user_subscription_token -> realm_app_user_subscription_token
-  ([PR #7300](https://github.com/realm/realm-core/pull/7300).
-* The `ClientAppDeallocated` error code no longer exists as this error code can no longer occur. ([PR #7300](https://github.com/realm/realm-core/pull/7300).
-* Some fields have moved from SyncClientConfig to AppConfig. AppConfig now has a SyncClientConfig field rather than it being passed separately to App::get_app(). ([PR #7300](https://github.com/realm/realm-core/pull/7300).
-* Sync user management has been removed from SyncManager. This functionality was already additionally available on App. ([PR #7300](https://github.com/realm/realm-core/pull/7300).
-* AuditConfig now has a base_file_path field which must be set by the SDK rather than inheriting it from the SyncManager. ([PR #7300](https://github.com/realm/realm-core/pull/7300).
-* App::switch_user() no longer returns a user. The return value was always exactly the passed-in user and any code which needs it can just use that. ([PR #7300](https://github.com/realm/realm-core/pull/7300).
+  - SyncManager::get_user -> App::create_fake_user_for_testing
+  ([PR #7300](https://github.com/realm/realm-core/pull/7300)).
+* The `ClientAppDeallocated` error code no longer exists as this error code can no longer occur. ([PR #7300](https://github.com/realm/realm-core/pull/7300)).
+* Some fields have moved from SyncClientConfig to AppConfig. AppConfig now has a SyncClientConfig field rather than it being passed separately to App::get_app(). ([PR #7300](https://github.com/realm/realm-core/pull/7300)).
+* Sync user management has been removed from SyncManager. This functionality was already additionally available on App. ([PR #7300](https://github.com/realm/realm-core/pull/7300)).
+* AuditConfig now has a base_file_path field which must be set by the SDK rather than inheriting it from the SyncManager. ([PR #7300](https://github.com/realm/realm-core/pull/7300)).
+* App::switch_user() no longer returns a user. The return value was always exactly the passed-in user and any code which needs it can just use that. ([PR #7300](https://github.com/realm/realm-core/pull/7300)).
 * Non-streaming download progress callback no longer stops reporting values immediately after the registration (if the progress update has happened earlier), but waits for the next batch of data to start syncing to report its progress, since the previous behaviour was not useful (PR [#7561](https://github.com/realm/realm-core/issues/7561)).
 
 ### Compatibility

--- a/src/realm/object-store/sync/app.cpp
+++ b/src/realm/object-store/sync/app.cpp
@@ -979,10 +979,16 @@ void App::link_user(const std::shared_ptr<User>& user, const AppCredentials& cre
 std::shared_ptr<User> App::create_fake_user_for_testing(const std::string& user_id, const std::string& access_token,
                                                         const std::string& refresh_token)
 {
-    m_metadata_store->create_user(user_id, refresh_token, access_token, "fake_device");
-    util::CheckedLockGuard lock(m_user_mutex);
-    user_data_updated(user_id); // FIXME: needs to be callback from metadata store
-    return get_user_for_id(user_id);
+    std::shared_ptr<User> user;
+    {
+        m_metadata_store->create_user(user_id, refresh_token, access_token, "fake_device");
+        util::CheckedLockGuard lock(m_user_mutex);
+        user_data_updated(user_id); // FIXME: needs to be callback from metadata store
+        user = get_user_for_id(user_id);
+    }
+
+    switch_user(user);
+    return user;
 }
 
 

--- a/src/realm/object-store/sync/app.cpp
+++ b/src/realm/object-store/sync/app.cpp
@@ -976,6 +976,16 @@ void App::link_user(const std::shared_ptr<User>& user, const AppCredentials& cre
     log_in_with_credentials(credentials, user, std::move(completion));
 }
 
+std::shared_ptr<User> App::create_fake_user_for_testing(const std::string& user_id, const std::string& access_token,
+                                                        const std::string& refresh_token)
+{
+    m_metadata_store->create_user(user_id, refresh_token, access_token, "fake_device");
+    util::CheckedLockGuard lock(m_user_mutex);
+    user_data_updated(user_id); // FIXME: needs to be callback from metadata store
+    return get_user_for_id(user_id);
+}
+
+
 void App::refresh_custom_data(const std::shared_ptr<User>& user,
                               UniqueFunction<void(Optional<AppError>)>&& completion)
 {

--- a/src/realm/object-store/sync/app.hpp
+++ b/src/realm/object-store/sync/app.hpp
@@ -184,6 +184,14 @@ public:
                      util::UniqueFunction<void(std::optional<AppError>)>&& completion)
         REQUIRES(!m_route_mutex, !m_user_mutex);
 
+    /// Creates a fake user with the provided access and refresh tokens. No validation is done to ensure that the
+    /// credentials are actually valid and as such, this should only be used for testing purposes.
+    /// @param user_id The id of the user that will be created
+    /// @param access_token The access token of the user
+    /// @param refresh_token The refresh token of the user
+    std::shared_ptr<User> create_fake_user_for_testing(const std::string& user_id, const std::string& access_token,
+                                                       const std::string& refresh_token);
+
     // MARK: - Provider Clients
 
     /// A struct representing a user API key as returned by the App server.


### PR DESCRIPTION
## What, How & Why?
This is a follow-up on https://github.com/realm/realm-core/pull/7300, where we restore the ability for SDKs to construct a fake user for testing when actual sync session is not necessary. This is only intended to be used for tests and should never be exposed to users.

Fixes https://github.com/realm/realm-core/issues/7633.

## ☑️ ToDos
* [x] 📝 Changelog update
