### PR TITLE
RCORE-2108 Avoid deleting self if the instance of the same object is added to a collection in a mixed.

### DIFF
--- a/src/realm/array.hpp
+++ b/src/realm/array.hpp
@@ -865,11 +865,13 @@ inline void Array::erase(size_t ndx)
 {
     // This can throw, but only if array is currently in read-only
     // memory.
-    move(ndx + 1, size(), ndx);
 
-    // Update size (also in header)
-    --m_size;
-    set_header_size(m_size);
+    if (ndx < size()) {
+        // Update size (also in header)
+        move(ndx + 1, size(), ndx);
+        --m_size;
+        set_header_size(m_size);
+    }
 }
 
 

--- a/test/test_list.cpp
+++ b/test/test_list.cpp
@@ -969,7 +969,7 @@ TEST(List_NestedCollection_Unresolved)
     CHECK_EQUAL(list.get(0), Mixed(obj.get_link()));
 }
 
-TEST(List_Avoid_cyclic_dependecy)
+TEST(Collection_Mixed_avoid_deleting_self)
 {
     SHARED_GROUP_TEST_PATH(path);
     DBRef db = DB::create(make_in_realm_history(), path);
@@ -977,21 +977,29 @@ TEST(List_Avoid_cyclic_dependecy)
     auto origin = tr->add_table("origin");
     auto col_any = origin->add_column(type_Mixed, "any");
 
-    Obj o = origin->create_object();
     std::vector<Obj> objs;
     for (size_t i = 0; i < 10; ++i)
         objs.push_back(origin->create_object());
 
+    Obj o = origin->create_object();
     o.set_collection(col_any, CollectionType::List);
     Lst<Mixed> list(o, col_any);
+    for (auto& obj : objs)
+        list.add(obj.get_link());
+
+    for (auto obj : objs)
+        obj.invalidate();
+
+    objs.clear();
+    for (size_t i = 0; i < 10; ++i)
+        objs.push_back(origin->create_object());
+
+    o.set_collection(col_any, CollectionType::Dictionary);
+    auto dict = o.get_dictionary_ptr(col_any);
     size_t i = 0;
     for (auto& obj : objs)
-        list.insert(i++, obj.get_link());
-
-    for (auto& obj : objs)
-        CHECK(obj.get_backlink_count() == 1);
-
-    for (auto& obj : objs)
+        dict->insert(Mixed{std::to_string(i++)}, obj.get_link());
+    for (auto obj : objs)
         obj.invalidate();
 }
 


### PR DESCRIPTION
## What, How & Why?
We should not allow this behaviour, probably the right fix is to throw an exception if we add a link to an object that is basically an instance of the same table, if the table has just one mixed column. 

The aim is to prevent this issue:  https://github.com/realm/realm-core/issues/7657

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed
* [ ] `bindgen/spec.yml`, if public C++ API changed
