### PR TITLE
[bindgen] fix signature of update_base_url

### DIFF
--- a/bindgen/spec.yml
+++ b/bindgen/spec.yml
@@ -1295,7 +1295,7 @@ classes:
       unsubscribe: '(token: AppSubscriptionToken)'
       call_function: '(user: const SharedUser&, name: std::string, args: EJsonArray, service_name: std::optional<std::string>, cb: AsyncCallback<(result: Nullable<const EJson*>, err: std::optional<AppError>)>)'
       make_streaming_request: '(user: SharedUser, name: std::string, args: bson::BsonArray, service_name: std::optional<std::string>) -> Request'
-      update_base_url: '(base_url: std::optional<std::string>, cb: AsyncCallback<(err: std::optional<AppError>)>&&)'
+      update_base_url: '(base_url: std::string_view, cb: AsyncCallback<(err: std::optional<AppError>)>&&)'
       get_base_url: '() const -> std::string'
       immediately_run_file_actions: '(realm_path: std::string) -> bool'
 


### PR DESCRIPTION
## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- Link to relevant issue this fixes -->

In [this commit](https://github.com/realm/realm-core/commit/978ae24bd68f337efb118fb747d4aaca5f7642e9#diff-6423f65e7503b75f69dfdb175adc29ad7ee3ca341f3301466ef202e56ccfa93d) the signature of `update_base_url` was changed, but `spec.xml` wasn't updated to match it.


## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed
* [ ] `bindgen/spec.yml`, if public C++ API changed
