### PR TITLE
RCORE-2102 Query in fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Fix assertion failure or wrong results when evaluating a RQL query with multiple IN conditions on the same property. Applies to non-indexed int/string/ObjectId/UUID properties, or if they were indexed and had > 100 conditions. ((RCORE-2098) [PR #7628](https://github.com/realm/realm-core/pull/7628) since v14.6.0).
 * Fixed a bug when running a IN query (or a query of the pattern `x == 1 OR x == 2 OR x == 3`) when evaluating on a string property with an empty string in the search condition. Matches with an empty string would have been evaluated as if searching for a null string instead. ([PR #7628](https://github.com/realm/realm-core/pull/7628) since v10.0.0-beta.9)
+* Fixed a bug when running a IN query on a String/Int/UUID/ObjectId property that was indexed. ([7642](https://github.com/realm/realm-core/issues/7642) since v14.6.0)
 
 ### Breaking changes
 * None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Fix assertion failure or wrong results when evaluating a RQL query with multiple IN conditions on the same property. Applies to non-indexed int/string/ObjectId/UUID properties, or if they were indexed and had > 100 conditions. ((RCORE-2098) [PR #7628](https://github.com/realm/realm-core/pull/7628) since v14.6.0).
 * Fixed a bug when running a IN query (or a query of the pattern `x == 1 OR x == 2 OR x == 3`) when evaluating on a string property with an empty string in the search condition. Matches with an empty string would have been evaluated as if searching for a null string instead. ([PR #7628](https://github.com/realm/realm-core/pull/7628) since v10.0.0-beta.9)
 * Fixed a bug when running a IN query on a String/Int/UUID/ObjectId property that was indexed. ([7642](https://github.com/realm/realm-core/issues/7642) since v14.6.0)
+* Fixed a bug when running a IN query on a integer property where double/float parameters were ignored. ([7642](https://github.com/realm/realm-core/issues/7642) since v14.6.0)
 
 ### Breaking changes
 * None.

--- a/src/realm/query_engine.cpp
+++ b/src/realm/query_engine.cpp
@@ -283,6 +283,7 @@ void StringNodeEqualBase::init(bool will_query_ranges)
     }
 
     if (uses_index) {
+        m_index_evaluator = std::make_optional(IndexEvaluator{});
         _search_index_init();
     }
 }
@@ -392,8 +393,9 @@ StringNode<Equal>::StringNode(ColKey col, const Mixed* begin, const Mixed* end)
             m_needles.emplace();
         }
         else if (const StringData* str = it->get_if<StringData>()) {
-            m_needle_storage.push_back(std::make_unique<char[]>(str->size()));
+            m_needle_storage.push_back(std::make_unique<char[]>(str->size() + 1));
             std::copy(str->data(), str->data() + str->size(), m_needle_storage.back().get());
+            m_needle_storage.back()[str->size()] = '\0';
             m_needles.insert(StringData(m_needle_storage.back().get(), str->size()));
         }
     }
@@ -404,6 +406,10 @@ StringNode<Equal>::StringNode(ColKey col, const Mixed* begin, const Mixed* end)
 
 void StringNode<Equal>::_search_index_init()
 {
+    if (!m_needles.empty()) {
+        m_index_evaluator.reset();
+        return;
+    }
     REALM_ASSERT(bool(m_index_evaluator));
     auto index = ParentNode::m_table.unchecked_ptr()->get_search_index(ParentNode::m_condition_column_key);
     m_index_evaluator->init(index, StringNodeBase::m_string_value);

--- a/src/realm/query_engine.hpp
+++ b/src/realm/query_engine.hpp
@@ -1246,18 +1246,12 @@ public:
         if (!this->m_value_is_null) {
             m_optional_value = this->m_value;
         }
-        if (m_index_evaluator && m_nb_needles == 0) {
+        if (m_nb_needles == 0 && has_search_index()) {
+            m_index_evaluator = std::make_optional(IndexEvaluator{});
             SearchIndex* index = BaseType::m_table->get_search_index(BaseType::m_condition_column_key);
             m_index_evaluator->init(index, m_optional_value);
             this->m_dT = 0;
         }
-    }
-
-    void table_changed() override
-    {
-        const bool has_index =
-            this->m_table->search_index_type(BaseType::m_condition_column_key) == IndexType::General;
-        m_index_evaluator = has_index ? std::make_optional(IndexEvaluator{}) : std::nullopt;
     }
 
     const IndexEvaluator* index_based_keys() override
@@ -1267,7 +1261,7 @@ public:
 
     bool has_search_index() const override
     {
-        return bool(m_index_evaluator);
+        return this->m_table->search_index_type(BaseType::m_condition_column_key) == IndexType::General;
     }
 
     size_t find_first_local(size_t start, size_t end) override
@@ -1882,17 +1876,9 @@ public:
 
     void init(bool) override;
 
-    void table_changed() override
-    {
-        StringNodeBase::table_changed();
-        const bool has_index =
-            m_table.unchecked_ptr()->search_index_type(m_condition_column_key) == IndexType::General;
-        m_index_evaluator = has_index ? std::make_optional(IndexEvaluator{}) : std::nullopt;
-    }
-
     bool has_search_index() const override
     {
-        return bool(m_index_evaluator);
+        return bool(m_table.unchecked_ptr()->search_index_type(m_condition_column_key) == IndexType::General);
     }
 
     void cluster_changed() override

--- a/src/realm/query_engine.hpp
+++ b/src/realm/query_engine.hpp
@@ -514,10 +514,10 @@ public:
             }
             else if (const double* val = it->get_if<double>()) {
                 // JS encodes numbers as double
-                m_needles.insert(int64_t(*val));
-            }
-            else if (const float* val = it->get_if<float>()) {
-                m_needles.insert(int64_t(*val));
+                // only add this value if it represents an integer
+                if (*val == double(int64_t(*val))) {
+                    m_needles.insert(int64_t(*val));
+                }
             }
         }
     }

--- a/src/realm/query_engine.hpp
+++ b/src/realm/query_engine.hpp
@@ -512,6 +512,13 @@ public:
             if (const int64_t* val = it->get_if<int64_t>()) {
                 m_needles.insert(*val);
             }
+            else if (const double* val = it->get_if<double>()) {
+                // JS encodes numbers as double
+                m_needles.insert(int64_t(*val));
+            }
+            else if (const float* val = it->get_if<float>()) {
+                m_needles.insert(int64_t(*val));
+            }
         }
     }
 

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -4129,7 +4129,8 @@ TEST_TYPES(Parser_7642, std::true_type, std::false_type)
 
     using Vec = std::vector<Mixed>;
     verify_query(test_context, cars, "make IN $0", {Vec{"Tesla", "Audi"}}, 2);
-    verify_query(test_context, cars, "value IN $0", {Vec{456, 789.0f, 123.0}}, 3);
+    // do not compare to floats, and do not compare to doubles that are not an exact integer
+    verify_query(test_context, cars, "value IN $0", {Vec{456, 789.0f, 123.0, 789.10}}, 2);
 }
 
 TEST(Parser_KeyPathSubstitution)

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -4124,8 +4124,8 @@ TEST_TYPES(Parser_7642, std::true_type, std::false_type)
     }
 
     cars->create_object().set(col_make, "Tesla").set(col_int, 123);
-    cars->create_object().set(col_make, "Ford").set(col_int, 456);;
-    cars->create_object().set(col_make, "Audi").set(col_int, 789);;
+    cars->create_object().set(col_make, "Ford").set(col_int, 456);
+    cars->create_object().set(col_make, "Audi").set(col_int, 789);
 
     using Vec = std::vector<Mixed>;
     verify_query(test_context, cars, "make IN $0", {Vec{"Tesla", "Audi"}}, 2);

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -4112,6 +4112,26 @@ TEST(Parser_OrOfIn)
                  "name IN {'Ani', 'Teddy'} OR name IN {'Poly', 'Teddy'} OR name IN {null} OR name IN {''}", 5);
 }
 
+TEST_TYPES(Parser_7642, std::true_type, std::false_type)
+{
+    Group g;
+    auto cars = g.add_table("class_Car");
+    auto col_make = cars->add_column(type_String, "make");
+    auto col_int = cars->add_column(type_Int, "value");
+    if (TEST_TYPE::value) {
+        cars->add_search_index(col_make);
+        cars->add_search_index(col_int);
+    }
+
+    cars->create_object().set(col_make, "Tesla").set(col_int, 123);
+    cars->create_object().set(col_make, "Ford").set(col_int, 456);;
+    cars->create_object().set(col_make, "Audi").set(col_int, 789);;
+
+    using Vec = std::vector<Mixed>;
+    verify_query(test_context, cars, "make IN $0", {Vec{"Tesla", "Audi"}}, 2);
+    verify_query(test_context, cars, "value IN $0", {Vec{456, 789.0f, 123.0}}, 3);
+}
+
 TEST(Parser_KeyPathSubstitution)
 {
     Group g;

--- a/test/test_query2.cpp
+++ b/test/test_query2.cpp
@@ -5958,9 +5958,8 @@ TEST(Query_links_to_with_bpnode_split)
 TEST_TYPES(Query_ManyIn, Prop<Int>, Prop<String>, Prop<Float>, Prop<Double>, Prop<Timestamp>, Prop<UUID>,
            Prop<ObjectId>, Prop<Decimal128>, Prop<BinaryData>, Prop<Mixed>, Nullable<Int>, Nullable<String>,
            Nullable<Float>, Nullable<Double>, Nullable<Timestamp>, Nullable<UUID>, Nullable<ObjectId>,
-           Nullable<Decimal128>, Nullable<BinaryData>, Indexed<Int>, Indexed<String>, Indexed<Float>, Indexed<Double>,
-           Indexed<Timestamp>, Indexed<UUID>, Indexed<ObjectId>, Indexed<Decimal128>, Indexed<BinaryData>,
-           Indexed<Mixed>)
+           Nullable<Decimal128>, Nullable<BinaryData>, Indexed<Int>, Indexed<String>, Indexed<Timestamp>,
+           Indexed<UUID>, Indexed<ObjectId>, Indexed<Mixed>)
 {
     using type = typename TEST_TYPE::type;
     TestValueGenerator gen;
@@ -5968,6 +5967,9 @@ TEST_TYPES(Query_ManyIn, Prop<Int>, Prop<String>, Prop<Float>, Prop<Double>, Pro
 
     auto t = g.add_table("foo");
     auto col = t->add_column(TEST_TYPE::data_type, "value", TEST_TYPE::is_nullable);
+    if (TEST_TYPE::is_indexed) {
+        t->add_search_index(col);
+    }
     constexpr size_t num_values = 200;
     std::vector<int64_t> seed_values;
     seed_values.resize(num_values);


### PR DESCRIPTION
I think this should fix https://github.com/realm/realm-core/issues/7642

There were two issues I discovered:
- Indexes were still being used when conditions had been combined
- It has been tradition that integer queries accept double values as input because JS passes all numbers as doubles.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [x] C-API, if public C++ API changed
* [x] `bindgen/spec.yml`, if public C++ API changed
