### PR TITLE
RNET-1141 multiprocess encryption for writers with different page sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Accessing App::current_user() from within a notification produced by App:switch_user() (which includes notifications for a newly logged in user) would deadlock ([#7670](https://github.com/realm/realm-core/issues/7670), since v14.6.0).
 * Inserting the same typed link to the same key in a dictionary more than once would incorrectly create multiple backlinks to the object. This did not appear to cause any crashes later, but would have affecting explicit backlink count queries (eg: `...@links.@count`) and possibly notifications ([#7676](https://github.com/realm/realm-core/issues/7676) since v14.5.2).
 * Automatic client reset recovery would crash when recovering AddInteger instructions on a Mixed property if its type was changed to non-integer ([PR #7683](https://github.com/realm/realm-core/pull/7683), since v11.16.0).
+* Multiple processes from devices of a different page size operating on an encrypted Realm simultaneously may have created a file that produces a "Decryption failed" exception. (For example, an iOS simulator and Realm Studio) ([.NET-3592](https://github.com/realm/realm-dotnet/issues/3592) since the introduction of multiprocess encryption in v13.9.0)
 
 ### Breaking changes
 * None.

--- a/src/realm/util/file.cpp
+++ b/src/realm/util/file.cpp
@@ -418,12 +418,13 @@ size_t page_size()
 OnlyForTestingPageSizeChange::OnlyForTestingPageSizeChange(size_t new_page_size)
 {
     REALM_ASSERT(new_page_size % c_min_supported_page_size == 0);
+    m_previous_page_size = page_size();
     cached_page_size = new_page_size;
 }
 
 OnlyForTestingPageSizeChange::~OnlyForTestingPageSizeChange()
 {
-    cached_page_size = get_page_size();
+    cached_page_size = m_previous_page_size;
 }
 
 void File::open_internal(const std::string& path, AccessMode a, CreateMode c, int flags, bool* success)

--- a/src/realm/util/file.hpp
+++ b/src/realm/util/file.hpp
@@ -117,6 +117,7 @@ size_t page_size();
 struct OnlyForTestingPageSizeChange {
     OnlyForTestingPageSizeChange(size_t new_page_size);
     ~OnlyForTestingPageSizeChange();
+    size_t m_previous_page_size = 0;
 };
 
 /// This class provides a RAII abstraction over the concept of a file

--- a/test/test_encrypted_file_mapping.cpp
+++ b/test/test_encrypted_file_mapping.cpp
@@ -449,9 +449,9 @@ NONCONCURRENT_TEST(Encrypted_empty_blocks)
         wt.commit();
     }
 
-    // change back to 16k page size and advance the reader
+    // back to the db with 16k page size, advance the reader
     // this requires the new block to be decrypted
-    OnlyForTestingPageSizeChange change_third(16384);
+    REALM_ASSERT_3(page_size(), ==, 16384);
     pin.get_group().verify();
     // advance and make sure the new page is read correctly from disk
     pin = ReadTransaction(db_16);

--- a/test/test_encrypted_file_mapping.cpp
+++ b/test/test_encrypted_file_mapping.cpp
@@ -26,6 +26,7 @@
 #include <realm/util/file.hpp>
 
 #include "test.hpp"
+#include "util/spawned_process.hpp"
 
 // Test independence and thread-safety
 // -----------------------------------
@@ -396,6 +397,322 @@ NONCONCURRENT_TEST(EncryptedFile_Portablility)
         check_attach_and_read(key, path, num_entries);
     }
 }
+
+static void verify_data(const Group& g)
+{
+    g.verify();
+    // not all types have implemented verify() and our goal
+    // here is to access all data, so we use to_json() to make
+    // sure that all pages can be decrypted
+    std::stringstream ss;
+    g.to_json(ss);
+}
+
+NONCONCURRENT_TEST(Encrypted_empty_blocks)
+{
+    const char* key = test_util::crypt_key(true);
+
+    TEST_PATH(path);
+    DBOptions options(key);
+    std::string pk_longer_than_block_size = std::string(5, 'a');
+    std::string more_than_1_block = std::string(5000, 'b');
+
+    {
+        // create an initial state, 1 4096 block file
+        // (total file size is: 4096 metadata block + 4096 data block = 8192)
+        OnlyForTestingPageSizeChange change_page_size(4096);
+        auto db = DB::create(path, options);
+        WriteTransaction wt(db);
+        auto table = wt.get_group().add_table_with_primary_key("table_foo", type_String, "pk");
+        table->create_object_with_primary_key(Mixed{pk_longer_than_block_size});
+        wt.commit();
+    }
+    // Now extend the file, adding 3 empty blocks to a total of 16384
+    // This happens without a write transaction during DB::open
+    // during alloc.align_filesize_for_mmap()
+    OnlyForTestingPageSizeChange change_page_size(16384);
+    auto db_16 = DB::create(path, options);
+    ReadTransaction rt(db_16);
+    verify_data(rt.get_group());
+    ReadTransaction pin(db_16);
+
+    {
+        // open with 4k page size again, the file cannot be truncated, because
+        // the presence of the previous reader means we are not the session initiator
+        // write at least one extra block so we can verify it is read later on
+        OnlyForTestingPageSizeChange change_again_size(4096);
+        auto db_4k = DB::create(path, options);
+        WriteTransaction wt(db_4k);
+        auto table = wt.get_group().get_table("table_foo");
+        table->create_object_with_primary_key(Mixed{more_than_1_block});
+        verify_data(wt.get_group());
+        wt.commit();
+    }
+
+    // change back to 16k page size and advance the reader
+    // this requires the new block to be decrypted
+    OnlyForTestingPageSizeChange change_third(16384);
+    pin.get_group().verify();
+    // advance and make sure the new page is read correctly from disk
+    pin = ReadTransaction(db_16);
+    verify_data(pin.get_group());
+
+    // open a third instance with 16k page size
+    // to verify that an external reader can also see all the data
+    auto another_db = DB::create(path, options);
+    WriteTransaction wt16(another_db);
+    auto table = wt16.get_group().get_table("table_foo");
+    table->create_object_with_primary_key(Mixed{"baz"});
+    verify_data(wt16.get_group());
+    wt16.commit();
+}
+
+#if !REALM_ANDROID && !REALM_IOS
+// spawn process test is not supported on ios/android
+NONCONCURRENT_TEST_IF(Encrypted_multiprocess_different_page_sizes, testing_supports_spawn_process)
+{
+    const char* key = test_util::crypt_key(true);
+    DBOptions options(key);
+    SHARED_GROUP_TEST_PATH(path);
+    constexpr size_t num_transactions = 100;
+    constexpr size_t num_objs_per_transaction = 10;
+
+    if (test_util::SpawnedProcess::is_parent()) {
+        std::unique_ptr<Replication> hist = make_in_realm_history();
+        DBRef sg = DB::create(*hist, path, options);
+        if (test_util::SpawnedProcess::is_parent()) {
+            WriteTransaction wt(sg);
+            TableRef tr = wt.get_group().add_table_with_primary_key("Foo", type_String, "pk");
+            for (size_t j = 0; j < num_objs_per_transaction; j++) {
+                tr->create_object_with_primary_key(util::format("parent_init_%1", j));
+            }
+            wt.commit();
+        }
+        auto process = test_util::spawn_process(test_context.test_details.test_name, "external_writer");
+        for (size_t i = 0; i < num_transactions; ++i) {
+            WriteTransaction wt(sg);
+            TableRef tr = wt.get_table("Foo");
+            for (size_t j = 0; j < num_objs_per_transaction; j++) {
+                tr->create_object_with_primary_key(util::format("parent_%1_%2", i, j));
+            }
+            verify_data(wt.get_group());
+            wt.commit();
+        }
+        process->wait_for_child_to_finish();
+        ReadTransaction rt(sg);
+        verify_data(rt.get_group());
+    }
+    else {
+        OnlyForTestingPageSizeChange change_page(4096);
+
+        try {
+            std::unique_ptr<Replication> hist = make_in_realm_history();
+            DBRef sg = DB::create(*hist, path, options);
+            for (size_t i = 0; i < num_transactions; ++i) {
+                WriteTransaction wt(sg);
+                TableRef tr = wt.get_table("Foo");
+                for (size_t j = 0; j < num_objs_per_transaction; j++) {
+                    tr->create_object_with_primary_key(util::format("child_%1_%2", i, j));
+                }
+                verify_data(wt.get_group());
+                wt.commit();
+            }
+        }
+        catch (const std::exception& e) {
+            REALM_ASSERT_EX(false, e.what());
+            static_cast<void>(e); // e is unused without assertions on
+        }
+
+        exit(0);
+    }
+}
+
+#endif // !REALM_ANDROID && !REALM_IOS
+
+TEST_TYPES(Encrypted_truncation_is_not_an_error, std::true_type, std::false_type)
+{
+    class TestWriteObserver : public WriteObserver {
+    public:
+        bool no_concurrent_writer_seen() override
+        {
+            if (m_callback) {
+                m_callback();
+            }
+            // simulate that a concurrent writer is seen
+            // this forces the retry to wait for the max period
+            // before ultimately giving up
+            return false;
+        }
+        util::UniqueFunction<void()> m_callback;
+    };
+
+    std::unique_ptr<TestWriteObserver> observer;
+    if (TEST_TYPE::value) {
+        observer = std::make_unique<TestWriteObserver>();
+    }
+
+    TEST_PATH(path);
+    constexpr size_t block_size = 4096;
+
+    char data[block_size * 3];
+    for (size_t i = 0; i < sizeof(data); ++i)
+        data[i] = static_cast<char>(i);
+
+    AESCryptor cryptor(test_key);
+    cryptor.set_file_size(sizeof(data));
+    char buffer[sizeof(data)];
+    File file(path, realm::util::File::mode_Write);
+
+    auto verify_blocks_with_middle_zerod = [&]() {
+        for (size_t i = 0; i < 3 * block_size; ++i) {
+            // middle block is zero'd out
+            if (i >= block_size && i < 2 * block_size) {
+                CHECK_EQUAL(buffer[i], 0);
+                continue;
+            }
+            // but the blocks on either side are valid
+            CHECK_EQUAL(buffer[i], static_cast<char>(i));
+        }
+    };
+    auto read_to_buffer = [&]() -> size_t {
+        return cryptor.read(file.get_descriptor(), 0, buffer, sizeof(buffer), observer.get());
+    };
+
+    auto write_encrypted_data = [&]() {
+        cryptor.write(file.get_descriptor(), 0, data, sizeof(data));
+        size_t bytes_read = read_to_buffer();
+        CHECK_EQUAL(bytes_read, 3 * block_size);
+        CHECK(memcmp(buffer, data, sizeof(data)) == 0);
+    };
+
+    // first write: iv2 is still zero, only the first block can be read
+    write_encrypted_data();
+    // zero out the second block
+    file.seek(2 * block_size);
+    memset(buffer, '\0', block_size);
+    file.write(buffer, block_size);
+    // this hits the case of "the very first write was interrupted"
+    // we know this because iv2 is still 0
+    size_t bytes_read = read_to_buffer();
+    // reading the second block failed, but it was not a decryption error
+    // this treats the second block as uninitialized data
+    CHECK_EQUAL(bytes_read, block_size);
+
+    // second write: iv2 is set now, but still only the first block can be read
+    write_encrypted_data();
+    // zero out the second block
+    file.seek(2 * block_size);
+    memset(buffer, '\0', block_size);
+    file.write(buffer, block_size);
+    bytes_read = read_to_buffer();
+    // reading the second block failed, but it was not a decryption error
+    // this treats the second block as uninitialized data
+    CHECK_EQUAL(bytes_read, 3 * block_size);
+    verify_blocks_with_middle_zerod();
+
+    // third write: on a hmac check failure and no iv2 fallback, throw an exception
+    write_encrypted_data();
+    // zero out the second block, except for one byte
+    file.seek(2 * block_size);
+    memset(buffer, '\0', block_size);
+    buffer[block_size - 1] = '\1';
+    file.write(buffer, block_size);
+    // this is a decryption error because the hmac check fails and it is not an entirely zero'd block
+    // with an observer present, this takes an entire 5 seconds
+    CHECK_THROW(read_to_buffer(), DecryptionFailed);
+
+    // fourth write: if an uninitialized block is in the middle of
+    // two valid blocks but it also has an iv1=0 all 3 blocks can be read
+    write_encrypted_data();
+    // zero out the second block
+    file.seek(2 * block_size);
+    memset(buffer, '\0', block_size);
+    file.write(buffer, block_size);
+    // now set the ivs of block 2 to 0
+    constexpr size_t metadata_size = 64; // sizeof(iv_table)
+    file.seek(1 * metadata_size);
+    file.write(buffer, metadata_size);
+    // force refresh the iv cache
+    auto refresh_states = cryptor.refresh_ivs(file.get_descriptor(), 0, 0, 1);
+    CHECK_EQUAL(refresh_states.size(), 1);
+    CHECK_EQUAL(refresh_states.count(size_t(0)), 1);
+    CHECK(refresh_states[0] == IVRefreshState::RequiresRefresh);
+    bytes_read = read_to_buffer();
+    CHECK_EQUAL(bytes_read, 3 * block_size);
+    verify_blocks_with_middle_zerod();
+
+    if (observer) {
+        // simulate a second writer finally finishing the page write that matches the written iv
+        char encrypted_block_copy[block_size];
+        write_encrypted_data();
+        file.seek(2 * block_size);
+        file.read(encrypted_block_copy, block_size);
+        file.seek(2 * block_size);
+        file.write("data corruption!", 16);
+
+        size_t num_retries = 0;
+        bool did_write = false;
+        observer->m_callback = [&]() {
+            if (++num_retries >= 10 && !did_write) {
+                file.seek(2 * block_size);
+                file.write(encrypted_block_copy, block_size);
+                did_write = true;
+            }
+        };
+        // the retry logic does eventually succeed once the page data is restored
+        bytes_read = read_to_buffer();
+        CHECK_EQUAL(bytes_read, 3 * block_size);
+        CHECK(memcmp(buffer, data, sizeof(data)) == 0);
+    }
+}
+
+
+// The following can be used to debug encrypted customer Realm files
+/*
+static unsigned int hex_char_to_bin(char c)
+{
+    if (c >= '0' && c <= '9')
+        return c - '0';
+    if (c >= 'a' && c <= 'f')
+        return c - 'a' + 10;
+    if (c >= 'A' && c <= 'F')
+        return c - 'A' + 10;
+    throw std::invalid_argument("Illegal key (not a hex digit)");
+}
+
+static unsigned int hex_to_bin(char first, char second)
+{
+    return (hex_char_to_bin(first) << 4) | hex_char_to_bin(second);
+}
+
+ONLY(OpenEncrypted)
+{
+    std::string path = "my_path.realm";
+    const char* hex_key = "792cddc553a0452ee893e7583735d4e9f0942d6c8404398f612fd5e415e115e19443aa3be112e072f5fc22b7e2"
+                          "471a11ad2924c19413d84d19c32179c1063bd2";
+    char crypt_key[64];
+    for (int idx = 0; idx < 64; ++idx) {
+        crypt_key[idx] = hex_to_bin(hex_key[idx * 2], hex_key[idx * 2 + 1]);
+    }
+    std::unique_ptr<Replication> hist_w(make_in_realm_history());
+
+    CHECK_OR_RETURN(File::exists(path));
+    SHARED_GROUP_TEST_PATH(temp_copy);
+    File::copy(path, temp_copy);
+    DBOptions options(crypt_key);
+    DBRef db = DB::create(*hist_w, temp_copy, options);
+
+    TransactionRef rt = db->start_read();
+    TableKeys table_keys = rt->get_table_keys();
+    for (auto key : table_keys) {
+        TableRef table = rt->get_table(key);
+        util::format(std::cout, "table %1 has %2 rows\n", table->get_name(), table->size());
+        table->to_json(std::cout);
+        table->verify();
+        std::cout << std::endl;
+    }
+}
+*/
 
 #endif // REALM_ENABLE_ENCRYPTION
 #endif // TEST_ENCRYPTED_FILE_MAPPING

--- a/test/test_query2.cpp
+++ b/test/test_query2.cpp
@@ -5730,51 +5730,6 @@ TEST(Query_ListOfMixed)
     CHECK_EQUAL(tv.size(), 5);
 }
 
-
-static unsigned int hex_char_to_bin(char c)
-{
-    if (c >= '0' && c <= '9')
-        return c - '0';
-    if (c >= 'a' && c <= 'f')
-        return c - 'a' + 10;
-    if (c >= 'A' && c <= 'F')
-        return c - 'A' + 10;
-    throw std::invalid_argument("Illegal key (not a hex digit)");
-}
-
-static unsigned int hex_to_bin(char first, char second)
-{
-    return (hex_char_to_bin(first) << 4) | hex_char_to_bin(second);
-}
-
-
-ONLY(OpenEncrypted)
-{
-    std::string path = "/Users/james.stone/Downloads/sensor_events.realm";
-    const char* hex_key = "792cddc553a0452ee893e7583735d4e9f0942d6c8404398f612fd5e415e115e19443aa3be112e072f5fc22b7e2"
-                          "471a11ad2924c19413d84d19c32179c1063bd2";
-    char crypt_key[64];
-    for (int idx = 0; idx < 64; ++idx) {
-        crypt_key[idx] = hex_to_bin(hex_key[idx * 2], hex_key[idx * 2 + 1]);
-    }
-    std::unique_ptr<Replication> hist_w(make_in_realm_history());
-
-    CHECK_OR_RETURN(File::exists(path));
-    SHARED_GROUP_TEST_PATH(temp_copy);
-    File::copy(path, temp_copy);
-    DBOptions options(crypt_key);
-    DBRef db = DB::create(*hist_w, temp_copy, options);
-
-    TransactionRef rt = db->start_read();
-    TableKeys table_keys = rt->get_table_keys();
-    for (auto key : table_keys) {
-        TableRef table = rt->get_table(key);
-        util::format(std::cout, "table %1 has %2 rows\n", table->get_name(), table->size());
-        table->to_json(std::cout);
-        std::cout << std::endl;
-    }
-}
-
 TEST(Query_Dictionary)
 {
     Group g;

--- a/test/test_query2.cpp
+++ b/test/test_query2.cpp
@@ -5730,6 +5730,51 @@ TEST(Query_ListOfMixed)
     CHECK_EQUAL(tv.size(), 5);
 }
 
+
+static unsigned int hex_char_to_bin(char c)
+{
+    if (c >= '0' && c <= '9')
+        return c - '0';
+    if (c >= 'a' && c <= 'f')
+        return c - 'a' + 10;
+    if (c >= 'A' && c <= 'F')
+        return c - 'A' + 10;
+    throw std::invalid_argument("Illegal key (not a hex digit)");
+}
+
+static unsigned int hex_to_bin(char first, char second)
+{
+    return (hex_char_to_bin(first) << 4) | hex_char_to_bin(second);
+}
+
+
+ONLY(OpenEncrypted)
+{
+    std::string path = "/Users/james.stone/Downloads/sensor_events.realm";
+    const char* hex_key = "792cddc553a0452ee893e7583735d4e9f0942d6c8404398f612fd5e415e115e19443aa3be112e072f5fc22b7e2"
+                          "471a11ad2924c19413d84d19c32179c1063bd2";
+    char crypt_key[64];
+    for (int idx = 0; idx < 64; ++idx) {
+        crypt_key[idx] = hex_to_bin(hex_key[idx * 2], hex_key[idx * 2 + 1]);
+    }
+    std::unique_ptr<Replication> hist_w(make_in_realm_history());
+
+    CHECK_OR_RETURN(File::exists(path));
+    SHARED_GROUP_TEST_PATH(temp_copy);
+    File::copy(path, temp_copy);
+    DBOptions options(crypt_key);
+    DBRef db = DB::create(*hist_w, temp_copy, options);
+
+    TransactionRef rt = db->start_read();
+    TableKeys table_keys = rt->get_table_keys();
+    for (auto key : table_keys) {
+        TableRef table = rt->get_table(key);
+        util::format(std::cout, "table %1 has %2 rows\n", table->get_name(), table->size());
+        table->to_json(std::cout);
+        std::cout << std::endl;
+    }
+}
+
 TEST(Query_Dictionary)
 {
     Group g;


### PR DESCRIPTION
Fixes https://github.com/realm/realm-dotnet/issues/3592
A customer sent us an encrypted Realm that had an unusual data pattern in it:

```
IVs/metadata
blocks 1-5 [valid data]
block 6-8 [zeros] 
block 9-13 [valid data]
block 14-17 [zeros]
```

This caused a Decryption failed exception when trying to access ref 16384 (block 5),  because we could only read 4096 bytes, but 16k was requested. (The file can be read by faking a page size of 4k, but here I have a 16k page size).

I was not able to come up with a test case to create a hole in the data like our customer had, but I can create a close scenario with zeros at the end, by careful writes from a db with 16k page size and a db with 4k page size (see tests).

The fix is to change from returning early to allowing a block with all zeros as a valid read. The assumption still being that these blocks can only be created by fallocate extending the file.

I don't know how we could end up with zero'd blocks as holes in the middle of the file unless something wacky is going on with our allocator, but the changes here at least do allow us to read Realms with this kind of data pattern.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [x] C-API, if public C++ API changed
* [x] `bindgen/spec.yml`, if public C++ API changed