### PR TITLE
RCORE-2030 Add full support for automatic client reset for collections in mixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,13 @@
 
 ### Enhancements
 * <New feature description> (PR [#????](https://github.com/realm/realm-core/pull/????))
-* None.
+* Nested collections have full support for automatic client reset ([PR #7683](https://github.com/realm/realm-core/pull/7683)).
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Accessing App::current_user() from within a notification produced by App:switch_user() (which includes notifications for a newly logged in user) would deadlock ([#7670](https://github.com/realm/realm-core/issues/7670), since v14.6.0).
 * Inserting the same typed link to the same key in a dictionary more than once would incorrectly create multiple backlinks to the object. This did not appear to cause any crashes later, but would have affecting explicit backlink count queries (eg: `...@links.@count`) and possibly notifications ([#7676](https://github.com/realm/realm-core/issues/7676) since v14.5.2).
+* Automatic client reset recovery would crash when recovering AddInteger instructions on a Mixed property if its type was changed to non-integer ([PR #7683](https://github.com/realm/realm-core/pull/7683), since v11.16.0).
 
 ### Breaking changes
 * None.

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -3,5 +3,5 @@ VERSION: 14.6.2
 OPENSSL_VERSION: 3.2.0
 ZLIB_VERSION: 1.2.13
 # https://github.com/10gen/baas/commits
-# 5138f5c is 2024 Apr 19
-BAAS_VERSION: 5138f5c924f9f376d31cbc2b1819e1d934600277
+# 9d1b4d6 is 2024 May 8
+BAAS_VERSION: 9d1b4d628babadfb606ebcadb93b1e5cae3c9565

--- a/src/realm/object_converter.cpp
+++ b/src/realm/object_converter.cpp
@@ -70,9 +70,9 @@ void InterRealmValueConverter::copy_list(const LstBase& src, LstBase& dst, bool*
 
     auto dst_as_link_list = dynamic_cast<LnkLst*>(&dst);
     auto dst_as_lst_mixed = dynamic_cast<Lst<Mixed>*>(&dst);
-    auto is_link_to_deleted_object = [&](const Mixed& src_value, const Mixed& converted_value) -> bool {
-        return (dst_as_link_list && converted_value.is_null()) ||
-               (dst_as_lst_mixed && converted_value.is_null() && src_value.is_type(type_TypedLink));
+    REALM_ASSERT(!dst_as_lst_mixed);
+    auto is_link_to_deleted_object = [&](const Mixed& converted_value) -> bool {
+        return dst_as_link_list && converted_value.is_null();
     };
 
     std::vector<size_t> dst_to_erase;
@@ -85,7 +85,7 @@ void InterRealmValueConverter::copy_list(const LstBase& src, LstBase& dst, bool*
                 Obj embedded = dst_as_link_list->create_and_set_linked_object(ndx);
                 track_new_embedded(converted_src.src_embedded_to_check, embedded);
             }
-            else if (is_link_to_deleted_object(src_value, converted_src.converted_value)) {
+            else if (is_link_to_deleted_object(converted_src.converted_value)) {
                 // this can happen when the source linked list points to an object
                 // which has been deleted in the dest Realm. Lists do not support
                 // setting an element to null, so it must be deleted later.
@@ -110,7 +110,7 @@ void InterRealmValueConverter::copy_list(const LstBase& src, LstBase& dst, bool*
             Obj embedded = dst_as_link_list->create_and_insert_linked_object(dst_ndx_to_insert);
             track_new_embedded(converted_src.src_embedded_to_check, embedded);
         }
-        else if (is_link_to_deleted_object(src_value, converted_src.converted_value)) {
+        else if (is_link_to_deleted_object(converted_src.converted_value)) {
             // ignore trying to insert a link to a object which no longer exists
         }
         else {
@@ -241,7 +241,6 @@ void InterRealmValueConverter::copy_dictionary(const Dictionary& src, Dictionary
             else {
                 // src > dst: delete dst, advance only dst
                 to_delete.push_back(dst_ndx++);
-                continue;
             }
         }
     }
@@ -276,11 +275,19 @@ void InterRealmValueConverter::copy_value(const Obj& src_obj, Obj& dst_obj, bool
     if (m_src_col.is_list()) {
         LstBasePtr src = src_obj.get_listbase_ptr(m_src_col);
         LstBasePtr dst = dst_obj.get_listbase_ptr(m_dst_col);
+        if (src->get_data_type() == type_Mixed) {
+            Lst<Mixed> src_list{src_obj, m_src_col};
+            Lst<Mixed> dst_list{dst_obj, m_dst_col};
+            return handle_list_in_mixed(src_list, dst_list);
+        }
         copy_list(*src, *dst, update_out);
     }
     else if (m_src_col.is_dictionary()) {
         Dictionary src = src_obj.get_dictionary(m_src_col);
         Dictionary dst = dst_obj.get_dictionary(m_dst_col);
+        if (src.get_value_data_type() == type_Mixed) {
+            return handle_dictionary_in_mixed(src, dst);
+        }
         copy_dictionary(src, dst, update_out);
     }
     else if (m_src_col.is_set()) {
@@ -323,11 +330,22 @@ void InterRealmValueConverter::copy_value(const Obj& src_obj, Obj& dst_obj, bool
     }
 }
 
+void InterRealmValueConverter::copy_list(const LstBase& src_list, LstBase& dst_list) const
+{
+    auto src_as_lst_mixed = dynamic_cast<const Lst<Mixed>*>(&src_list);
+    auto dst_as_lst_mixed = dynamic_cast<Lst<Mixed>*>(&dst_list);
+    REALM_ASSERT(bool(src_as_lst_mixed) == bool(dst_as_lst_mixed));
+    if (src_as_lst_mixed) {
+        return handle_list_in_mixed(*src_as_lst_mixed, *dst_as_lst_mixed);
+    }
+    copy_list(src_list, dst_list, nullptr);
+}
+
 //
 // Handle collections in mixed. A collection can have N nested levels (except for Sets). And these levels can be
 // nested in arbitrary way (eg a List within a Dictionary or viceversa). In order to try to merge server changes with
 // client changes, the algorithm needs to go through each single element in the collection, check its type and perform
-// the most appropriate action in order to miminize the number of notifications triggered.
+// the most appropriate action in order to minimize the number of notifications triggered.
 //
 void InterRealmValueConverter::handle_list_in_mixed(const Lst<Mixed>& src_list, Lst<Mixed>& dst_list) const
 {
@@ -335,35 +353,26 @@ void InterRealmValueConverter::handle_list_in_mixed(const Lst<Mixed>& src_list, 
     int left = 0;
 
     // find fist not matching element from beginning
-    while (left < sz) {
-        auto src_any = src_list.get_any(left);
-        auto dst_any = dst_list.get_any(left);
-        if (src_any != dst_any)
-            break;
-        if (is_collection(src_any) &&
-            !check_matching_list(src_list, dst_list, left, left, to_collection_type(src_any)))
-            break;
+    while (left < sz && check_matching_list(src_list, dst_list, left, left)) {
         left += 1;
     }
 
     // find first not matching element from end
     int right_src = (int)src_list.size() - 1;
     int right_dst = (int)dst_list.size() - 1;
-    while (right_src >= left && right_dst >= left) {
-        auto src_any = src_list.get_any(right_src);
-        auto dst_any = dst_list.get_any(right_dst);
-        if (src_any != dst_any)
-            break;
-        if (is_collection(src_any) &&
-            !check_matching_list(src_list, dst_list, right_src, right_dst, to_collection_type(src_any)))
-            break;
+    while (right_src >= left && right_dst >= left && check_matching_list(src_list, dst_list, right_src, right_dst)) {
         right_src -= 1;
         right_dst -= 1;
     }
 
+    auto is_link_to_deleted_object = [&](const Mixed& src_value, const Mixed& converted_value) -> bool {
+        return converted_value.is_null() && src_value.is_type(type_TypedLink);
+    };
+
     // Replace all different elements in [left, right]
     auto left_src = left;
     auto left_dst = left;
+    std::vector<size_t> dst_to_erase;
     while (left_src <= right_src && left_dst <= right_dst) {
         auto src_any = src_list.get_any(left_src);
         auto dst_any = dst_list.get_any(left_dst);
@@ -372,13 +381,12 @@ void InterRealmValueConverter::handle_list_in_mixed(const Lst<Mixed>& src_list, 
             auto coll_type = to_collection_type(src_any);
 
             if (!dst_any.is_type(src_any.get_type())) {
-                // Mixed vs Collection
+                // Primitive vs Collection or different collection types
                 dst_list.set_collection(left_dst, coll_type);
                 copy_list_in_mixed(src_list, dst_list, left_src, left_dst, coll_type);
             }
-            else if (!check_matching_list(src_list, dst_list, left_src, left_dst, coll_type)) {
-                // Collection vs Collection
-                dst_list.set_any(left_dst, src_any);
+            else if (!check_matching_list(src_list, dst_list, left_src, left_dst)) {
+                // Same collection type but different contents
                 copy_list_in_mixed(src_list, dst_list, left_src, left_dst, coll_type);
             }
         }
@@ -387,13 +395,12 @@ void InterRealmValueConverter::handle_list_in_mixed(const Lst<Mixed>& src_list, 
             InterRealmValueConverter::ConversionResult converted_src;
             bool update_out = false;
             cmp_src_to_dst(src_any, dst_any, &converted_src, &update_out);
-            if (update_out) {
-                // we do not support embedded objects
-                REALM_ASSERT(!converted_src.requires_new_embedded_object);
-                dst_list.set_any(left_dst, converted_src.converted_value);
+            REALM_ASSERT(!converted_src.requires_new_embedded_object);
+            if (is_link_to_deleted_object(src_any, converted_src.converted_value)) {
+                dst_to_erase.push_back(left_dst);
             }
             else {
-                dst_list.set_any(left_dst, src_any);
+                dst_list.set_any(left_dst, converted_src.converted_value);
             }
         }
         left_src += 1;
@@ -401,10 +408,8 @@ void InterRealmValueConverter::handle_list_in_mixed(const Lst<Mixed>& src_list, 
     }
 
     // remove dst elements not present in src
-    if (right_dst > right_src) {
-        while (right_dst > right_src)
-            dst_list.remove(right_dst--);
-    }
+    while (right_dst > right_src)
+        dst_list.remove(right_dst--);
 
     // append remainig src into dst
     for (int i = left_src; i <= right_src; ++i) {
@@ -418,15 +423,20 @@ void InterRealmValueConverter::handle_list_in_mixed(const Lst<Mixed>& src_list, 
             InterRealmValueConverter::ConversionResult converted_src;
             bool update_out = false;
             cmp_src_to_dst(src_any, Mixed{}, &converted_src, &update_out);
-            if (update_out) {
-                // we do not support embedded objects
-                REALM_ASSERT(!converted_src.requires_new_embedded_object);
-                dst_list.insert_any(i, converted_src.converted_value);
+            REALM_ASSERT(!converted_src.requires_new_embedded_object);
+            if (is_link_to_deleted_object(src_any, converted_src.converted_value)) {
+                // ignore trying to insert a link to a object which no longer exists
             }
             else {
-                dst_list.insert_any(i, src_any);
+                dst_list.insert_any(i, converted_src.converted_value);
             }
         }
+    }
+
+    while (dst_to_erase.size()) {
+        size_t ndx_to_remove = dst_to_erase.back();
+        dst_list.remove(ndx_to_remove);
+        dst_to_erase.pop_back();
     }
 }
 
@@ -445,8 +455,7 @@ void InterRealmValueConverter::handle_dictionary_in_mixed(Dictionary& src_dictio
                 to_insert.push_back(src_ndx);
             }
             else if (is_collection(src_any) &&
-                     !check_matching_dictionary(src_dictionary, dst_dictionary, key_src.get_string(),
-                                                to_collection_type(src_any))) {
+                     !check_matching_dictionary(src_dictionary, dst_dictionary, key_src.get_string())) {
                 to_insert.push_back(src_ndx);
             }
             src_ndx += 1;
@@ -505,36 +514,41 @@ void InterRealmValueConverter::handle_dictionary_in_mixed(Dictionary& src_dictio
 }
 
 bool InterRealmValueConverter::check_matching_list(const Lst<Mixed>& src_list, Lst<Mixed>& dst_list, size_t ndx_src,
-                                                   size_t ndx_dst, CollectionType type) const
+                                                   size_t ndx_dst) const
 {
-
-    if (type == CollectionType::List) {
-        auto nested_src_list = src_list.get_list(ndx_src);
-        auto nested_dst_list = dst_list.get_list(ndx_dst);
-        auto size_src = nested_src_list->size();
-        auto size_dst = nested_dst_list->size();
-        if (size_src != size_dst)
+    REALM_ASSERT(ndx_src < src_list.size() && ndx_dst < dst_list.size());
+    auto src_any = src_list.get_any(ndx_src);
+    auto dst_any = dst_list.get_any(ndx_dst);
+    if (src_any != dst_any)
+        return false;
+    if (!is_collection(src_any))
+        return true;
+    // Check collections are equal
+    if (src_any.is_type(type_List)) {
+        auto src_element = src_list.get_list(ndx_src);
+        auto dst_element = dst_list.get_list(ndx_dst);
+        auto src_element_size = src_element->size();
+        auto dst_element_size = dst_element->size();
+        if (src_element_size != dst_element_size)
             return false;
-        for (size_t i = 0; i < size_src; ++i) {
-            auto src_mixed = nested_src_list->get_any(i);
-            auto dst_mixed = nested_dst_list->get_any(i);
-            if (src_mixed != dst_mixed)
+        for (size_t i = 0; i < src_element_size; ++i) {
+            if (!(check_matching_list(*src_element, *dst_element, i, i)))
                 return false;
         }
     }
-    else if (type == CollectionType::Dictionary) {
-        auto nested_src_dictionary = src_list.get_dictionary(ndx_src);
-        auto nested_dst_dictionary = dst_list.get_dictionary(ndx_dst);
-        auto size_src = nested_src_dictionary->size();
-        auto size_dst = nested_dst_dictionary->size();
-        if (size_src != size_dst)
+    else if (src_any.is_type(type_Dictionary)) {
+        auto src_element = src_list.get_dictionary(ndx_src);
+        auto dst_element = dst_list.get_dictionary(ndx_dst);
+        auto src_element_size = src_element->size();
+        auto dst_element_size = dst_element->size();
+        if (src_element_size != dst_element_size)
             return false;
-        for (size_t i = 0; i < size_src; ++i) {
-            auto [src_key, src_mixed] = nested_src_dictionary->get_pair(i);
-            auto [dst_key, dst_mixed] = nested_dst_dictionary->get_pair(i);
+        for (size_t i = 0; i < src_element_size; ++i) {
+            auto src_key = src_element->get_key(i);
+            auto dst_key = dst_element->get_key(i);
             if (src_key != dst_key)
                 return false;
-            if (src_mixed != dst_mixed)
+            if (!check_matching_dictionary(*src_element, *dst_element, src_key.get_string()))
                 return false;
         }
     }
@@ -542,36 +556,41 @@ bool InterRealmValueConverter::check_matching_list(const Lst<Mixed>& src_list, L
 }
 
 bool InterRealmValueConverter::check_matching_dictionary(const Dictionary& src_dictionary,
-                                                         const Dictionary& dst_dictionary, StringData key,
-                                                         CollectionType type) const
+                                                         const Dictionary& dst_dictionary, StringData key) const
 {
-    if (type == CollectionType::List) {
-        auto n_src_list = src_dictionary.get_list(key);
-        auto n_dst_list = dst_dictionary.get_list(key);
-        auto size_src = n_src_list->size();
-        auto size_dst = n_dst_list->size();
-        if (size_src != size_dst)
+    REALM_ASSERT(src_dictionary.contains(key) && dst_dictionary.contains(key));
+    auto src_any = src_dictionary.get(key);
+    auto dst_any = dst_dictionary.get(key);
+    if (src_any != dst_any)
+        return false;
+    if (!is_collection(src_any))
+        return true;
+    // Check collections are equal
+    if (src_any.is_type(type_List)) {
+        auto src_element = src_dictionary.get_list(key);
+        auto dst_element = dst_dictionary.get_list(key);
+        auto src_element_size = src_element->size();
+        auto dst_element_size = dst_element->size();
+        if (src_element_size != dst_element_size)
             return false;
-        for (size_t i = 0; i < size_src; ++i) {
-            auto src_mixed = n_src_list->get_any(i);
-            auto dst_mixed = n_dst_list->get_any(i);
-            if (src_mixed != dst_mixed)
+        for (size_t i = 0; i < src_element_size; ++i) {
+            if (!(check_matching_list(*src_element, *dst_element, i, i)))
                 return false;
         }
     }
-    else if (type == CollectionType::Dictionary) {
-        auto n_src_dictionary = src_dictionary.get_dictionary(key);
-        auto n_dst_dictionary = dst_dictionary.get_dictionary(key);
-        auto size_src = n_src_dictionary->size();
-        auto size_dst = n_dst_dictionary->size();
-        if (size_src != size_dst)
+    else if (src_any.is_type(type_Dictionary)) {
+        auto src_element = src_dictionary.get_dictionary(key);
+        auto dst_element = dst_dictionary.get_dictionary(key);
+        auto src_element_size = src_element->size();
+        auto dst_element_size = dst_element->size();
+        if (src_element_size != dst_element_size)
             return false;
-        for (size_t i = 0; i < size_src; ++i) {
-            auto [src_key, src_mixed] = n_src_dictionary->get_pair(i);
-            auto [dst_key, dst_mixed] = n_dst_dictionary->get_pair(i);
-            if (src_key != dst_key)
+        for (size_t i = 0; i < src_element_size; ++i) {
+            auto left_key = src_element->get_key(i);
+            auto right_key = dst_element->get_key(i);
+            if (left_key != right_key)
                 return false;
-            if (src_mixed != dst_mixed)
+            if (!check_matching_dictionary(*src_element, *dst_element, left_key.get_string()))
                 return false;
         }
     }

--- a/src/realm/object_converter.hpp
+++ b/src/realm/object_converter.hpp
@@ -51,6 +51,7 @@ struct InterRealmValueConverter {
     int cmp_src_to_dst(Mixed src, Mixed dst, ConversionResult* converted_src_out = nullptr,
                        bool* did_update_out = nullptr) const;
     void copy_value(const Obj& src_obj, Obj& dst_obj, bool* update_out);
+    void copy_list(const LstBase& src_list, LstBase& dst_list) const;
 
 private:
     void copy_list(const LstBase& src_obj, LstBase& dst_obj, bool* update_out) const;
@@ -63,10 +64,8 @@ private:
                             CollectionType type) const;
     void copy_dictionary_in_mixed(const Dictionary& src_list, Dictionary& dst_list, StringData key,
                                   CollectionType type) const;
-    bool check_matching_list(const Lst<Mixed>& src_list, Lst<Mixed>& dst_list, size_t ndx_src, size_t ndx_dst,
-                             CollectionType type) const;
-    bool check_matching_dictionary(const Dictionary& src_list, const Dictionary& dst_list, StringData key,
-                                   CollectionType type) const;
+    bool check_matching_list(const Lst<Mixed>& src_list, Lst<Mixed>& dst_list, size_t ndx_src, size_t ndx_dst) const;
+    bool check_matching_dictionary(const Dictionary& src_list, const Dictionary& dst_list, StringData key) const;
     bool is_collection(Mixed) const;
     CollectionType to_collection_type(Mixed) const;
 

--- a/src/realm/object_converter.hpp
+++ b/src/realm/object_converter.hpp
@@ -64,8 +64,10 @@ private:
                             CollectionType type) const;
     void copy_dictionary_in_mixed(const Dictionary& src_list, Dictionary& dst_list, StringData key,
                                   CollectionType type) const;
-    bool check_matching_list(const Lst<Mixed>& src_list, Lst<Mixed>& dst_list, size_t ndx_src, size_t ndx_dst) const;
-    bool check_matching_dictionary(const Dictionary& src_list, const Dictionary& dst_list, StringData key) const;
+    bool check_if_list_elements_match(const Lst<Mixed>& src_list, Lst<Mixed>& dst_list, size_t ndx_src,
+                                      size_t ndx_dst) const;
+    bool check_if_dictionary_elements_match(const Dictionary& src_list, const Dictionary& dst_list,
+                                            StringData key) const;
     bool is_collection(Mixed) const;
     CollectionType to_collection_type(Mixed) const;
 

--- a/src/realm/sync/changeset.cpp
+++ b/src/realm/sync/changeset.cpp
@@ -399,6 +399,7 @@ void Changeset::Reflector::operator()(const Instruction::Clear& p) const
 {
     m_tracer.name("Clear");
     path_instr(p);
+    m_tracer.field("collection_type", p.collection_type);
 }
 
 void Changeset::Reflector::operator()(const Instruction::SetInsert& p) const

--- a/src/realm/sync/instruction_applier.cpp
+++ b/src/realm/sync/instruction_applier.cpp
@@ -317,7 +317,7 @@ void InstructionApplier::operator()(const Instruction::Update& instr)
             , m_instr(instr)
         {
         }
-        void on_property(Obj& obj, ColKey col) override
+        Status on_property(Obj& obj, ColKey col) override
         {
             // Update of object field.
 
@@ -386,6 +386,7 @@ void InstructionApplier::operator()(const Instruction::Update& instr)
             };
 
             m_applier->visit_payload(m_instr.value, visitor);
+            return Status::Pending;
         }
         Status on_list_index(LstBase& list, uint32_t index) override
         {
@@ -524,7 +525,7 @@ void InstructionApplier::operator()(const Instruction::AddInteger& instr)
             , m_instr(instr)
         {
         }
-        void on_property(Obj& obj, ColKey col)
+        Status on_property(Obj& obj, ColKey col)
         {
             // Increment of object field.
             if (!obj.is_null(col)) {
@@ -537,6 +538,7 @@ void InstructionApplier::operator()(const Instruction::AddInteger& instr)
                                                    table->get_column_name(col), table->get_name());
                 }
             }
+            return Status::Pending;
         }
 
     private:
@@ -940,21 +942,24 @@ void InstructionApplier::operator()(const Instruction::Clear& instr)
         Status on_dictionary_key(Dictionary& dict, Mixed key) override
         {
             REALM_ASSERT(m_collection_type);
-            auto val = dict.get(key);
-            if (val.is_type(type_Dictionary)) {
-                Dictionary d(dict, dict.build_index(key));
-                d.clear();
+            if (auto val = dict.try_get(key)) {
+                if (val->is_type(type_Dictionary)) {
+                    Dictionary d(dict, dict.build_index(key));
+                    d.clear();
+                }
+                else if (val->is_type(type_List)) {
+                    Lst<Mixed> l(dict, dict.build_index(key));
+                    l.clear();
+                }
+                else if (val->is_type(type_Set)) {
+                    m_applier->bad_transaction_log("Clear: Item at key '%1' is a Set",
+                                                   key); // Throws
+                }
+                dict.insert_collection(key.get_string(), *m_collection_type);
+                return Status::Pending;
             }
-            else if (val.is_type(type_List)) {
-                Lst<Mixed> l(dict, dict.build_index(key));
-                l.clear();
-            }
-            else if (val.is_type(type_Set)) {
-                m_applier->bad_transaction_log("Clear: Item at key '%1' is a Set",
-                                               key); // Throws
-            }
-            dict.insert_collection(key.get_string(), *m_collection_type);
-            return Status::Pending;
+            m_applier->bad_transaction_log("Clear: Key '%1' not found", key);
+            return Status::DidNotResolve;
         }
         void on_set(SetBase& set) override
         {
@@ -964,7 +969,7 @@ void InstructionApplier::operator()(const Instruction::Clear& instr)
             }
             set.clear();
         }
-        void on_property(Obj& obj, ColKey col_key) override
+        Status on_property(Obj& obj, ColKey col_key) override
         {
             if (col_key.get_type() == col_type_Mixed) {
                 REALM_ASSERT(m_collection_type);
@@ -981,10 +986,10 @@ void InstructionApplier::operator()(const Instruction::Clear& instr)
                     m_applier->bad_transaction_log("Clear: Mixed property is a Set"); // Throws
                 }
                 obj.set_collection(col_key, *m_collection_type);
-                return;
+                return Status::Pending;
             }
 
-            PathResolver::on_property(obj, col_key);
+            return PathResolver::on_property(obj, col_key);
         }
 
     private:
@@ -1020,9 +1025,10 @@ bool InstructionApplier::allows_null_links(const Instruction::PathInstruction& i
             m_allows_nulls = true;
             return Status::Pending;
         }
-        void on_property(Obj&, ColKey) override
+        Status on_property(Obj&, ColKey) override
         {
             m_allows_nulls = true;
+            return Status::Pending;
         }
         bool allows_nulls()
         {
@@ -1096,12 +1102,13 @@ void InstructionApplier::operator()(const Instruction::SetInsert& instr)
             , m_instr(instr)
         {
         }
-        void on_property(Obj& obj, ColKey col) override
+        Status on_property(Obj& obj, ColKey col) override
         {
             // This better be a mixed column
             REALM_ASSERT(col.get_type() == col_type_Mixed);
             auto set = obj.get_set<Mixed>(col);
             on_set(set);
+            return Status::Pending;
         }
         void on_set(SetBase& set) override
         {
@@ -1190,12 +1197,13 @@ void InstructionApplier::operator()(const Instruction::SetErase& instr)
             , m_instr(instr)
         {
         }
-        void on_property(Obj& obj, ColKey col) override
+        Status on_property(Obj& obj, ColKey col) override
         {
             // This better be a mixed column
             REALM_ASSERT(col.get_type() == col_type_Mixed);
             auto set = obj.get_set<Mixed>(col);
             on_set(set);
+            return Status::Pending;
         }
         void on_set(SetBase& set) override
         {
@@ -1370,9 +1378,10 @@ InstructionApplier::PathResolver::~PathResolver()
     on_finish();
 }
 
-void InstructionApplier::PathResolver::on_property(Obj&, ColKey)
+InstructionApplier::PathResolver::Status InstructionApplier::PathResolver::on_property(Obj&, ColKey)
 {
     m_applier->bad_transaction_log(util::format("Invalid path for %1 (object, column)", m_instr_name));
+    return Status::DidNotResolve;
 }
 
 void InstructionApplier::PathResolver::on_list(LstBase&)
@@ -1407,6 +1416,13 @@ void InstructionApplier::PathResolver::on_error(const std::string& err_msg)
     m_applier->bad_transaction_log(err_msg);
 }
 
+InstructionApplier::PathResolver::Status
+InstructionApplier::PathResolver::on_mixed_type_changed(const std::string& err_msg)
+{
+    m_applier->bad_transaction_log(err_msg);
+    return Status::DidNotResolve;
+}
+
 void InstructionApplier::PathResolver::on_column_advance(ColKey col)
 {
     m_applier->m_last_field = col;
@@ -1421,6 +1437,12 @@ InstructionApplier::PathResolver::Status InstructionApplier::PathResolver::on_li
 
 InstructionApplier::PathResolver::Status InstructionApplier::PathResolver::on_null_link_advance(StringData,
                                                                                                 StringData)
+{
+    return Status::Pending;
+}
+
+InstructionApplier::PathResolver::Status
+InstructionApplier::PathResolver::on_dict_key_not_found(StringData, StringData, StringData)
 {
     return Status::Pending;
 }
@@ -1495,7 +1517,7 @@ InstructionApplier::PathResolver::Status InstructionApplier::PathResolver::resol
             on_set(*set);
         }
         else {
-            on_property(obj, col);
+            return on_property(obj, col);
         }
         return Status::Pending;
     }
@@ -1520,22 +1542,28 @@ InstructionApplier::PathResolver::Status InstructionApplier::PathResolver::resol
     }
     else if (col.get_type() == col_type_Mixed) {
         auto val = obj.get<Mixed>(col);
+        std::string error_msg;
         if (val.is_type(type_Dictionary)) {
             if (auto pkey = mpark::get_if<InternString>(&*m_it_begin)) {
                 Dictionary dict(obj, col);
                 ++m_it_begin;
                 return resolve_dictionary_element(dict, *pkey);
             }
+            error_msg = "%1: Dictionary key is not a string on field '%2' in class '%3'";
         }
-        if (val.is_type(type_List)) {
+        else if (val.is_type(type_List)) {
             if (auto pindex = mpark::get_if<uint32_t>(&*m_it_begin)) {
                 Lst<Mixed> list(obj, col);
                 ++m_it_begin;
                 return resolve_list_element(list, *pindex);
             }
+            error_msg = "%1: List index is not an integer on field '%2' in class '%3'";
         }
-        on_error(util::format("%1: Not a list or dictionary on field '%2' in class '%3'", m_instr_name, field_name,
-                              obj.get_table()->get_name()));
+        else {
+            error_msg = "%1: Not a list or dictionary on field '%2' in class '%3'";
+        }
+        return on_mixed_type_changed(
+            util::format(error_msg.c_str(), m_instr_name, field_name, obj.get_table()->get_name()));
     }
     else if (col.get_type() == col_type_Link) {
         auto target = obj.get_table()->get_link_target(col);
@@ -1576,13 +1604,14 @@ InstructionApplier::PathResolver::Status InstructionApplier::PathResolver::resol
     }
 
     auto col = list.get_col_key();
-    auto field_name = list.get_table()->get_column_name(col);
+    auto table = list.get_table();
+    auto field_name = table->get_column_name(col);
 
     if (col.get_type() == col_type_Link) {
-        auto target = list.get_table()->get_link_target(col);
+        auto target = table->get_link_target(col);
         if (!target->is_embedded()) {
-            on_error(util::format("%1: Reference through non-embedded link at '%3.%2[%4]'", m_instr_name, field_name,
-                                  list.get_table()->get_name(), index));
+            on_error(util::format("%1: Reference through non-embedded link at '%2.%3[%4]'", m_instr_name,
+                                  table->get_name(), field_name, index));
             return Status::DidNotResolve;
         }
 
@@ -1594,8 +1623,8 @@ InstructionApplier::PathResolver::Status InstructionApplier::PathResolver::resol
         REALM_ASSERT(dynamic_cast<LnkLst*>(&list));
         auto& link_list = static_cast<LnkLst&>(list);
         if (index >= link_list.size()) {
-            on_error(util::format("%1: Out-of-bounds index through list at '%3.%2[%4]'", m_instr_name, field_name,
-                                  list.get_table()->get_name(), index));
+            on_error(util::format("%1: Out-of-bounds index through list at '%2.%3[%4]'", m_instr_name,
+                                  table->get_name(), field_name, index));
         }
         else if (auto pfield = mpark::get_if<InternString>(&*m_it_begin)) {
             auto embedded_object = link_list.get_object(index);
@@ -1606,9 +1635,18 @@ InstructionApplier::PathResolver::Status InstructionApplier::PathResolver::resol
     }
     else {
         if (list.get_data_type() == type_Mixed) {
+            Status list_status = on_list_index_advance(index);
+            if (list_status != Status::Pending) {
+                return list_status;
+            }
             auto& mixed_list = static_cast<Lst<Mixed>&>(list);
-            if (index < mixed_list.size()) {
+            if (index >= mixed_list.size()) {
+                on_error(util::format("%1: Out-of-bounds index '%2' through list along path '%2.%3'", m_instr_name,
+                                      index, table->get_name(), field_name));
+            }
+            else {
                 auto val = mixed_list.get(index);
+                std::string error_msg;
 
                 if (val.is_type(type_Dictionary)) {
                     if (auto pfield = mpark::get_if<InternString>(&*m_it_begin)) {
@@ -1616,20 +1654,26 @@ InstructionApplier::PathResolver::Status InstructionApplier::PathResolver::resol
                         ++m_it_begin;
                         return resolve_dictionary_element(d, *pfield);
                     }
+                    error_msg = "%1: Dictionary key is not a string on field '%2' in class '%3'";
                 }
-                if (val.is_type(type_List)) {
+                else if (val.is_type(type_List)) {
                     if (auto pindex = mpark::get_if<uint32_t>(&*m_it_begin)) {
                         Lst<Mixed> l(mixed_list, mixed_list.get_key(index));
                         ++m_it_begin;
                         return resolve_list_element(l, *pindex);
                     }
+                    error_msg = "%1: List index is not an integer on field '%2' in class '%3'";
                 }
+                else {
+                    error_msg = "%1: Not a list or dictionary on field '%2' in class '%3'";
+                }
+                return on_mixed_type_changed(
+                    util::format(error_msg.c_str(), m_instr_name, field_name, table->get_name()));
             }
         }
-
         on_error(util::format(
-            "%1: Resolving path through unstructured list element on '%3.%2', which is a list of type '%4'",
-            m_instr_name, field_name, list.get_table()->get_name(), col.get_type()));
+            "%1: Resolving path through unstructured list element on '%2.%3', which is a list of type '%4'",
+            m_instr_name, table->get_name(), field_name, col.get_type()));
     }
     return Status::DidNotResolve;
 }
@@ -1674,24 +1718,36 @@ InstructionApplier::PathResolver::resolve_dictionary_element(Dictionary& dict, I
         }
     }
     else {
-        auto val = dict.get(string_key);
-        if (val.is_type(type_Dictionary)) {
-            if (auto pfield = mpark::get_if<InternString>(&*m_it_begin)) {
-                Dictionary d(dict, dict.build_index(string_key));
-                ++m_it_begin;
-                return resolve_dictionary_element(d, *pfield);
+        if (auto val = dict.try_get(string_key)) {
+            std::string error_msg;
+            if (val->is_type(type_Dictionary)) {
+                if (auto pfield = mpark::get_if<InternString>(&*m_it_begin)) {
+                    Dictionary d(dict, dict.build_index(string_key));
+                    ++m_it_begin;
+                    return resolve_dictionary_element(d, *pfield);
+                }
+                error_msg = "%1: Dictionary key is not a string on field '%2' in class '%3'";
             }
-        }
-        if (val.is_type(type_List)) {
-            if (auto pindex = mpark::get_if<uint32_t>(&*m_it_begin)) {
-                Lst<Mixed> l(dict, dict.build_index(string_key));
-                ++m_it_begin;
-                return resolve_list_element(l, *pindex);
+            else if (val->is_type(type_List)) {
+                if (auto pindex = mpark::get_if<uint32_t>(&*m_it_begin)) {
+                    Lst<Mixed> l(dict, dict.build_index(string_key));
+                    ++m_it_begin;
+                    return resolve_list_element(l, *pindex);
+                }
+                error_msg = "%1: List index is not an integer on field '%2' in class '%3'";
             }
+            else {
+                error_msg = "%1: Not a list or dictionary on field '%2' in class '%3'";
+            }
+            return on_mixed_type_changed(
+                util::format(error_msg.c_str(), m_instr_name, field_name, table->get_name()));
         }
-        on_error(
-            util::format("%1: Resolving path through non link element on '%3.%2', which is a dictionary of type '%4'",
-                         m_instr_name, field_name, table->get_name(), col.get_type()));
+        Status key_not_found_status = on_dict_key_not_found(table->get_name(), field_name, string_key);
+        if (key_not_found_status != Status::Pending) {
+            return key_not_found_status;
+        }
+        on_error(util::format("%1: Unmatched key '%2' through dictionary along path '%3.%4'", m_instr_name,
+                              string_key, table->get_name(), field_name));
     }
     return Status::DidNotResolve;
 }

--- a/src/realm/sync/instruction_applier.hpp
+++ b/src/realm/sync/instruction_applier.hpp
@@ -80,24 +80,22 @@ protected:
         virtual ~PathResolver();
         virtual Status resolve();
 
-        virtual void on_property(Obj&, ColKey);
+        [[nodiscard]] virtual Status on_property(Obj&, ColKey);
         virtual void on_list(LstBase&);
         [[nodiscard]] virtual Status on_list_index(LstBase&, uint32_t);
         virtual void on_dictionary(Dictionary&);
         [[nodiscard]] virtual Status on_dictionary_key(Dictionary&, Mixed);
         virtual void on_set(SetBase&);
         virtual void on_error(const std::string&);
+        [[nodiscard]] virtual Status on_mixed_type_changed(const std::string&);
         virtual void on_column_advance(ColKey);
         virtual void on_dict_key_advance(StringData);
         [[nodiscard]] virtual Status on_list_index_advance(uint32_t);
         [[nodiscard]] virtual Status on_null_link_advance(StringData, StringData);
+        [[nodiscard]] virtual Status on_dict_key_not_found(StringData, StringData, StringData);
         [[nodiscard]] virtual Status on_begin(const util::Optional<Obj>& obj);
         virtual void on_finish();
         virtual StringData get_string(InternString);
-        const std::string_view& instruction_name() const noexcept
-        {
-            return m_instr_name;
-        }
 
     protected:
         [[nodiscard]] Status resolve_field(Obj& obj, InternString field);

--- a/src/realm/sync/noinst/client_reset_recovery.cpp
+++ b/src/realm/sync/noinst/client_reset_recovery.cpp
@@ -176,21 +176,23 @@ private:
     struct RecoveryResolver : public InstructionApplier::PathResolver {
         RecoveryResolver(RecoverLocalChangesetsHandler* applier, Instruction::PathInstruction& instr,
                          const std::string_view& instr_name);
-        void on_property(Obj&, ColKey) override;
+        Status on_property(Obj&, ColKey) override;
         void on_list(LstBase&) override;
         Status on_list_index(LstBase&, uint32_t) override;
         void on_dictionary(Dictionary&) override;
         Status on_dictionary_key(Dictionary&, Mixed) override;
         void on_set(SetBase&) override;
         void on_error(const std::string&) override;
+        Status on_mixed_type_changed(const std::string&) override;
         void on_column_advance(ColKey) override;
         void on_dict_key_advance(StringData) override;
         Status on_list_index_advance(uint32_t) override;
         Status on_null_link_advance(StringData, StringData) override;
+        Status on_dict_key_not_found(StringData, StringData, StringData) override;
         Status on_begin(const util::Optional<Obj>&) override;
         void on_finish() override {}
 
-        void set_last_path_index(uint32_t ndx);
+        void update_path_index(uint32_t ndx);
 
         ListPath m_list_path;
         Instruction::PathInstruction& m_mutable_instr;
@@ -600,13 +602,11 @@ void RecoverLocalChangesetsHandler::copy_lists_with_unrecoverable_changes()
             ConstTableRef remote_table = remote_list.get_table();
             ColKey local_col_key = local_list.get_col_key();
             ColKey remote_col_key = remote_list.get_col_key();
-            Obj local_obj = local_list.get_obj();
-            Obj remote_obj = remote_list.get_obj();
             InterRealmValueConverter value_converter(local_table, local_col_key, remote_table, remote_col_key,
                                                      &embedded_object_tracker);
             m_logger.debug(util::LogCategory::reset, "Recovery overwrites list for '%1' size: %2 -> %3", path_str,
                            remote_list.size(), local_list.size());
-            value_converter.copy_value(local_obj, remote_obj, nullptr);
+            value_converter.copy_list(local_list, remote_list);
             embedded_object_tracker.process_pending();
         });
         if (did_translate) {
@@ -626,52 +626,68 @@ void RecoverLocalChangesetsHandler::copy_lists_with_unrecoverable_changes()
 bool RecoverLocalChangesetsHandler::resolve_path(ListPath& path, Obj remote_obj, Obj local_obj,
                                                  util::UniqueFunction<void(LstBase&, LstBase&)> callback)
 {
+    Dictionary local_dict, remote_dict;
     for (auto it = path.begin(); it != path.end();) {
         if (!remote_obj || !local_obj) {
             return false;
         }
-        REALM_ASSERT(it->type == ListPath::Element::Type::ColumnKey);
-        ColKey col = it->col_key;
-        REALM_ASSERT(col);
-        if (col.is_list()) {
-            auto remote_list = get_list_from_path(remote_obj, col);
-            ColKey local_col = local_obj.get_table()->get_column_key(remote_obj.get_table()->get_column_name(col));
-            REALM_ASSERT(local_col);
-            auto local_list = get_list_from_path(local_obj, local_col);
-            ++it;
-            if (it == path.end()) {
+        REALM_ASSERT(it->type != ListPath::Element::Type::ListIndex);
+
+        if (it->type == ListPath::Element::Type::InternKey) {
+            StringData dict_key = m_intern_keys.get_key(it->intern_key);
+            // At least one dictionary does not contain the key.
+            if (!local_dict.contains(dict_key) || !remote_dict.contains(dict_key))
+                return false;
+            auto local_any = local_dict.get(dict_key);
+            auto remote_any = remote_dict.get(dict_key);
+            // Type mismatch.
+            if (local_any != remote_any)
+                return false;
+            if (local_any.is_type(type_Link, type_TypedLink)) {
+                local_obj = local_dict.get_object(dict_key);
+                remote_obj = remote_dict.get_object(dict_key);
+            }
+            else if (local_any.is_type(type_Dictionary)) {
+                local_dict = *local_dict.get_dictionary(dict_key);
+                remote_dict = *remote_dict.get_dictionary(dict_key);
+            }
+            else if (local_any.is_type(type_List)) {
+                ++it;
+                REALM_ASSERT(it == path.end());
+                auto local_list = local_dict.get_list(dict_key);
+                auto remote_list = remote_dict.get_list(dict_key);
                 callback(*remote_list, *local_list);
                 return true;
             }
             else {
-                REALM_ASSERT(it->type == ListPath::Element::Type::ListIndex);
-                REALM_ASSERT(it != path.end());
-                size_t stable_index_id = it->index;
-                REALM_ASSERT(stable_index_id != realm::npos);
-                // This code path could be implemented, but because it is currently not possible to
-                // excercise in tests, it is marked unreachable. The assumption here is that only the
-                // first embedded object list would ever need to be copied over. If the first embedded
-                // list is allowed then all sub objects are allowed, and likewise if the first embedded
-                // list is copied, then this implies that all embedded children are also copied over.
-                // Therefore, we should never have a situtation where a secondary embedded list needs copying.
-                REALM_UNREACHABLE();
-            }
-        }
-        else if (col.is_dictionary()) {
-            ++it;
-            REALM_ASSERT(it != path.end());
-            REALM_ASSERT(it->type == ListPath::Element::Type::InternKey);
-            Dictionary remote_dict = remote_obj.get_dictionary(col);
-            Dictionary local_dict = local_obj.get_dictionary(remote_obj.get_table()->get_column_name(col));
-            StringData dict_key = m_intern_keys.get_key(it->intern_key);
-            if (remote_dict.contains(dict_key) && local_dict.contains(dict_key)) {
-                remote_obj = remote_dict.get_object(dict_key);
-                local_obj = local_dict.get_object(dict_key);
-                ++it;
-            }
-            else {
                 return false;
             }
+            ++it;
+            continue;
+        }
+
+        REALM_ASSERT(it->type == ListPath::Element::Type::ColumnKey);
+        ColKey col = it->col_key;
+        REALM_ASSERT(col);
+        if (col.is_list()) {
+            ++it;
+            // A list is copied verbatim when there is an operation on an ambiguous index
+            // (includes accessing elements). An index is considered ambiguous if it was
+            // not just inserted.
+            // Once the list is marked to be copied, any access to nested collections
+            // or embedded objects through that list is stopped.
+            REALM_ASSERT(it == path.end());
+            auto remote_list = remote_obj.get_listbase_ptr(col);
+            ColKey local_col = local_obj.get_table()->get_column_key(remote_obj.get_table()->get_column_name(col));
+            REALM_ASSERT(local_col);
+            auto local_list = local_obj.get_listbase_ptr(local_col);
+            callback(*remote_list, *local_list);
+            return true;
+        }
+        else if (col.is_dictionary()) {
+            remote_dict = remote_obj.get_dictionary(col);
+            local_dict = local_obj.get_dictionary(remote_obj.get_table()->get_column_name(col));
+            ++it;
         }
         else if (col.get_type() == col_type_Mixed) {
             StringData col_name = remote_obj.get_table()->get_column_name(col);
@@ -680,35 +696,22 @@ bool RecoverLocalChangesetsHandler::resolve_path(ListPath& path, Obj remote_obj,
 
             if (local_any.is_type(type_List) && remote_any.is_type(type_List)) {
                 ++it;
-                if (it == path.end()) {
-                    auto local_col = local_obj.get_table()->get_column_key(col_name);
-                    Lst<Mixed> local_list{local_obj, local_col};
-                    Lst<Mixed> remote_list{remote_obj, col};
-                    callback(remote_list, local_list);
-                    return true;
-                }
-                else {
-                    // same as above.
-                    REALM_UNREACHABLE();
-                }
+                REALM_ASSERT(it == path.end());
+                auto local_col = local_obj.get_table()->get_column_key(col_name);
+                Lst<Mixed> local_list{local_obj, local_col};
+                Lst<Mixed> remote_list{remote_obj, col};
+                callback(remote_list, local_list);
+                return true;
             }
             else if (local_any.is_type(type_Dictionary) && remote_any.is_type(type_Dictionary)) {
-                ++it;
-                REALM_ASSERT(it != path.end());
-                REALM_ASSERT(it->type == ListPath::Element::Type::InternKey);
                 StringData col_name = remote_obj.get_table()->get_column_name(col);
                 auto local_col = local_obj.get_table()->get_column_key(col_name);
-                Dictionary remote_dict{remote_obj, col};
-                Dictionary local_dict{local_obj, local_col};
-                StringData dict_key = m_intern_keys.get_key(it->intern_key);
-                if (remote_dict.contains(dict_key) && local_dict.contains(dict_key)) {
-                    remote_obj = remote_dict.get_object(dict_key);
-                    local_obj = local_dict.get_object(dict_key);
-                    ++it;
-                }
-                else {
-                    return false;
-                }
+                remote_dict = remote_obj.get_dictionary(col);
+                local_dict = local_obj.get_dictionary(local_col);
+                ++it;
+            }
+            else {
+                return false;
             }
         }
         else {
@@ -756,9 +759,11 @@ RecoverLocalChangesetsHandler::RecoveryResolver::RecoveryResolver(RecoverLocalCh
 {
 }
 
-void RecoverLocalChangesetsHandler::RecoveryResolver::on_property(Obj&, ColKey)
+RecoverLocalChangesetsHandler::RecoveryResolver::Status
+RecoverLocalChangesetsHandler::RecoveryResolver::on_property(Obj&, ColKey)
 {
     m_recovery_applier->handle_error(util::format("Invalid path for %1 (object, column)", m_instr_name));
+    return Status::DidNotResolve;
 }
 
 void RecoverLocalChangesetsHandler::RecoveryResolver::on_list(LstBase&)
@@ -795,6 +800,16 @@ void RecoverLocalChangesetsHandler::RecoveryResolver::on_error(const std::string
     m_recovery_applier->handle_error(err_msg);
 }
 
+RecoverLocalChangesetsHandler::RecoveryResolver::Status
+RecoverLocalChangesetsHandler::RecoveryResolver::on_mixed_type_changed(const std::string& err_msg)
+{
+    std::string full_message =
+        util::format("Discarding a local %1 made to a collection which no longer exists along path. Error: %2",
+                     m_instr_name, err_msg);
+    m_recovery_applier->m_logger.warn(full_message.c_str());
+    return Status::DidNotResolve; // discard the instruction because the type of a property of collection item changed
+}
+
 void RecoverLocalChangesetsHandler::RecoveryResolver::on_column_advance(ColKey col)
 {
     m_list_path.append(ListPath::Element(col));
@@ -817,11 +832,12 @@ RecoverLocalChangesetsHandler::RecoveryResolver::on_list_index_advance(uint32_t 
         }
         REALM_ASSERT(cross_ndx->remote != uint32_t(-1));
 
-        set_last_path_index(cross_ndx->remote); // translate the index of the path
+        update_path_index(cross_ndx->remote); // translate the index of the path
 
-        // At this point, the first part of an embedded object path has been allowed.
-        // This implies that all parts of the rest of the path are also allowed so the index translation is
-        // not necessary because instructions are operating on local only operations.
+        // At this point, the first part of a path has been allowed.
+        // This implies that all parts of the rest of the path are also allowed
+        // so the index translation is not necessary because instructions are
+        // operating on local only operations.
         return Status::Success;
     }
     // no record of this base list so far, track it for verbatim copy
@@ -840,6 +856,17 @@ RecoverLocalChangesetsHandler::RecoveryResolver::on_null_link_advance(StringData
 }
 
 RecoverLocalChangesetsHandler::RecoveryResolver::Status
+RecoverLocalChangesetsHandler::RecoveryResolver::on_dict_key_not_found(StringData table_name, StringData field_name,
+                                                                       StringData key)
+{
+    m_recovery_applier->m_logger.warn(
+        util::LogCategory::reset,
+        "Discarding a local %1 because the key '%2' does not exist in a dictionary along path '%2.%3'", m_instr_name,
+        key, table_name, field_name);
+    return Status::DidNotResolve; // discard this instruction as its path cannot be resolved
+}
+
+RecoverLocalChangesetsHandler::RecoveryResolver::Status
 RecoverLocalChangesetsHandler::RecoveryResolver::on_begin(const util::Optional<Obj>& obj)
 {
     if (!obj) {
@@ -851,7 +878,7 @@ RecoverLocalChangesetsHandler::RecoveryResolver::on_begin(const util::Optional<O
     return Status::Pending;
 }
 
-void RecoverLocalChangesetsHandler::RecoveryResolver::set_last_path_index(uint32_t ndx)
+void RecoverLocalChangesetsHandler::RecoveryResolver::update_path_index(uint32_t ndx)
 {
     REALM_ASSERT(m_it_begin != m_path_instr.path.begin());
     size_t distance = (m_it_begin - m_path_instr.path.begin()) - 1;
@@ -934,18 +961,18 @@ void RecoverLocalChangesetsHandler::operator()(const Instruction::Update& instr)
         }
         Status on_list_index(LstBase& list, uint32_t index) override
         {
-            util::Optional<ListTracker::CrossListIndex> cross_index;
-            cross_index = m_recovery_applier->m_lists.at(m_list_path).update(index);
-            if (cross_index) {
-                m_instr.prior_size = static_cast<uint32_t>(list.size());
-                m_instr.path.back() = cross_index->remote;
-            }
-            else {
+            auto cross_index = m_recovery_applier->m_lists.at(m_list_path).update(index);
+            if (!cross_index) {
                 return Status::DidNotResolve;
             }
+            m_instr.prior_size = static_cast<uint32_t>(list.size());
+            m_instr.path.back() = cross_index->remote;
             return Status::Pending;
         }
-        void on_property(Obj&, ColKey) override {}
+        Status on_property(Obj&, ColKey) override
+        {
+            return Status::Pending;
+        }
 
     private:
         Instruction::Update& m_instr;
@@ -972,9 +999,14 @@ void RecoverLocalChangesetsHandler::operator()(const Instruction::AddInteger& in
             : RecoveryResolver(applier, instr, "AddInteger")
         {
         }
-        void on_property(Obj&, ColKey) override
+        Status on_property(Obj& obj, ColKey key) override
         {
             // AddInteger only applies to a property
+            auto old_value = obj.get_any(key);
+            if (old_value.is_type(type_Int) && !obj.is_null(key)) {
+                return Status::Pending;
+            }
+            return Status::DidNotResolve;
         }
     };
     Instruction::AddInteger instr_copy = instr;
@@ -989,14 +1021,55 @@ void RecoverLocalChangesetsHandler::operator()(const Instruction::Clear& instr)
         ClearResolver(RecoverLocalChangesetsHandler* applier, Instruction::Clear& instr)
             : RecoveryResolver(applier, instr, "Clear")
         {
+            switch (instr.collection_type) {
+                case Instruction::CollectionType::Single:
+                    break;
+                case Instruction::CollectionType::List:
+                    m_collection_type = CollectionType::List;
+                    break;
+                case Instruction::CollectionType::Dictionary:
+                    m_collection_type = CollectionType::Dictionary;
+                    break;
+                case Instruction::CollectionType::Set:
+                    m_collection_type = CollectionType::Set;
+                    break;
+            }
         }
         void on_list(LstBase&) override
         {
             m_recovery_applier->m_lists.at(m_list_path).clear();
-            // Clear.prior_size is ignored and always zero
+        }
+        Status on_list_index(LstBase&, uint32_t index) override
+        {
+            Status list_status = on_list_index_advance(index);
+            return list_status;
+            // There is no need to clear the potential list at 'index' because that's
+            // one level deeper than the current list.
         }
         void on_set(SetBase&) override {}
         void on_dictionary(Dictionary&) override {}
+        Status on_dictionary_key(Dictionary& dict, Mixed key) override
+        {
+            on_dict_key_advance(key.get_string());
+            // Create the collection if the key does not exist.
+            if (dict.find(key) == dict.end()) {
+                dict.insert_collection(key.get_string(), m_collection_type);
+            }
+            else if (m_collection_type == CollectionType::List) {
+                m_recovery_applier->m_lists.at(m_list_path).clear();
+            }
+            return Status::Pending;
+        }
+        Status on_property(Obj&, ColKey) override
+        {
+            if (m_collection_type == CollectionType::List) {
+                m_recovery_applier->m_lists.at(m_list_path).clear();
+            }
+            return Status::Pending;
+        }
+
+    private:
+        CollectionType m_collection_type;
     };
     Instruction::Clear instr_copy = instr;
     if (ClearResolver(this, instr_copy).resolve() == RecoveryResolver::Status::Success) {

--- a/test/object-store/sync/client_reset.cpp
+++ b/test/object-store/sync/client_reset.cpp
@@ -265,6 +265,7 @@ TEST_CASE("sync: client reset", "[sync][pbs][client reset][baas]") {
          {
              {"_id", PropertyType::ObjectId, Property::IsPrimary{true}},
              {"value", PropertyType::Int},
+             {"any_mixed", PropertyType::Mixed | PropertyType::Nullable},
              partition_prop,
          }},
         {"link target",
@@ -773,7 +774,7 @@ TEST_CASE("sync: client reset", "[sync][pbs][client reset][baas]") {
                     list.add(key2);
                     list.add(key3); // common suffix of key3
                     // 1, 2, 2, 3, 2, 3
-                    // this set operation triggers the list copy because the index becomes ambiguious
+                    // this set operation triggers the list copy because the index becomes ambiguous
                     list.set(0, key1);
                 })
                 ->make_remote_changes([&](SharedRealm remote) {
@@ -795,6 +796,47 @@ TEST_CASE("sync: client reset", "[sync][pbs][client reset][baas]") {
                     REQUIRE(list.get_object(0).get<Int>("value") == 1);
                     REQUIRE(list.get_object(1).get<Int>("value") == 3);
                     REQUIRE(list.get_object(2).get<Int>("value") == 3);
+                })
+                ->run();
+        }
+
+        SECTION("add_int on non-integer field") {
+            ObjectId pk = ObjectId::gen();
+            test_reset
+                ->setup([&](SharedRealm realm) {
+                    auto table = get_table(*realm, "object");
+                    REQUIRE(table);
+                    auto obj = create_object(*realm, "object", {pk}, partition);
+                    auto col = obj.get_table()->get_column_key("any_mixed");
+                    obj.set_any(col, 42);
+                })
+                ->make_local_changes([&](SharedRealm local) {
+                    auto table = get_table(*local, "object");
+                    REQUIRE(table);
+                    REQUIRE(table->size() == 2);
+                    ObjKey key = table->get_objkey_from_primary_key(pk);
+                    REQUIRE(key);
+                    Obj obj = table->get_object(key);
+                    obj.add_int("any_mixed", 200);
+                })
+                ->make_remote_changes([&](SharedRealm remote) {
+                    auto table = get_table(*remote, "object");
+                    REQUIRE(table);
+                    REQUIRE(table->size() == 2);
+                    ObjKey key = table->get_objkey_from_primary_key(pk);
+                    REQUIRE(key);
+                    Obj obj = table->get_object(key);
+                    obj.set_any("any_mixed", "value");
+                })
+                ->on_post_reset([&](SharedRealm realm) {
+                    REQUIRE_NOTHROW(realm->refresh());
+                    auto table = get_table(*realm, "object");
+                    REQUIRE(table->size() == 2);
+                    ObjKey key = table->get_objkey_from_primary_key(pk);
+                    REQUIRE(key);
+                    Obj obj = table->get_object(key);
+                    REQUIRE(obj);
+                    REQUIRE(obj.get_any("any_mixed") == "value");
                 })
                 ->run();
         }
@@ -3684,8 +3726,9 @@ TEST_CASE("client reset with embedded object", "[sync][pbs][client reset][embedd
             TopLevelContent expected_recovered = local;
             reset_embedded_object({local}, {remote}, expected_recovered);
         }
-        SECTION("local ArraySet to an embedded object through a deep link->linklist element which is removed by the "
-                "remote triggers a list copy") {
+        SECTION(
+            "local ArrayUpdate to an embedded object through a deep link->linklist element which is removed by the "
+            "remote triggers a list copy") {
             local.link_value->array_vals[0] = 12345;
             remote.link_value->array_vals.erase(remote.link_value->array_vals.begin());
             TopLevelContent expected_recovered = local;
@@ -4350,12 +4393,15 @@ TEST_CASE("client reset with nested collection", "[client reset][local][nested c
                                      {"value", PropertyType::Int},
                                  }};
 
-    config.schema = Schema{shared_class,
-                           {"TopLevel",
-                            {
-                                {"_id", PropertyType::ObjectId, Property::IsPrimary{true}},
-                                {"any_mixed", PropertyType::Mixed | PropertyType::Nullable},
-                            }}};
+    config.schema =
+        Schema{shared_class,
+               {"TopLevel",
+                {
+                    {"_id", PropertyType::ObjectId, Property::IsPrimary{true}},
+                    {"any_mixed", PropertyType::Mixed | PropertyType::Nullable},
+                    {"list_mixed", PropertyType::Array | PropertyType::Mixed | PropertyType::Nullable},
+                    {"dictionary_mixed", PropertyType::Dictionary | PropertyType::Mixed | PropertyType::Nullable},
+                }}};
 
     SECTION("add nested collection locally") {
         ObjectId pk_val = ObjectId::gen();
@@ -4827,6 +4873,8 @@ TEST_CASE("client reset with nested collection", "[client reset][local][nested c
                 n_list.insert(0, Mixed{31});
             })
             ->make_local_changes([&](SharedRealm local_realm) {
+                // The changes are recovered (instead of copying the entire list) because
+                // the first index in the path is known (it is just inserted)
                 advance_and_notify(*local_realm);
                 TableRef table = get_table(*local_realm, "TopLevel");
                 REQUIRE(table->size() == 1);
@@ -4960,6 +5008,7 @@ TEST_CASE("client reset with nested collection", "[client reset][local][nested c
                 auto obj = table->get_object(0);
                 auto col = table->get_column_key("any_mixed");
                 List list{local_realm, obj, col};
+                // this insert operation triggers the list copy because the index becomes ambiguous
                 auto n_list = list.get_list(0);
                 n_list.insert(0, Mixed{50});
                 list.insert_collection(0, CollectionType::List); // shift
@@ -4998,18 +5047,14 @@ TEST_CASE("client reset with nested collection", "[client reset][local][nested c
                 }
                 else {
                     List list{local_realm, obj, col};
-                    REQUIRE(list.size() == 3);
-                    auto n_list = list.get_list(0);
-                    auto n_list1 = list.get_list(1);
-                    auto n_list2 = list.get_list(2);
-                    REQUIRE(n_list.size() == 1);
-                    REQUIRE(n_list1.size() == 2);
+                    REQUIRE(list.size() == 2);
+                    auto n_list1 = list.get_list(0);
+                    auto n_list2 = list.get_list(1);
+                    REQUIRE(n_list1.size() == 1);
                     REQUIRE(n_list2.size() == 2);
-                    REQUIRE(n_list.get_any(0).get_int() == 150);
-                    REQUIRE(n_list1.get_any(0).get_int() == 50);
-                    REQUIRE(n_list1.get_any(1).get_int() == 42);
-                    REQUIRE(n_list2.get_any(0).get_int() == 30);
-                    REQUIRE(n_list2.get_any(1).get_int() == 100);
+                    REQUIRE(n_list1.get_any(0).get_int() == 150);
+                    REQUIRE(n_list2.get_any(0).get_int() == 50);
+                    REQUIRE(n_list2.get_any(1).get_int() == 30);
                 }
             })
             ->run();
@@ -5232,8 +5277,12 @@ TEST_CASE("client reset with nested collection", "[client reset][local][nested c
                 List list{local_realm, obj, col};
                 REQUIRE(list.size() == 2);
                 auto nlist = list.get_list(0);
+                nlist.insert_collection(0, CollectionType::List);
+                nlist = nlist.get_list(0);
                 nlist.add(Mixed{4});
                 auto ndict = list.get_dictionary(1);
+                ndict.insert_collection("key", CollectionType::Dictionary);
+                ndict = ndict.get_dictionary("key");
                 ndict.insert("Int2", 6);
             })
             ->make_remote_changes([&](SharedRealm remote_realm) {
@@ -5245,8 +5294,12 @@ TEST_CASE("client reset with nested collection", "[client reset][local][nested c
                 List list{remote_realm, obj, col};
                 REQUIRE(list.size() == 2);
                 auto nlist = list.get_list(0);
+                nlist.insert_collection(0, CollectionType::List);
+                nlist = nlist.get_list(0);
                 nlist.add(Mixed{7});
                 auto ndict = list.get_dictionary(1);
+                ndict.insert_collection("key", CollectionType::Dictionary);
+                ndict = ndict.get_dictionary("key");
                 ndict.insert("Int3", Mixed{9});
             })
             ->on_post_reset([&](SharedRealm local_realm) {
@@ -5263,28 +5316,35 @@ TEST_CASE("client reset with nested collection", "[client reset][local][nested c
                     auto ndict = list.get_dictionary(1);
                     REQUIRE(nlist.size() == 3);
                     REQUIRE(ndict.size() == 3);
-                    REQUIRE(nlist.get_any(0).get_int() == 1);
-                    REQUIRE(nlist.get_any(1).get_string() == "Test");
-                    REQUIRE(nlist.get_any(2).get_int() == 7);
+                    REQUIRE(nlist.get_any(1).get_int() == 1);
+                    REQUIRE(nlist.get_any(2).get_string() == "Test");
+                    nlist = nlist.get_list(0);
+                    REQUIRE(nlist.size() == 1);
+                    REQUIRE(nlist.get_any(0).get_int() == 7);
                     REQUIRE(ndict.get_any("Int").get_int() == 3);
                     REQUIRE(ndict.get_any("String").get_string() == "Test");
+                    ndict = ndict.get_dictionary("key");
+                    REQUIRE(ndict.size() == 1);
                     REQUIRE(ndict.get_any("Int3").get_int() == 9);
                 }
                 else {
+                    // db must be equal to local
                     List list{local_realm, obj, col};
                     REQUIRE(list.size() == 2);
                     auto nlist = list.get_list(0);
                     auto ndict = list.get_dictionary(1);
-                    REQUIRE(nlist.size() == 4);
-                    REQUIRE(ndict.size() == 4);
-                    REQUIRE(nlist.get_any(0).get_int() == 1);
-                    REQUIRE(nlist.get_any(1).get_string() == "Test");
-                    REQUIRE(nlist.get_any(2).get_int() == 4);
-                    REQUIRE(nlist.get_any(3).get_int() == 7);
+                    REQUIRE(nlist.size() == 3);
+                    REQUIRE(ndict.size() == 3);
+                    REQUIRE(nlist.get_any(1).get_int() == 1);
+                    REQUIRE(nlist.get_any(2).get_string() == "Test");
+                    auto nlist2 = nlist.get_list(0);
+                    REQUIRE(nlist2.size() == 1);
+                    REQUIRE(nlist2.get_any(0).get_int() == 4);
                     REQUIRE(ndict.get_any("Int").get_int() == 3);
                     REQUIRE(ndict.get_any("String").get_string() == "Test");
+                    ndict = ndict.get_dictionary("key");
+                    REQUIRE(ndict.size() == 1);
                     REQUIRE(ndict.get_any("Int2").get_int() == 6);
-                    REQUIRE(ndict.get_any("Int3").get_int() == 9);
                 }
             })
             ->run();
@@ -5364,10 +5424,11 @@ TEST_CASE("client reset with nested collection", "[client reset][local][nested c
                     REQUIRE(nlist.get_any(8).get_int() == 7);
                 }
                 else {
+                    // db must be equal to local
                     List list{local_realm, obj, col};
                     REQUIRE(list.size() == 1);
                     auto nlist = list.get_list(0);
-                    REQUIRE(nlist.size() == 13);
+                    REQUIRE(nlist.size() == 7);
                     REQUIRE(nlist.get_any(0).get_int() == 1);
                     REQUIRE(nlist.get_any(1).get_int() == 2);
                     REQUIRE(nlist.get_any(2).get_int() == 3);
@@ -5375,12 +5436,6 @@ TEST_CASE("client reset with nested collection", "[client reset][local][nested c
                     REQUIRE(nlist.get_any(4).get_int() == 5);
                     REQUIRE(nlist.get_any(5).get_int() == 6);
                     REQUIRE(nlist.get_any(6).get_int() == 7);
-                    REQUIRE(nlist.get_any(7).get_int() == 4);
-                    REQUIRE(nlist.get_any(8).get_int() == 5);
-                    REQUIRE(nlist.get_any(9).get_int() == 8);
-                    REQUIRE(nlist.get_any(10).get_int() == 9);
-                    REQUIRE(nlist.get_any(11).get_int() == 6);
-                    REQUIRE(nlist.get_any(12).get_int() == 7);
                 }
             })
             ->run();
@@ -5440,6 +5495,170 @@ TEST_CASE("client reset with nested collection", "[client reset][local][nested c
                     auto ndict = list.get_dictionary(1);
                     REQUIRE(ndict.get_any("Test").get_string() == "Remote");
                     REQUIRE(nlist.get_any(0).get_string() == "Local");
+                }
+            })
+            ->run();
+    }
+    SECTION("Verify copy logic for List<Mixed>") {
+        ObjectId pk_val = ObjectId::gen();
+        SyncTestFile config2(oas.app()->current_user(), "default");
+        config2.schema = config.schema;
+        auto test_reset = reset_utils::make_fake_local_client_reset(config, config2);
+        test_reset
+            ->setup([&](SharedRealm realm) {
+                auto table = get_table(*realm, "TopLevel");
+                auto obj = table->create_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("list_mixed");
+                List list{realm, obj, col};
+                list.insert_collection(0, CollectionType::List);
+                list.insert_collection(1, CollectionType::Dictionary);
+                auto nlist = list.get_list(0);
+                auto ndict = list.get_dictionary(1);
+                nlist.add(Mixed{1});
+                nlist.add(Mixed{"Test"});
+                ndict.insert("Int", Mixed(3));
+                ndict.insert("String", Mixed("Test"));
+            })
+            ->make_local_changes([&](SharedRealm local_realm) {
+                advance_and_notify(*local_realm);
+                TableRef table = get_table(*local_realm, "TopLevel");
+                REQUIRE(table->size() == 1);
+                auto obj = table->get_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("list_mixed");
+                List list{local_realm, obj, col};
+                REQUIRE(list.size() == 2);
+                list.insert(2, Mixed{42});
+                auto nlist = list.get_list(0);
+                nlist.set_any(0, Mixed{2});
+                auto ndict = list.get_dictionary(1);
+                ndict.insert("Int", Mixed{6});
+            })
+            ->make_remote_changes([&](SharedRealm remote_realm) {
+                advance_and_notify(*remote_realm);
+                TableRef table = get_table(*remote_realm, "TopLevel");
+                REQUIRE(table->size() == 1);
+                auto obj = table->get_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("list_mixed");
+                List list{remote_realm, obj, col};
+                REQUIRE(list.size() == 2);
+                list.insert(2, Mixed{43});
+                auto nlist = list.get_list(0);
+                nlist.set_any(1, Mixed{3});
+                auto ndict = list.get_dictionary(1);
+                ndict.insert("Int", Mixed{9});
+            })
+            ->on_post_reset([&](SharedRealm local_realm) {
+                advance_and_notify(*local_realm);
+                TableRef table = get_table(*local_realm, "TopLevel");
+                REQUIRE(table->size() == 1);
+                auto obj = table->get_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("list_mixed");
+                List list{local_realm, obj, col};
+                if (test_mode == ClientResyncMode::DiscardLocal) {
+                    // db must be equal to remote
+                    REQUIRE(list.size() == 3);
+                    auto nlist = list.get_list(0);
+                    auto ndict = list.get_dictionary(1);
+                    REQUIRE(list.get_any(2).get_int() == 43);
+                    REQUIRE(nlist.size() == 2);
+                    REQUIRE(ndict.size() == 2);
+                    REQUIRE(nlist.get_any(0).get_int() == 1);
+                    REQUIRE(nlist.get_any(1).get_int() == 3);
+                    REQUIRE(ndict.get_any("Int").get_int() == 9);
+                    REQUIRE(ndict.get_any("String").get_string() == "Test");
+                }
+                else {
+                    // db must be equal to local
+                    REQUIRE(list.size() == 3);
+                    auto nlist = list.get_list(0);
+                    auto ndict = list.get_dictionary(1);
+                    REQUIRE(list.get_any(2).get_int() == 42);
+                    REQUIRE(nlist.size() == 2);
+                    REQUIRE(ndict.size() == 2);
+                    REQUIRE(nlist.get_any(0).get_int() == 2);
+                    REQUIRE(nlist.get_any(1).get_string() == "Test");
+                    REQUIRE(ndict.get_any("Int").get_int() == 6);
+                    REQUIRE(ndict.get_any("String").get_string() == "Test");
+                }
+            })
+            ->run();
+    }
+    SECTION("Verify copy logic for Dictionary<Mixed>") {
+        ObjectId pk_val = ObjectId::gen();
+        SyncTestFile config2(oas.app()->current_user(), "default");
+        config2.schema = config.schema;
+        auto test_reset = reset_utils::make_fake_local_client_reset(config, config2);
+        test_reset
+            ->setup([&](SharedRealm realm) {
+                auto table = get_table(*realm, "TopLevel");
+                auto obj = table->create_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("dictionary_mixed");
+                object_store::Dictionary dict{realm, obj, col};
+                dict.insert_collection("key1", CollectionType::List);
+                dict.insert_collection("key2", CollectionType::Dictionary);
+                auto nlist = dict.get_list("key1");
+                auto ndict = dict.get_dictionary("key2");
+                nlist.add(Mixed{1});
+                nlist.add(Mixed{"Test"});
+                ndict.insert("Int", Mixed(3));
+                ndict.insert("String", Mixed("Test"));
+            })
+            ->make_local_changes([&](SharedRealm local_realm) {
+                advance_and_notify(*local_realm);
+                TableRef table = get_table(*local_realm, "TopLevel");
+                REQUIRE(table->size() == 1);
+                auto obj = table->get_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("dictionary_mixed");
+                object_store::Dictionary dict{local_realm, obj, col};
+                REQUIRE(dict.size() == 2);
+                auto nlist = dict.get_list("key1");
+                nlist.set_any(0, Mixed{2});
+                auto ndict = dict.get_dictionary("key2");
+                ndict.insert("Int", Mixed{6});
+            })
+            ->make_remote_changes([&](SharedRealm remote_realm) {
+                advance_and_notify(*remote_realm);
+                TableRef table = get_table(*remote_realm, "TopLevel");
+                REQUIRE(table->size() == 1);
+                auto obj = table->get_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("dictionary_mixed");
+                object_store::Dictionary dict{remote_realm, obj, col};
+                REQUIRE(dict.size() == 2);
+                auto nlist = dict.get_list("key1");
+                nlist.set_any(1, Mixed{3});
+                auto ndict = dict.get_dictionary("key2");
+                ndict.insert("String", Mixed("Test2"));
+            })
+            ->on_post_reset([&](SharedRealm local_realm) {
+                advance_and_notify(*local_realm);
+                TableRef table = get_table(*local_realm, "TopLevel");
+                REQUIRE(table->size() == 1);
+                auto obj = table->get_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("dictionary_mixed");
+                object_store::Dictionary dict{local_realm, obj, col};
+                if (test_mode == ClientResyncMode::DiscardLocal) {
+                    // db must be equal to remote
+                    REQUIRE(dict.size() == 2);
+                    auto nlist = dict.get_list("key1");
+                    auto ndict = dict.get_dictionary("key2");
+                    REQUIRE(nlist.size() == 2);
+                    REQUIRE(ndict.size() == 2);
+                    REQUIRE(nlist.get_any(0).get_int() == 1);
+                    REQUIRE(nlist.get_any(1).get_int() == 3);
+                    REQUIRE(ndict.get_any("Int").get_int() == 3);
+                    REQUIRE(ndict.get_any("String").get_string() == "Test2");
+                }
+                else {
+                    // db must be equal to local
+                    REQUIRE(dict.size() == 2);
+                    auto nlist = dict.get_list("key1");
+                    auto ndict = dict.get_dictionary("key2");
+                    REQUIRE(nlist.size() == 2);
+                    REQUIRE(ndict.size() == 2);
+                    REQUIRE(nlist.get_any(0).get_int() == 2);
+                    REQUIRE(nlist.get_any(1).get_string() == "Test");
+                    REQUIRE(ndict.get_any("Int").get_int() == 6);
+                    REQUIRE(ndict.get_any("String").get_string() == "Test2");
                 }
             })
             ->run();
@@ -6540,6 +6759,887 @@ TEST_CASE("client reset with nested collection", "[client reset][local][nested c
                     CHECK(table->query("any_mixed['MyDictionary']['KeyLocal'].any_mixed.@size == 2").count() == 1);
                     CHECK(table->query("any_mixed['MyDictionary']['KeyLocal'].any_mixed[0] == 1").count() == 1);
                     CHECK(table->query("any_mixed['MyDictionary']['KeyLocal'].any_mixed[1] == 2").count() == 1);
+                }
+            })
+            ->run();
+    }
+    SECTION("Append to list that was reduced in size remotely") {
+        ObjectId pk_val = ObjectId::gen();
+        SyncTestFile config2(oas.app()->current_user(), "default");
+        config2.schema = config.schema;
+        auto test_reset = reset_utils::make_fake_local_client_reset(config, config2);
+        test_reset
+            ->setup([&](SharedRealm realm) {
+                // Baseline: {"_id": <id>, "any_mixed": {{"key1": {{"key2": [1, 2, 3]}}}}}
+                auto table = get_table(*realm, "TopLevel");
+                auto obj = table->create_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("any_mixed");
+                obj.set_collection(col, CollectionType::Dictionary);
+                object_store::Dictionary dictionary{realm, obj, col};
+                dictionary.insert_collection("key1", CollectionType::Dictionary);
+                auto ndictionary = dictionary.get_dictionary("key1");
+                ndictionary.insert_collection("key2", CollectionType::List);
+                auto nlist = ndictionary.get_list("key2");
+                nlist.add(Mixed{1});
+                nlist.add(Mixed{2});
+                nlist.add(Mixed{3});
+            })
+            ->make_local_changes([&](SharedRealm local_realm) {
+                // Local client: {"_id": <id>, "any_mixed": {{"key1": {{"key2": [1, 2, 3, 4, [5]]}}}}}
+                advance_and_notify(*local_realm);
+                TableRef table = get_table(*local_realm, "TopLevel");
+                REQUIRE(table->size() == 1);
+                auto obj = table->get_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("any_mixed");
+                auto nlist = obj.get_list_ptr<Mixed>({col, "key1", "key2"});
+                nlist->add(Mixed{4});
+                REQUIRE(nlist->size() == 4);
+                nlist->insert_collection(4, CollectionType::List);
+                nlist = nlist->get_list(4);
+                nlist->add(Mixed{5});
+            })
+            ->make_remote_changes([&](SharedRealm remote_realm) {
+                // Remote client: {"_id": <id>, "any_mixed": {{"key1": {{"key2": [2, 3]}}}}}
+                advance_and_notify(*remote_realm);
+                TableRef table = get_table(*remote_realm, "TopLevel");
+                REQUIRE(table->size() == 1);
+                auto obj = table->get_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("any_mixed");
+                auto nlist = obj.get_list_ptr<Mixed>({col, "key1", "key2"});
+                nlist->remove(0);
+            })
+            ->on_post_reset([&](SharedRealm local_realm) {
+                advance_and_notify(*local_realm);
+                TableRef table = get_table(*local_realm, "TopLevel");
+                REQUIRE(table->size() == 1);
+                auto obj = table->get_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("any_mixed");
+                auto nlist = obj.get_list_ptr<Mixed>({col, "key1", "key2"});
+
+                if (test_mode == ClientResyncMode::DiscardLocal) {
+                    // Result: {"_id": <id>, "any_mixed": {{"key1": {{"key2": [2, 3]}}}}}
+                    REQUIRE(nlist->size() == 2);
+                    REQUIRE(nlist->get_any(0).get_int() == 2);
+                    REQUIRE(nlist->get_any(1).get_int() == 3);
+                }
+                else {
+                    // Index of the recovered instruction is updated accordingly.
+                    // Result: {"_id": <id>, "any_mixed": {{"key1": {{"key2": [2, 3, 4, [5]]}}}}}
+                    REQUIRE(nlist->size() == 4);
+                    REQUIRE(nlist->get_any(0).get_int() == 2);
+                    REQUIRE(nlist->get_any(1).get_int() == 3);
+                    REQUIRE(nlist->get_any(2).get_int() == 4);
+                    nlist = nlist->get_list(3);
+                    REQUIRE(nlist->size() == 1);
+                    REQUIRE(nlist->get_any(0).get_int() == 5);
+                }
+            })
+            ->run();
+    }
+    SECTION("Operating on local list does not trigger a copy") {
+        ObjectId pk_val = ObjectId::gen();
+        SyncTestFile config2(oas.app()->current_user(), "default");
+        config2.schema = config.schema;
+        auto test_reset = reset_utils::make_fake_local_client_reset(config, config2);
+        test_reset
+            ->setup([&](SharedRealm realm) {
+                // Baseline: {"_id": <id>, "any_mixed": {{"key1": [1, [2]]}}}
+                auto table = get_table(*realm, "TopLevel");
+                auto obj = table->create_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("any_mixed");
+                obj.set_collection(col, CollectionType::Dictionary);
+                object_store::Dictionary dictionary{realm, obj, col};
+                dictionary.insert_collection("key1", CollectionType::List);
+                auto nlist = dictionary.get_list("key1");
+                nlist.add(Mixed{1});
+                nlist.insert_collection(1, CollectionType::List);
+                nlist = nlist.get_list(1);
+                nlist.add(Mixed{2});
+            })
+            ->make_local_changes([&](SharedRealm local_realm) {
+                // Local client: {"_id": <id>, "any_mixed": {{"key1": [1, [2], [3]]}}}
+                advance_and_notify(*local_realm);
+                TableRef table = get_table(*local_realm, "TopLevel");
+                REQUIRE(table->size() == 1);
+                auto obj = table->get_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("any_mixed");
+                auto nlist = obj.get_list_ptr<Mixed>({col, "key1"});
+                REQUIRE(nlist->size() == 2);
+                nlist->insert_collection(2, CollectionType::List);
+                nlist = nlist->get_list(2);
+                nlist->add(Mixed{3});
+            })
+            ->make_remote_changes([&](SharedRealm remote_realm) {
+                // Remote client: {"_id": <id>, "any_mixed": {{"key1": [1, [2], 4]}}}
+                advance_and_notify(*remote_realm);
+                TableRef table = get_table(*remote_realm, "TopLevel");
+                REQUIRE(table->size() == 1);
+                auto obj = table->get_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("any_mixed");
+                auto nlist = obj.get_list_ptr<Mixed>({col, "key1"});
+                nlist->add(Mixed{4});
+            })
+            ->on_post_reset([&](SharedRealm local_realm) {
+                advance_and_notify(*local_realm);
+                TableRef table = get_table(*local_realm, "TopLevel");
+                REQUIRE(table->size() == 1);
+                auto obj = table->get_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("any_mixed");
+                auto nlist = obj.get_list_ptr<Mixed>({col, "key1"});
+
+                if (test_mode == ClientResyncMode::DiscardLocal) {
+                    // list must be equal to remote
+                    // Result: {"_id": <id>, "any_mixed": {{"key1": [1, [2], 4]}}}
+                    REQUIRE(nlist->size() == 3);
+                    REQUIRE(nlist->get_any(0).get_int() == 1);
+                    auto nlist2 = nlist->get_list(1);
+                    REQUIRE(nlist2->size() == 1);
+                    REQUIRE(nlist2->get_any(0).get_int() == 2);
+                    REQUIRE(nlist->get_any(2).get_int() == 4);
+                }
+                else {
+                    // Result: {"_id": <id>, "any_mixed": {{"key1": [1, [2], [3], 4]}}}
+                    REQUIRE(nlist->size() == 4);
+                    REQUIRE(nlist->get_any(0).get_int() == 1);
+                    auto nlist2 = nlist->get_list(1);
+                    REQUIRE(nlist2->size() == 1);
+                    REQUIRE(nlist2->get_any(0).get_int() == 2);
+                    nlist2 = nlist->get_list(2);
+                    REQUIRE(nlist2->size() == 1);
+                    REQUIRE(nlist2->get_any(0).get_int() == 3);
+                    REQUIRE(nlist->get_any(3).get_int() == 4);
+                }
+            })
+            ->run();
+    }
+
+    // Test type mismatch in the instruction path.
+
+    SECTION("List changed into Dictionary remotely") {
+        ObjectId pk_val = ObjectId::gen();
+        SyncTestFile config2(oas.app()->current_user(), "default");
+        config2.schema = config.schema;
+        auto test_reset = reset_utils::make_fake_local_client_reset(config, config2);
+        test_reset
+            ->setup([&](SharedRealm realm) {
+                // Baseline: {"_id": <id>, "any_mixed": [1]}
+                auto table = get_table(*realm, "TopLevel");
+                auto obj = table->create_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("any_mixed");
+                obj.set_collection(col, CollectionType::List);
+                List list{realm, obj, col};
+                list.add(Mixed{1});
+            })
+            ->make_local_changes([&](SharedRealm local_realm) {
+                // Local client: {"_id": <id>, "any_mixed": [1, 2, 3]}
+                advance_and_notify(*local_realm);
+                TableRef table = get_table(*local_realm, "TopLevel");
+                REQUIRE(table->size() == 1);
+                auto obj = table->get_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("any_mixed");
+                List list{local_realm, obj, col};
+                REQUIRE(list.size() == 1);
+                list.add(Mixed{2});
+                list.add(Mixed{3});
+            })
+            ->make_remote_changes([&](SharedRealm remote_realm) {
+                // Remote client: {"_id": <id>, "any_mixed": {{"key": "value"}}}
+                advance_and_notify(*remote_realm);
+                TableRef table = get_table(*remote_realm, "TopLevel");
+                REQUIRE(table->size() == 1);
+                auto obj = table->get_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("any_mixed");
+                // Change type from list to dictionary
+                obj.set_collection(col, CollectionType::Dictionary);
+                object_store::Dictionary dictionary{remote_realm, obj, col};
+                dictionary.insert("key", "value");
+            })
+            ->on_post_reset([&](SharedRealm local_realm) {
+                // Result: {"_id": <id>, "any_mixed": {{"key": "value"}}}
+                advance_and_notify(*local_realm);
+                TableRef table = get_table(*local_realm, "TopLevel");
+                REQUIRE(table->size() == 1);
+                auto obj = table->get_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("any_mixed");
+                // In the recovery case, the local instructions cannot be recovered
+                // because the property type changed.
+                object_store::Dictionary dictionary{local_realm, obj, col};
+                REQUIRE(dictionary.size() == 1);
+                REQUIRE(dictionary.get_any("key").get_string() == "value");
+            })
+            ->run();
+    }
+    SECTION("Dictionary changed into List remotely") {
+        ObjectId pk_val = ObjectId::gen();
+        SyncTestFile config2(oas.app()->current_user(), "default");
+        config2.schema = config.schema;
+        auto test_reset = reset_utils::make_fake_local_client_reset(config, config2);
+        test_reset
+            ->setup([&](SharedRealm realm) {
+                // Baseline: {"_id": <id>, "any_mixed": {{"key": 42}}}
+                auto table = get_table(*realm, "TopLevel");
+                auto obj = table->create_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("any_mixed");
+                obj.set_collection(col, CollectionType::Dictionary);
+                object_store::Dictionary dict{realm, obj, col};
+                dict.insert("key", 42);
+            })
+            ->make_local_changes([&](SharedRealm local_realm) {
+                // Local client: {"_id": <id>, "any_mixed": {{"key": 42}, {"key2": 1}, {"key3": 2}}}
+                advance_and_notify(*local_realm);
+                TableRef table = get_table(*local_realm, "TopLevel");
+                REQUIRE(table->size() == 1);
+                auto obj = table->get_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("any_mixed");
+                object_store::Dictionary dict{local_realm, obj, col};
+                REQUIRE(dict.size() == 1);
+                dict.insert("key2", 1);
+                dict.insert("key3", 2);
+            })
+            ->make_remote_changes([&](SharedRealm remote_realm) {
+                // Remote client: {"_id": <id>, "any_mixed": ["value"]}
+                advance_and_notify(*remote_realm);
+                TableRef table = get_table(*remote_realm, "TopLevel");
+                REQUIRE(table->size() == 1);
+                auto obj = table->get_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("any_mixed");
+                // Change type from dictionary to list
+                obj.set_collection(col, CollectionType::List);
+                List list{remote_realm, obj, col};
+                list.add(Mixed{"value"});
+            })
+            ->on_post_reset([&](SharedRealm local_realm) {
+                // Result: {"_id": <id>, "any_mixed": ["value"]}
+                advance_and_notify(*local_realm);
+                TableRef table = get_table(*local_realm, "TopLevel");
+                REQUIRE(table->size() == 1);
+                auto obj = table->get_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("any_mixed");
+                // In the recovery case, the local instructions cannot be recovered
+                // because the property type changed.
+                List list{local_realm, obj, col};
+                REQUIRE(list.size() == 1);
+                REQUIRE(list.get_any(0).get_string() == "value");
+            })
+            ->run();
+    }
+    SECTION("List changed into string remotely") {
+        ObjectId pk_val = ObjectId::gen();
+        SyncTestFile config2(oas.app()->current_user(), "default");
+        config2.schema = config.schema;
+        auto test_reset = reset_utils::make_fake_local_client_reset(config, config2);
+        test_reset
+            ->setup([&](SharedRealm realm) {
+                // Baseline: {"_id": <id>, "any_mixed": [1]}
+                auto table = get_table(*realm, "TopLevel");
+                auto obj = table->create_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("any_mixed");
+                obj.set_collection(col, CollectionType::List);
+                List list{realm, obj, col};
+                list.add(Mixed{1});
+            })
+            ->make_local_changes([&](SharedRealm local_realm) {
+                // Local client: {"_id": <id>, "any_mixed": [1, 2, 3]}
+                advance_and_notify(*local_realm);
+                TableRef table = get_table(*local_realm, "TopLevel");
+                REQUIRE(table->size() == 1);
+                auto obj = table->get_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("any_mixed");
+                List list{local_realm, obj, col};
+                REQUIRE(list.size() == 1);
+                list.add(Mixed{2});
+                list.add(Mixed{3});
+            })
+            ->make_remote_changes([&](SharedRealm remote_realm) {
+                // Remote client: {"_id": <id>, "any_mixed": "value"}
+                advance_and_notify(*remote_realm);
+                TableRef table = get_table(*remote_realm, "TopLevel");
+                REQUIRE(table->size() == 1);
+                auto obj = table->get_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("any_mixed");
+                // Change type from list to string
+                obj.set_any(col, "value");
+            })
+            ->on_post_reset([&](SharedRealm local_realm) {
+                // Result: {"_id": <id>, "any_mixed": "value"}
+                advance_and_notify(*local_realm);
+                TableRef table = get_table(*local_realm, "TopLevel");
+                REQUIRE(table->size() == 1);
+                auto obj = table->get_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("any_mixed");
+                // In the recovery case, the local instructions cannot be recovered
+                // because the property type changed.
+                REQUIRE(obj.get_any(col) == "value");
+            })
+            ->run();
+    }
+    SECTION("Key in intermediate dictionary does not exist") {
+        ObjectId pk_val = ObjectId::gen();
+        SyncTestFile config2(oas.app()->current_user(), "default");
+        config2.schema = config.schema;
+        auto test_reset = reset_utils::make_fake_local_client_reset(config, config2);
+        test_reset
+            ->setup([&](SharedRealm realm) {
+                // Baseline: {"_id": <id>, "any_mixed": {{"key1": {{"key2": []}}}}}
+                auto table = get_table(*realm, "TopLevel");
+                auto obj = table->create_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("any_mixed");
+                obj.set_collection(col, CollectionType::Dictionary);
+                object_store::Dictionary dictionary{realm, obj, col};
+                dictionary.insert_collection("key1", CollectionType::Dictionary);
+                auto ndictionary = dictionary.get_dictionary("key1");
+                ndictionary.insert_collection("key2", CollectionType::List);
+            })
+            ->make_local_changes([&](SharedRealm local_realm) {
+                // Local client: {"_id": <id>, "any_mixed": {{"key1": {{"key2": [1]}}}}}
+                advance_and_notify(*local_realm);
+                TableRef table = get_table(*local_realm, "TopLevel");
+                REQUIRE(table->size() == 1);
+                auto obj = table->get_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("any_mixed");
+                auto nlist = obj.get_list_ptr<Mixed>({col, "key1", "key2"});
+                nlist->add(Mixed{1});
+            })
+            ->make_remote_changes([&](SharedRealm remote_realm) {
+                // Remote client: {"_id": <id>, "any_mixed": {{"key3": "value"}}}
+                advance_and_notify(*remote_realm);
+                TableRef table = get_table(*remote_realm, "TopLevel");
+                REQUIRE(table->size() == 1);
+                auto obj = table->get_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("any_mixed");
+                obj.set_collection(col, CollectionType::Dictionary);
+                object_store::Dictionary dict{remote_realm, obj, col};
+                // Remove dictionary at 'key1' so the path to local insert does not exist anymore.
+                dict.erase("key1");
+                dict.insert("key3", "value");
+            })
+            ->on_post_reset([&](SharedRealm local_realm) {
+                // Result: {"_id": <id>, "any_mixed": {{"key3": "value"}}}
+                advance_and_notify(*local_realm);
+                TableRef table = get_table(*local_realm, "TopLevel");
+                REQUIRE(table->size() == 1);
+                auto obj = table->get_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("any_mixed");
+                // In the recovery case, the local instructions cannot be recovered
+                // because the path does not exist anymore.
+                object_store::Dictionary dict{local_realm, obj, col};
+                REQUIRE(dict.size() == 1);
+                REQUIRE(dict.get_any("key3").get_string() == "value");
+            })
+            ->run();
+    }
+    SECTION("Intermediate dictionary changed into string remotely") {
+        ObjectId pk_val = ObjectId::gen();
+        SyncTestFile config2(oas.app()->current_user(), "default");
+        config2.schema = config.schema;
+        auto test_reset = reset_utils::make_fake_local_client_reset(config, config2);
+        test_reset
+            ->setup([&](SharedRealm realm) {
+                // Baseline: {"_id": <id>, "any_mixed": {{"key1": {{"key2": []}}}}}
+                auto table = get_table(*realm, "TopLevel");
+                auto obj = table->create_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("any_mixed");
+                obj.set_collection(col, CollectionType::Dictionary);
+                object_store::Dictionary dictionary{realm, obj, col};
+                dictionary.insert_collection("key1", CollectionType::Dictionary);
+                auto ndictionary = dictionary.get_dictionary("key1");
+                ndictionary.insert_collection("key2", CollectionType::List);
+            })
+            ->make_local_changes([&](SharedRealm local_realm) {
+                // Local client: {"_id": <id>, "any_mixed": {{"key1": {{"key2": [1]}}}}}
+                advance_and_notify(*local_realm);
+                TableRef table = get_table(*local_realm, "TopLevel");
+                REQUIRE(table->size() == 1);
+                auto obj = table->get_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("any_mixed");
+                auto nlist = obj.get_list_ptr<Mixed>({col, "key1", "key2"});
+                nlist->add(Mixed{1});
+            })
+            ->make_remote_changes([&](SharedRealm remote_realm) {
+                // Remote client: {"_id": <id>, "any_mixed": {{"key1": "value"}}}
+                advance_and_notify(*remote_realm);
+                TableRef table = get_table(*remote_realm, "TopLevel");
+                REQUIRE(table->size() == 1);
+                auto obj = table->get_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("any_mixed");
+                auto ndict = obj.get_dictionary_ptr({col});
+                // Change type of value at 'key1' so the path to local insert does not exist anymore.
+                ndict->insert("key1", "value");
+            })
+            ->on_post_reset([&](SharedRealm local_realm) {
+                // Result: {"_id": <id>, "any_mixed": {{"key1": "value"}}}
+                advance_and_notify(*local_realm);
+                TableRef table = get_table(*local_realm, "TopLevel");
+                REQUIRE(table->size() == 1);
+                auto obj = table->get_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("any_mixed");
+                // In the recovery case, the local instructions cannot be recovered
+                // because the path does not exist anymore.
+                object_store::Dictionary dict{local_realm, obj, col};
+                REQUIRE(dict.size() == 1);
+                REQUIRE(dict.get_any("key1").get_string() == "value");
+            })
+            ->run();
+    }
+    SECTION("Accessing ambiguous index triggers list copy") {
+        ObjectId pk_val = ObjectId::gen();
+        SyncTestFile config2(oas.app()->current_user(), "default");
+        config2.schema = config.schema;
+        auto test_reset = reset_utils::make_fake_local_client_reset(config, config2);
+        test_reset
+            ->setup([&](SharedRealm realm) {
+                // Baseline: {"_id": <id>, "any_mixed": {{"key1": [1, [2]]}, {"key2": 42}}}
+                auto table = get_table(*realm, "TopLevel");
+                auto obj = table->create_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("any_mixed");
+                obj.set_collection(col, CollectionType::Dictionary);
+                object_store::Dictionary dictionary{realm, obj, col};
+                dictionary.insert_collection("key1", CollectionType::List);
+                dictionary.insert("key2", Mixed{42});
+                auto nlist = dictionary.get_list("key1");
+                nlist.add(Mixed{1});
+                nlist.insert_collection(1, CollectionType::List);
+                nlist = nlist.get_list(1);
+                nlist.add(Mixed{2});
+            })
+            ->make_local_changes([&](SharedRealm local_realm) {
+                // Local client: {"_id": <id>, "any_mixed": {{"key1": [1, [2, 3]]}, {"key2": 42}}}
+                advance_and_notify(*local_realm);
+                TableRef table = get_table(*local_realm, "TopLevel");
+                REQUIRE(table->size() == 1);
+                auto obj = table->get_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("any_mixed");
+                // this insert operation triggers the list copy because the index becomes ambiguous
+                auto nlist = obj.get_list_ptr<Mixed>({col, "key1", 1});
+                nlist->add(Mixed{3});
+            })
+            ->make_remote_changes([&](SharedRealm remote_realm) {
+                // Remote client: {"_id": <id>, "any_mixed": {{"key1": [1, [2]]}, {"key2": 43}}}
+                advance_and_notify(*remote_realm);
+                TableRef table = get_table(*remote_realm, "TopLevel");
+                REQUIRE(table->size() == 1);
+                auto obj = table->get_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("any_mixed");
+                auto dict = obj.get_dictionary(col);
+                dict.insert("key2", Mixed{43});
+            })
+            ->on_post_reset([&](SharedRealm local_realm) {
+                advance_and_notify(*local_realm);
+                TableRef table = get_table(*local_realm, "TopLevel");
+                REQUIRE(table->size() == 1);
+                auto obj = table->get_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("any_mixed");
+                object_store::Dictionary dict{local_realm, obj, col};
+                REQUIRE(dict.size() == 2);
+                REQUIRE(dict.get_any("key2").get_int() == 43);
+                auto nlist = dict.get_list("key1");
+
+                if (test_mode == ClientResyncMode::DiscardLocal) {
+                    // Result: {"_id": <id>, "any_mixed": {{"key1": [1, [2]]}, {"key2": 43}}}
+                    REQUIRE(nlist.size() == 2);
+                    REQUIRE(nlist.get_any(0).get_int() == 1);
+                    nlist = nlist.get_list(1);
+                    REQUIRE(nlist.size() == 1);
+                    REQUIRE(nlist.get_any(0).get_int() == 2);
+                }
+                else {
+                    // Result: {"_id": <id>, "any_mixed": {{"key1": [1, [2, 3]]}, {"key2": 43}}}
+                    REQUIRE(nlist.size() == 2);
+                    REQUIRE(nlist.get_any(0).get_int() == 1);
+                    nlist = nlist.get_list(1);
+                    REQUIRE(nlist.size() == 2);
+                    REQUIRE(nlist.get_any(0).get_int() == 2);
+                    REQUIRE(nlist.get_any(1).get_int() == 3);
+                }
+            })
+            ->run();
+    }
+    SECTION("List marked to be copied but path to it does not exist anymore") {
+        ObjectId pk_val = ObjectId::gen();
+        SyncTestFile config2(oas.app()->current_user(), "default");
+        config2.schema = config.schema;
+        auto test_reset = reset_utils::make_fake_local_client_reset(config, config2);
+        test_reset
+            ->setup([&](SharedRealm realm) {
+                // Baseline: {"_id": <id>, "any_mixed": {{"key1": [1, [2]]}}}
+                auto table = get_table(*realm, "TopLevel");
+                auto obj = table->create_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("any_mixed");
+                obj.set_collection(col, CollectionType::Dictionary);
+                object_store::Dictionary dictionary{realm, obj, col};
+                dictionary.insert_collection("key1", CollectionType::List);
+                auto nlist = dictionary.get_list("key1");
+                nlist.add(Mixed{1});
+                nlist.insert_collection(1, CollectionType::List);
+                nlist = nlist.get_list(1);
+                nlist.add(Mixed{2});
+            })
+            ->make_local_changes([&](SharedRealm local_realm) {
+                // Local client: {"_id": <id>, "any_mixed": {}}
+                advance_and_notify(*local_realm);
+                TableRef table = get_table(*local_realm, "TopLevel");
+                REQUIRE(table->size() == 1);
+                auto obj = table->get_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("any_mixed");
+                // this insert operation triggers the list copy because the index becomes ambiguous
+                auto nlist = obj.get_list_ptr<Mixed>({col, "key1", 1});
+                nlist->add(Mixed{3});
+                // Remove list at 'key1' so path above becomes invalid.
+                auto ndict = obj.get_dictionary(col);
+                ndict.erase("key1");
+            })
+            ->make_remote_changes([&](SharedRealm remote_realm) {
+                // Remote client: {"_id": <id>, "any_mixed": {{"key1": [[2]]}}}
+                advance_and_notify(*remote_realm);
+                TableRef table = get_table(*remote_realm, "TopLevel");
+                REQUIRE(table->size() == 1);
+                auto obj = table->get_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("any_mixed");
+                auto nlist = obj.get_list_ptr<Mixed>({col, "key1"});
+                // Remove first element in list at 'key1'
+                nlist->remove(0);
+            })
+            ->on_post_reset([&](SharedRealm local_realm) {
+                advance_and_notify(*local_realm);
+                TableRef table = get_table(*local_realm, "TopLevel");
+                REQUIRE(table->size() == 1);
+                auto obj = table->get_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("any_mixed");
+
+                if (test_mode == ClientResyncMode::DiscardLocal) {
+                    // list must be equal to remote
+                    // Result: {"_id": <id>, "any_mixed": {{"key1": [[2]]}}}
+                    auto nlist = obj.get_list_ptr<Mixed>({col, "key1"});
+                    REQUIRE(nlist->size() == 1);
+                    nlist = nlist->get_list(0);
+                    REQUIRE(nlist->size() == 1);
+                    REQUIRE(nlist->get_any(0).get_int() == 2);
+                }
+                else {
+                    // list must be equal to local
+                    // Result: {"_id": <id>, "any_mixed": {}}
+                    auto ndict = obj.get_dictionary(col);
+                    REQUIRE(ndict.size() == 0);
+                }
+            })
+            ->run();
+    }
+
+    // Test clearing nested collections and collections in mixed.
+
+    SECTION("Clear dictionary changed into primitive remotely") {
+        ObjectId pk_val = ObjectId::gen();
+        SyncTestFile config2(oas.app()->current_user(), "default");
+        config2.schema = config.schema;
+        auto test_reset = reset_utils::make_fake_local_client_reset(config, config2);
+        test_reset
+            ->setup([&](SharedRealm realm) {
+                // Baseline: {"_id": <id>, "any_mixed": {{"key": 42}}}
+                auto table = get_table(*realm, "TopLevel");
+                auto obj = table->create_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("any_mixed");
+                obj.set_collection(col, CollectionType::Dictionary);
+                object_store::Dictionary dict{realm, obj, col};
+                dict.insert("key", 42);
+            })
+            ->make_local_changes([&](SharedRealm local_realm) {
+                // Local client: {"_id": <id>, "any_mixed": {{"key": "some value"}}}
+                advance_and_notify(*local_realm);
+                TableRef table = get_table(*local_realm, "TopLevel");
+                REQUIRE(table->size() == 1);
+                auto obj = table->get_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("any_mixed");
+                object_store::Dictionary dict{local_realm, obj, col};
+                REQUIRE(dict.size() == 1);
+                dict.remove_all();
+                dict.insert("key", "some value");
+            })
+            ->make_remote_changes([&](SharedRealm remote_realm) {
+                // Remote client: {"_id": <id>, "any_mixed": "value"}
+                advance_and_notify(*remote_realm);
+                TableRef table = get_table(*remote_realm, "TopLevel");
+                REQUIRE(table->size() == 1);
+                auto obj = table->get_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("any_mixed");
+                // Change type from dictionary to string
+                obj.set_any(col, "value");
+            })
+            ->on_post_reset([&](SharedRealm local_realm) {
+                advance_and_notify(*local_realm);
+                TableRef table = get_table(*local_realm, "TopLevel");
+                REQUIRE(table->size() == 1);
+                auto obj = table->get_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("any_mixed");
+
+                if (test_mode == ClientResyncMode::DiscardLocal) {
+                    // Result: {"_id": <id>, "any_mixed": "value"}
+                    REQUIRE(obj.get_any(col).get_string() == "value");
+                }
+                else {
+                    // Clear changes the type back into dictionary.
+                    // Result: {"_id": <id>, "any_mixed": {{"key": "some value"}}}
+                    object_store::Dictionary dict{local_realm, obj, col};
+                    REQUIRE(dict.size() == 1);
+                    REQUIRE(dict.get_any("key").get_string() == "some value");
+                }
+            })
+            ->run();
+    }
+    SECTION("Clear list changed into primitive remotely") {
+        ObjectId pk_val = ObjectId::gen();
+        SyncTestFile config2(oas.app()->current_user(), "default");
+        config2.schema = config.schema;
+        auto test_reset = reset_utils::make_fake_local_client_reset(config, config2);
+        test_reset
+            ->setup([&](SharedRealm realm) {
+                // Baseline: {"_id": <id>, "any_mixed": [1]}
+                auto table = get_table(*realm, "TopLevel");
+                auto obj = table->create_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("any_mixed");
+                obj.set_collection(col, CollectionType::List);
+                List list{realm, obj, col};
+                list.add(Mixed{1});
+            })
+            ->make_local_changes([&](SharedRealm local_realm) {
+                // Local client: {"_id": <id>, "any_mixed": [2]}
+                advance_and_notify(*local_realm);
+                TableRef table = get_table(*local_realm, "TopLevel");
+                REQUIRE(table->size() == 1);
+                auto obj = table->get_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("any_mixed");
+                List list{local_realm, obj, col};
+                REQUIRE(list.size() == 1);
+                list.delete_all();
+                list.add(Mixed{2});
+            })
+            ->make_remote_changes([&](SharedRealm remote_realm) {
+                // Remote client: {"_id": <id>, "any_mixed": "value"}
+                advance_and_notify(*remote_realm);
+                TableRef table = get_table(*remote_realm, "TopLevel");
+                REQUIRE(table->size() == 1);
+                auto obj = table->get_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("any_mixed");
+                // Change type from list to string
+                obj.set_any(col, "value");
+            })
+            ->on_post_reset([&](SharedRealm local_realm) {
+                advance_and_notify(*local_realm);
+                TableRef table = get_table(*local_realm, "TopLevel");
+                REQUIRE(table->size() == 1);
+                auto obj = table->get_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("any_mixed");
+
+                if (test_mode == ClientResyncMode::DiscardLocal) {
+                    // Result: {"_id": <id>, "any_mixed": "value"}
+                    REQUIRE(obj.get_any(col).get_string() == "value");
+                }
+                else {
+                    // Clear changes the type back into list.
+                    // Result: {"_id": <id>, "any_mixed": [2]}
+                    List list{local_realm, obj, col};
+                    REQUIRE(list.size() == 1);
+                    REQUIRE(list.get_any(0).get_int() == 2);
+                }
+            })
+            ->run();
+    }
+    SECTION("Clear list within dictionary: list removed remotely") {
+        ObjectId pk_val = ObjectId::gen();
+        SyncTestFile config2(oas.app()->current_user(), "default");
+        config2.schema = config.schema;
+        auto test_reset = reset_utils::make_fake_local_client_reset(config, config2);
+        test_reset
+            ->setup([&](SharedRealm realm) {
+                // Baseline: {"_id": <id>, "any_mixed": {{"key": [42]}}}
+                auto table = get_table(*realm, "TopLevel");
+                auto obj = table->create_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("any_mixed");
+                obj.set_collection(col, CollectionType::Dictionary);
+                object_store::Dictionary dict{realm, obj, col};
+                dict.insert_collection("key", CollectionType::List);
+                auto nlist = dict.get_list("key");
+                nlist.add(Mixed{42});
+            })
+            ->make_local_changes([&](SharedRealm local_realm) {
+                // Local client: {"_id": <id>, "any_mixed": {{"key": [1]}}}
+                advance_and_notify(*local_realm);
+                TableRef table = get_table(*local_realm, "TopLevel");
+                REQUIRE(table->size() == 1);
+                auto obj = table->get_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("any_mixed");
+                auto nlist = obj.get_list_ptr<Mixed>({col, "key"});
+                REQUIRE(nlist->size() == 1);
+                nlist->clear();
+                nlist->add(Mixed{1});
+            })
+            ->make_remote_changes([&](SharedRealm remote_realm) {
+                // Remote client: {"_id": <id>, "any_mixed": {}}
+                advance_and_notify(*remote_realm);
+                TableRef table = get_table(*remote_realm, "TopLevel");
+                REQUIRE(table->size() == 1);
+                auto obj = table->get_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("any_mixed");
+                object_store::Dictionary dict{remote_realm, obj, col};
+                REQUIRE(dict.size() == 1);
+                // Remove list at 'key'
+                dict.erase("key");
+            })
+            ->on_post_reset([&](SharedRealm local_realm) {
+                advance_and_notify(*local_realm);
+                TableRef table = get_table(*local_realm, "TopLevel");
+                REQUIRE(table->size() == 1);
+                auto obj = table->get_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("any_mixed");
+                object_store::Dictionary dict{local_realm, obj, col};
+
+                if (test_mode == ClientResyncMode::DiscardLocal) {
+                    // Result: {"_id": <id>, "any_mixed": {}}
+                    REQUIRE(dict.size() == 0);
+                }
+                else {
+                    // List is added back into dictionary.
+                    // Result: {"_id": <id>, "any_mixed": {{"key": [1]}}}
+                    REQUIRE(dict.size() == 1);
+                    auto nlist = dict.get_list("key");
+                    REQUIRE(nlist.size() == 1);
+                    REQUIRE(nlist.get_any(0).get_int() == 1);
+                }
+            })
+            ->run();
+    }
+    SECTION("Clear list within list triggers list copy") {
+        ObjectId pk_val = ObjectId::gen();
+        SyncTestFile config2(oas.app()->current_user(), "default");
+        config2.schema = config.schema;
+        auto test_reset = reset_utils::make_fake_local_client_reset(config, config2);
+        test_reset
+            ->setup([&](SharedRealm realm) {
+                // Baseline: {"_id": <id>, "any_mixed": [1, [2]]}
+                auto table = get_table(*realm, "TopLevel");
+                auto obj = table->create_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("any_mixed");
+                obj.set_collection(col, CollectionType::List);
+                List list{realm, obj, col};
+                list.add(Mixed{1});
+                list.insert_collection(1, CollectionType::List);
+                auto nlist = list.get_list(1);
+                nlist.add(Mixed{2});
+            })
+            ->make_local_changes([&](SharedRealm local_realm) {
+                // Local client: {"_id": <id>, "any_mixed": [1, [3]]}
+                advance_and_notify(*local_realm);
+                TableRef table = get_table(*local_realm, "TopLevel");
+                REQUIRE(table->size() == 1);
+                auto obj = table->get_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("any_mixed");
+                List list{local_realm, obj, col};
+                REQUIRE(list.size() == 2);
+                // this clear operation triggers the list copy because the index becomes ambiguous
+                auto nlist = list.get_list(1);
+                nlist.delete_all();
+                nlist.add(Mixed{3});
+            })
+            ->make_remote_changes([&](SharedRealm remote_realm) {
+                // Remote client: {"_id": <id>, "any_mixed": [42, [2]]}
+                advance_and_notify(*remote_realm);
+                TableRef table = get_table(*remote_realm, "TopLevel");
+                REQUIRE(table->size() == 1);
+                auto obj = table->get_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("any_mixed");
+                List list{remote_realm, obj, col};
+                REQUIRE(list.size() == 2);
+                list.set_any(0, Mixed{42});
+            })
+            ->on_post_reset([&](SharedRealm local_realm) {
+                advance_and_notify(*local_realm);
+                TableRef table = get_table(*local_realm, "TopLevel");
+                REQUIRE(table->size() == 1);
+                auto obj = table->get_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("any_mixed");
+                List list{local_realm, obj, col};
+                REQUIRE(list.size() == 2);
+
+                if (test_mode == ClientResyncMode::DiscardLocal) {
+                    // Result: {"_id": <id>, "any_mixed": [42, [2]]}
+                    REQUIRE(list.get_any(0).get_int() == 42);
+                    auto nlist = list.get_list(1);
+                    REQUIRE(nlist.size() == 1);
+                    REQUIRE(nlist.get_any(0).get_int() == 2);
+                }
+                else {
+                    // Result: {"_id": <id>, "any_mixed": [1, [3]]}
+                    REQUIRE(list.get_any(0).get_int() == 1);
+                    auto nlist = list.get_list(1);
+                    REQUIRE(nlist.size() == 1);
+                    REQUIRE(nlist.get_any(0).get_int() == 3);
+                }
+            })
+            ->run();
+    }
+    SECTION("Clear nested list added locally") {
+        ObjectId pk_val = ObjectId::gen();
+        SyncTestFile config2(oas.app()->current_user(), "default");
+        config2.schema = config.schema;
+        auto test_reset = reset_utils::make_fake_local_client_reset(config, config2);
+        test_reset
+            ->setup([&](SharedRealm realm) {
+                // Baseline: {"_id": <id>, "any_mixed": {}}
+                auto table = get_table(*realm, "TopLevel");
+                auto obj = table->create_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("any_mixed");
+                obj.set_collection(col, CollectionType::Dictionary);
+            })
+            ->make_local_changes([&](SharedRealm local_realm) {
+                // Local client: {"_id": <id>, "any_mixed": {{"key": [42, [2]]}}}
+                advance_and_notify(*local_realm);
+                TableRef table = get_table(*local_realm, "TopLevel");
+                REQUIRE(table->size() == 1);
+                auto obj = table->get_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("any_mixed");
+                object_store::Dictionary dict{local_realm, obj, col};
+                dict.insert_collection("key", CollectionType::List);
+                auto nlist = dict.get_list("key");
+                nlist.add(Mixed{42});
+                nlist.insert_collection(1, CollectionType::List);
+                nlist = nlist.get_list(1);
+                nlist.add(Mixed{1});
+                nlist.delete_all();
+                nlist.add(Mixed{2});
+            })
+            ->make_remote_changes([&](SharedRealm remote_realm) {
+                // Remote client: {"_id": <id>, "any_mixed": {{"key2": "value"}}}
+                advance_and_notify(*remote_realm);
+                TableRef table = get_table(*remote_realm, "TopLevel");
+                REQUIRE(table->size() == 1);
+                auto obj = table->get_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("any_mixed");
+                object_store::Dictionary dict{remote_realm, obj, col};
+                REQUIRE(dict.size() == 0);
+                dict.insert("key2", "value");
+            })
+            ->on_post_reset([&](SharedRealm local_realm) {
+                advance_and_notify(*local_realm);
+                TableRef table = get_table(*local_realm, "TopLevel");
+                REQUIRE(table->size() == 1);
+                auto obj = table->get_object_with_primary_key(pk_val);
+                auto col = table->get_column_key("any_mixed");
+                object_store::Dictionary dict{local_realm, obj, col};
+
+                if (test_mode == ClientResyncMode::DiscardLocal) {
+                    // Result: {"_id": <id>, "any_mixed": {{"key2": "value"}}}
+                    REQUIRE(dict.size() == 1);
+                    REQUIRE(dict.get_any("key2").get_string() == "value");
+                }
+                else {
+                    // Result: {"_id": <id>, "any_mixed": {{"key": [42, [2]]}, {"key2": "value"}}}
+                    REQUIRE(dict.size() == 2);
+                    auto nlist = dict.get_list("key");
+                    REQUIRE(nlist.size() == 2);
+                    REQUIRE(nlist.get_any(0).get_int() == 42);
+                    nlist = nlist.get_list(1);
+                    REQUIRE(nlist.size() == 1);
+                    REQUIRE(nlist.get_any(0).get_int() == 2);
+                    REQUIRE(dict.get_any("key2").get_string() == "value");
                 }
             })
             ->run();


### PR DESCRIPTION
## What, How & Why?
The recovery of local instructions operating on nested collections follows closely the recovery of operations on embedded objects (you can think of a nested dictionary or list as an embedded object). 

Notably:

- list operations (including accessing an element in an intermediate list) are only applied if they involve elements inserted during the recovery, otherwise the entire list is copied verbatim
- clearing a collection sets the collection type too (even if it was changed remotely), essentially allowing to recover subsequent operations on that collection

Additionally, I fixed a crash when recovering AddInteger instructions on a non-integer value (changed remotely).


Fixes #7490.

## ☑️ ToDos
* [X] 📝 Changelog update
* [X] 🚦 Tests (or not relevant)
* ~~[ ] C-API, if public C++ API changed~~
* ~~[ ] `bindgen/spec.yml`, if public C++ API changed~~
