### PR TITLE
RCORE-2112 Fix a deadlock when accessing current user from inside an App listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Accessing App::current_user() from within a notification produced by App:switch_user() (which includes notifications for a newly logged in user) would deadlock ([#7670](https://github.com/realm/realm-core/issues/7670), since v14.6.0).
 
 ### Breaking changes
 * None.

--- a/src/realm/object-store/sync/app.hpp
+++ b/src/realm/object-store/sync/app.hpp
@@ -609,6 +609,8 @@ private:
 
     bool verify_user_present(const std::shared_ptr<User>& user) const REQUIRES(m_user_mutex);
 
+    void emit_change_to_subscribers() REQUIRES(!m_user_mutex);
+
     // UserProvider implementation
     friend class User;
 

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -4699,8 +4699,10 @@ TEST_CASE("app: user_semantics", "[sync][app][user]") {
     CHECK(!app->current_user());
 
     int event_processed = 0;
-    auto token = app->subscribe([&event_processed](auto&) {
+    auto token = app->subscribe([&](auto&) {
         event_processed++;
+        // Read the current user to verify that doing so does not deadlock
+        app->current_user();
     });
 
     SECTION("current user is populated") {


### PR DESCRIPTION
App::switch_user() emitted changes without first releasing the lock on m_user_mutex, leading to a deadlock if anyone inside the listener tried to acquire the mutex. The rest of the places where we emitted changes were correct.

The newly added wrapper catches this error when building with clang.

Fixes #7670.