### PR TITLE
RCORE-2115 Fix multiple backlinks created by dictionary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Accessing App::current_user() from within a notification produced by App:switch_user() (which includes notifications for a newly logged in user) would deadlock ([#7670](https://github.com/realm/realm-core/issues/7670), since v14.6.0).
+* Inserting the same typed link to the same key in a dictionary more than once would incorrectly create multiple backlinks to the object. This did not appear to cause any crashes later, but would have affecting explicit backlink count queries o@links.@count`) and possibly notifications ([#7676](https://github.com/realm/realm-core/issues/7676) since v14.5.2).
 
 ### Breaking changes
 * None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Accessing App::current_user() from within a notification produced by App:switch_user() (which includes notifications for a newly logged in user) would deadlock ([#7670](https://github.com/realm/realm-core/issues/7670), since v14.6.0).
-* Inserting the same typed link to the same key in a dictionary more than once would incorrectly create multiple backlinks to the object. This did not appear to cause any crashes later, but would have affecting explicit backlink count queries o@links.@count`) and possibly notifications ([#7676](https://github.com/realm/realm-core/issues/7676) since v14.5.2).
+* Inserting the same typed link to the same key in a dictionary more than once would incorrectly create multiple backlinks to the object. This did not appear to cause any crashes later, but would have affecting explicit backlink count queries (eg: `...@links.@count`) and possibly notifications ([#7676](https://github.com/realm/realm-core/issues/7676) since v14.5.2).
 
 ### Breaking changes
 * None.

--- a/src/realm/dictionary.cpp
+++ b/src/realm/dictionary.cpp
@@ -587,10 +587,10 @@ std::pair<Dictionary::Iterator, bool> Dictionary::insert(Mixed key, Mixed value)
     ObjLink old_link;
     if (old_entry) {
         Mixed old_value = m_values->get(ndx);
+        if (old_value.is_type(type_TypedLink)) {
+            old_link = old_value.get<ObjLink>();
+        }
         if (!value.is_same_type(old_value) || value != old_value) {
-            if (old_value.is_type(type_TypedLink)) {
-                old_link = old_value.get<ObjLink>();
-            }
             m_values->set(ndx, value);
         }
         else {

--- a/test/test_dictionary.cpp
+++ b/test/test_dictionary.cpp
@@ -239,16 +239,22 @@ TEST(Dictionary_TypedLinks)
         CHECK_EQUAL(lady.get_backlink_count(*persons, col_dict), 1);
         CHECK_EQUAL(lady.get_backlink(*persons, col_dict, 0), adam.get_key());
         CHECK_EQUAL(lady.get_backlink_count(), 1);
+        // make sure that inserting the same link again does nothing
+        CHECK_NOT(dict.insert("Pet", lady).second);
+        CHECK_EQUAL(lady.get_backlink_count(), 1);
         lady.remove();
         cmp(dict["Pet"], Mixed());
 
         // Reinsert lady
         lady = dogs->create_object_with_primary_key("lady");
         dict.insert("Pet", lady);
+        dict.insert("Pet", lady);
+        CHECK_EQUAL(lady.get_backlink_count(), 1);
         lady.invalidate(); // Make lady a tombstone :-(
         cmp(dict["Pet"], Mixed());
         lady = dogs->create_object_with_primary_key("lady");
         cmp(dict["Pet"], Mixed(lady.get_link()));
+        CHECK_EQUAL(lady.get_backlink_count(), 1);
 
         auto invalid_link = pluto.get_link();
         pluto.remove();


### PR DESCRIPTION
Fixes https://github.com/realm/realm-core/issues/7676
This regression was caused by https://github.com/realm/realm-core/pull/7523

I couldn't cause any hard crashes or exceptions so it is hard to say that this has been observed outside of niche query cases.
This is because we have previously chosen to ignore nullifying backlinks that point to an object that no longer exists, since https://github.com/realm/realm-core/pull/6638

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [x] C-API, if public C++ API changed
* [x] `bindgen/spec.yml`, if public C++ API changed
