### PR TITLE
RCORE-1991 Add small BPNode/no encryption builders

### DIFF
--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -1303,7 +1303,7 @@ buildvariants:
 
 - name: ubuntu-no-encryption
   display_name: "Ubuntu (No encryption support)"
-  run_on: ubutnu2204-arm64-large
+  run_on: ubuntu2204-arm64-large
   expansions:
     fetch_missing_dependencies: On
     c_compiler: "/opt/clang+llvm/bin/clang"

--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -138,7 +138,7 @@ functions:
           fi
 
           set_cmake_var realm_vars REALM_BUILD_COMMANDLINE_TOOLS BOOL On
-          set_cmake_var realm_vars REALM_ENABLE_ENCRYPTION BOOL On
+          set_cmake_var realm_vars REALM_ENABLE_ENCRYPTION BOOL "${enable_realm_encryption|On}"
 
           if [[ -n "${fetch_missing_dependencies|}" ]]; then
               set_cmake_var realm_vars REALM_FETCH_MISSING_DEPENDENCIES BOOL On
@@ -1289,6 +1289,28 @@ buildvariants:
     extra_flags: "-DREALM_ENABLE_GEOSPATIAL=OFF"
   tasks:
   - name: compile_test
+
+- name: ubuntu-small-bpnode-size
+  display_name: "Ubuntu (Small BPNode size)"
+  run_on: ubuntu2204-arm64-large
+  expansions:
+    fetch_missing_dependencies: On
+    c_compiler: "/opt/clang+llvm/bin/clang"
+    cxx_compiler: "/opt/clang+llvm/bin/clang++"
+    extra_flags: -DREALM_MAX_BPNODE_SIZE=4
+  tasks:
+  - name: compile_local_tests
+
+- name: ubuntu-no-encryption
+  display_name: "Ubuntu (No encryption support)"
+  run_on: ubutnu2204-arm64-large
+  expansions:
+    fetch_missing_dependencies: On
+    c_compiler: "/opt/clang+llvm/bin/clang"
+    cxx_compiler: "/opt/clang+llvm/bin/clang++"
+    enable_realm_encryption: Off
+  tasks:
+  - name: compile_local_tests
 
 - name: ubuntu-encryption-tsan
   display_name: "Ubuntu (Encryption Enabled w/TSAN)"

--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -137,7 +137,7 @@ functions:
               set_cmake_var realm_vars REALM_LLVM_COVERAGE BOOL On
           fi
 
-          set_cmake_var realm_vars REALM_BUILD_COMMANDLINE_TOOLS BOOL On
+          set_cmake_var realm_vars REALM_BUILD_COMMANDLINE_TOOLS BOOL "${build_command_line_tools|On}"
           set_cmake_var realm_vars REALM_ENABLE_ENCRYPTION BOOL "${enable_realm_encryption|On}"
 
           if [[ -n "${fetch_missing_dependencies|}" ]]; then
@@ -1298,6 +1298,7 @@ buildvariants:
     c_compiler: "/opt/clang+llvm/bin/clang"
     cxx_compiler: "/opt/clang+llvm/bin/clang++"
     extra_flags: -DREALM_MAX_BPNODE_SIZE=4
+    build_command_line_tools: Off
   tasks:
   - name: compile_local_tests
 
@@ -1309,6 +1310,8 @@ buildvariants:
     c_compiler: "/opt/clang+llvm/bin/clang"
     cxx_compiler: "/opt/clang+llvm/bin/clang++"
     enable_realm_encryption: Off
+    build_command_line_tools: Off
+    disable_tests_against_baas: On
   tasks:
   - name: compile_local_tests
 
@@ -1322,6 +1325,7 @@ buildvariants:
     run_with_encryption: On
     enable_tsan: On
     cmake_build_type: RelWithDebInfo
+    disable_tests_against_baas: On
   tasks:
   - name: core_tests_group
 

--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -1325,7 +1325,6 @@ buildvariants:
     run_with_encryption: On
     enable_tsan: On
     cmake_build_type: RelWithDebInfo
-    disable_tests_against_baas: On
   tasks:
   - name: core_tests_group
 

--- a/src/realm/CMakeLists.txt
+++ b/src/realm/CMakeLists.txt
@@ -387,7 +387,7 @@ if(REALM_HAVE_BACKTRACE AND NOT CMAKE_GENERATOR STREQUAL Xcode)
     target_link_libraries(Storage PUBLIC ${Backtrace_LIBRARIES})
 endif()
 
-if(REALM_ENABLE_ENCRYPTION AND REALM_HAVE_OPENSSL AND (UNIX OR WIN32))
+if(REALM_HAVE_OPENSSL AND (UNIX OR WIN32))
     target_link_libraries(Storage PUBLIC OpenSSL::Crypto)
 endif()
 

--- a/src/realm/util/encrypted_file_mapping.cpp
+++ b/src/realm/util/encrypted_file_mapping.cpp
@@ -20,6 +20,8 @@
 
 #include <realm/util/file_mapper.hpp>
 
+#include <sstream>
+
 #if REALM_ENABLE_ENCRYPTION
 #include <realm/util/aes_cryptor.hpp>
 #include <realm/util/errno.hpp>
@@ -30,7 +32,6 @@
 #include <cstdlib>
 #include <algorithm>
 #include <chrono>
-#include <sstream>
 #include <stdexcept>
 #include <string_view>
 #include <system_error>

--- a/test/object-store/sync/metadata.cpp
+++ b/test/object-store/sync/metadata.cpp
@@ -59,6 +59,7 @@ std::shared_ptr<Realm> get_metadata_realm()
 using realm::util::adoptCF;
 using realm::util::CFPtr;
 
+#if REALM_ENABLE_ENCRYPTION
 constexpr const char* access_group = "";
 bool can_access_keychain()
 {
@@ -74,6 +75,7 @@ bool can_access_keychain()
     }();
     return can_access_keychain;
 }
+#endif
 
 CFPtr<CFMutableDictionaryRef> build_search_dictionary(CFStringRef account, CFStringRef service)
 {
@@ -607,6 +609,7 @@ TEST_CASE("app metadata: persisted", "[sync][metadata]") {
     }
 }
 
+#if REALM_ENABLE_ENCRYPTION
 TEST_CASE("app metadata: encryption", "[sync][metadata]") {
     test_util::TestDirGuard test_dir(base_path);
 
@@ -731,6 +734,8 @@ TEST_CASE("app metadata: encryption", "[sync][metadata]") {
     }
 #endif // REALM_PLATFORM_APPLE
 }
+
+#endif
 
 #ifndef SWIFT_PACKAGE // The SPM build currently doesn't copy resource files
 TEST_CASE("sync metadata: can open old metadata realms", "[sync][metadata]") {
@@ -890,7 +895,7 @@ TEST_CASE("sync metadata: can open old metadata realms", "[sync][metadata]") {
 }
 #endif // SWIFT_PACKAGE
 
-#if REALM_PLATFORM_APPLE
+#if REALM_PLATFORM_APPLE && REALM_ENABLE_ENCRYPTION
 TEST_CASE("keychain", "[sync][metadata]") {
     if (!can_access_keychain()) {
         return;

--- a/test/test_sync_history_migration.cpp
+++ b/test/test_sync_history_migration.cpp
@@ -48,7 +48,7 @@ using namespace realm::test_util;
 namespace {
 
 #if !REALM_MOBILE
-TEST(Sync_HistoryMigration)
+TEST_IF(Sync_HistoryMigration, REALM_MAX_BPNODE_SIZE == 1000)
 {
     // Set to true to produce new versions of client and server-side files in
     // `resources/history_migration/` as needed. This should be done whenever

--- a/test/test_sync_subscriptions.cpp
+++ b/test/test_sync_subscriptions.cpp
@@ -399,7 +399,9 @@ TEST(Sync_SubscriptionStoreRefreshSubscriptionSetInvalid)
     CHECK_THROW(latest->refresh(), RuntimeError);
 }
 
-TEST(Sync_SubscriptionStoreInternalSchemaMigration)
+// Only runs if REALM_MAX_BPNODE_SIZE is 1000 since that's what the pre-created
+// test realm files were created with
+TEST_IF(Sync_SubscriptionStoreInternalSchemaMigration, REALM_MAX_BPNODE_SIZE == 1000)
 {
     SHARED_GROUP_TEST_PATH(sub_store_path)
 


### PR DESCRIPTION
## What, How & Why?
This adds two builders we ran in Jenkins to evergreen. The small BPNode builder runs the core/sync/local obj store tests with small BPNodes to force core to aggressively split BPNodes. The no encryption disables encryption support entirely at compile time rather than just not running tests with encryption enabled.

## ☑️ ToDos
~* [ ] 📝 Changelog update~
* [x] 🚦 Tests (or not relevant)
~* [ ] C-API, if public C++ API changed~
~* [ ] `bindgen/spec.yml`, if public C++ API changed~
