### PR TITLE
Temporarily revert exfat changes

### DIFF
--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -1569,7 +1569,6 @@ buildvariants:
     run_with_encryption: 1
   tasks:
   - name: core_tests_group
-  - name: test-on-exfat
 
 - name: macos-release
   display_name: "MacOS 11.0 x86_64 (Release build)"
@@ -1586,6 +1585,7 @@ buildvariants:
   tasks:
   - name: benchmarks
   - name: compile_test
+  - name: test-on-exfat
 
 - name: macos-1100-arm64-release
   display_name: "MacOS 11 arm64 (Release benchmarks)"
@@ -1617,7 +1617,6 @@ buildvariants:
   - name: compile_test
   - name: swift-build-and-test
   - name: validate-installed-headers
-  - name: test-on-exfat
 
 - name: macos-14-release
   display_name: "MacOS 14 arm64 (Release build)"
@@ -1631,14 +1630,12 @@ buildvariants:
     cmake_build_type: Release
     xcode_developer_dir: /Applications/Xcode15.2.app/Contents/Developer
     extra_flags: -DCMAKE_SYSTEM_NAME=Darwin -DCMAKE_OSX_ARCHITECTURES=arm64
-
   tasks:
   - name: compile_test_and_package
   # benchmarks are disabled for now because of perf problems on AWS macos instances.
   # - name: benchmarks
   - name: long-running-tests
   - name: swift-build-and-test
-  - name: test-on-exfat
 
 - name: macos-asan
   display_name: "MacOS 14 arm64 (ASAN)"


### PR DESCRIPTION
## What, How & Why?
Moving the exfat testing back to x86_64/macos 11 builders while we troubleshoot the macos 14 timeouts

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed
* [ ] `bindgen/spec.yml`, if public C++ API changed
