### PR TITLE
Fix building for Apple devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Internals
 * Follow on to ([PR #7300](https://github.com/realm/realm-core/pull/7300)) to allow SDKs to construct a fake user for testing SyncManager::get_user -> App::create_fake_user_for_testing ([PR #7632](https://github.com/realm/realm-core/pull/7632))
+* Fix build-apple-device.sh, broken in [#7603](https://github.com/realm/realm-core/pull/7603) ([PR #7640](https://github.com/realm/realm-core/pull/7640)).
 
 ----------------------------------------------
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -400,11 +400,7 @@ install(FILES tools/cmake/AcquireRealmDependency.cmake
         COMPONENT devel
         )
 
-if(REALM_BUILD_LIB_ONLY)
-    set(REALM_EXCLUDE_TESTS EXCLUDE_FROM_ALL)
-endif()
-
-if (NOT REALM_NO_TESTS)
+if(NOT REALM_BUILD_LIB_ONLY AND NOT REALM_NO_TESTS)
     enable_testing()
     add_subdirectory(test)
 endif()


### PR DESCRIPTION
12d53fc139cbc48350e5805d2ee58e733f2d95e8 made it so that REALM_BUILD_LIB_ONLY did not disable building the tests, which broke building for platforms where the tests aren't supported.