### PR TITLE
RCORE-2121 Fix audit test

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,5 +1,6 @@
 ---
-Language:        Cpp
+# Don't try to format any languages not described by this file
+DisableFormat: true
 AccessModifierOffset: -4
 AlignAfterOpenBracket: Align
 AlignArrayOfStructures: None
@@ -65,7 +66,6 @@ ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
 DeriveLineEnding: true
 DerivePointerAlignment: false
-DisableFormat:   false
 EmptyLineAfterAccessModifier: Never
 EmptyLineBeforeAccessModifier: LogicalBlock
 ExperimentalAutoDetectBinPacking: false
@@ -191,5 +191,11 @@ WhitespaceSensitiveMacros:
   - BOOST_PP_STRINGIZE
   - NS_SWIFT_NAME
   - CF_SWIFT_NAME
+---
+Language: Cpp
+DisableFormat:   false
+---
+Language: ObjC
+DisableFormat:   false
 ...
 

--- a/src/realm/object-store/audit.mm
+++ b/src/realm/object-store/audit.mm
@@ -1427,7 +1427,7 @@ std::shared_ptr<AuditInterface> make_audit_context(std::shared_ptr<DB> db, Realm
         throw LogicError(ErrorCodes::InvalidName, "Audit partition prefix must not be empty");
     if (audit_config.partition_value_prefix.find_first_of("\\/") != std::string::npos)
         throw LogicError(ErrorCodes::InvalidName,
-                         util::format("Invalid audit parition prefix '%1': prefix must not contain slashes",
+                         util::format("Invalid audit partition prefix '%1': prefix must not contain slashes",
                                       audit_config.partition_value_prefix));
     return std::make_shared<AuditContext>(db, config, audit_config);
 }

--- a/test/object-store/audit.cpp
+++ b/test/object-store/audit.cpp
@@ -1097,7 +1097,7 @@ TEST_CASE("audit management", "[sync][pbs][audit]") {
                               "Audit partition prefix must not be empty");
             config.audit_config->partition_value_prefix = "/audit";
             REQUIRE_EXCEPTION(Realm::get_shared_realm(config), InvalidName,
-                              "Invalid audit parition prefix '/audit': prefix must not contain slashes");
+                              "Invalid audit partition prefix '/audit': prefix must not contain slashes");
         }
         SECTION("invalid metadata") {
             config.audit_config->metadata = {{"", "a"}};
@@ -1881,11 +1881,11 @@ TEST_CASE("audit integration tests", "[sync][pbs][audit][baas]") {
     }
 
     SECTION("flexible sync") {
-        app::FLXSyncTestHarness harness("audit");
+        app::FLXSyncTestHarness harness("audit", {schema});
         create_user_and_log_in(harness.app());
 
         SECTION("auditing a flexible sync realm without specifying an audit user throws an exception") {
-            SyncTestFile config(harness.app()->current_user(), {}, SyncConfig::FLXSyncEnabled{});
+            SyncTestFile config(harness.app()->current_user(), schema, SyncConfig::FLXSyncEnabled{});
             config.audit_config = std::make_shared<AuditConfig>();
             REQUIRE_THROWS_CONTAINING(Realm::get_shared_realm(config), "partition-based sync");
         }
@@ -1904,6 +1904,7 @@ TEST_CASE("audit integration tests", "[sync][pbs][audit][baas]") {
             config.sync_config->user = harness.app()->current_user();
             config.sync_config->flx_sync_requested = true;
             config.sync_config->partition_value.clear();
+            config.schema_version = 0;
 
             auto realm = Realm::get_shared_realm(config);
             {


### PR DESCRIPTION
## What, How & Why?
Set the correct schema version in audit test using flx realm.

Fixes #7688.

## ☑️ ToDos
* ~~[ ] 📝 Changelog update~~
* [X] 🚦 Tests (or not relevant)
* ~~[ ] C-API, if public C++ API changed~~
* ~~[ ] `bindgen/spec.yml`, if public C++ API changed~~
