### PR TITLE
Delete the old pre-c++11 Thread implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 -----------
 
 ### Internals
-* None.
+* `util::Thread` no longer has any functionality other than `get_name()` and `set_name()`. Use `std::thread` instead ([PR #7696](https://github.com/realm/realm-core/pull/7696)).
 
 ----------------------------------------------
 

--- a/src/realm/util/thread.cpp
+++ b/src/realm/util/thread.cpp
@@ -16,12 +16,12 @@
  *
  **************************************************************************/
 
+#include <realm/util/thread.hpp>
+#include <realm/util/backtrace.hpp>
+
 #include <cstring>
 #include <stdexcept>
 #include <system_error>
-
-#include <realm/util/thread.hpp>
-#include <realm/util/backtrace.hpp>
 
 #if !defined _WIN32
 #include <unistd.h>
@@ -57,25 +57,6 @@
 
 using namespace realm;
 using namespace realm::util;
-
-void Thread::join()
-{
-    if (!m_joinable)
-        throw util::runtime_error("Thread is not joinable");
-
-#ifdef _WIN32
-    // Returns void; error handling not possible
-    m_std_thread.join();
-#else
-    void** value_ptr = nullptr; // Ignore return value
-    int r = pthread_join(m_id, value_ptr);
-    if (REALM_UNLIKELY(r != 0))
-        join_failed(r); // Throws
-#endif
-
-    m_joinable = false;
-}
-
 
 void Thread::set_name(const std::string& name)
 {
@@ -130,17 +111,6 @@ bool Thread::get_name(std::string& name) noexcept
 #endif
 }
 
-
-REALM_NORETURN void Thread::create_failed(int)
-{
-    throw std::runtime_error("pthread_create() failed");
-}
-
-REALM_NORETURN void Thread::join_failed(int)
-{
-    // It is intentional that the argument is ignored here.
-    throw std::runtime_error("pthread_join() failed.");
-}
 
 void Mutex::init_as_process_shared(bool robust_if_available)
 {

--- a/src/realm/util/thread.hpp
+++ b/src/realm/util/thread.hpp
@@ -19,68 +19,30 @@
 #ifndef REALM_UTIL_THREAD_HPP
 #define REALM_UTIL_THREAD_HPP
 
+#include <realm/util/assert.hpp>
+#include <realm/util/features.h>
+#include <realm/util/terminate.hpp>
+
+#include <atomic>
+#include <cerrno>
+#include <cstddef>
 #include <exception>
+#include <memory>
+#include <stdexcept>
+#include <string>
 
 #ifdef _WIN32
-#include <thread>
 #include <condition_variable> // for windows non-interprocess condvars we use std::condition_variable
+#include <thread>
 #include <Windows.h>
 #include <process.h> // _getpid()
 #else
 #include <pthread.h>
 #endif
 
-// Use below line to enable a thread bug detection tool. Note: Will make program execution slower.
-// #include <../test/pthread_test.hpp>
-
-#include <cerrno>
-#include <cstddef>
-#include <string>
-
-#include <realm/util/features.h>
-#include <realm/util/assert.hpp>
-#include <realm/util/terminate.hpp>
-#include <memory>
-#include <stdexcept>
-
-#include <atomic>
-
-namespace realm {
-namespace util {
-
-
-/// A separate thread of execution.
-///
-/// This class is a C++03 compatible reproduction of a subset of std::thread
-/// from C++11 (when discounting Thread::start(), Thread::set_name(), and
-/// Thread::get_name()).
+namespace realm::util {
 class Thread {
 public:
-    Thread();
-    ~Thread() noexcept;
-
-    template <class F>
-    explicit Thread(F func);
-
-    // Disable copying. It is an error to copy this Thread class.
-    Thread(const Thread&) = delete;
-    Thread& operator=(const Thread&) = delete;
-
-    Thread(Thread&&) noexcept;
-
-    /// This method is an extension of the API provided by
-    /// std::thread. This method exists because proper move semantics
-    /// is unavailable in C++03. If move semantics had been available,
-    /// calling `start(func)` would have been equivalent to `*this =
-    /// Thread(func)`. Please see std::thread::operator=() for
-    /// details.
-    template <class F>
-    void start(F func);
-
-    bool joinable() noexcept;
-
-    void join();
-
     // If supported by the platform, set the name of the calling thread (mainly
     // for debugging purposes). The name will be silently clamped to whatever
     // limit the platform places on these names. Linux places a limit of 15
@@ -91,23 +53,6 @@ public:
     // calling thread to \a name, and returns true, otherwise it does nothing
     // and returns false.
     static bool get_name(std::string& name) noexcept;
-
-private:
-#ifdef _WIN32
-    std::thread m_std_thread;
-#else
-    pthread_t m_id;
-#endif
-    bool m_joinable;
-    typedef void* (*entry_func_type)(void*);
-
-    void start(entry_func_type, void* arg);
-
-    template <class>
-    static void* entry_point(void*) noexcept;
-
-    REALM_NORETURN static void create_failed(int);
-    REALM_NORETURN static void join_failed(int);
 };
 
 
@@ -410,77 +355,6 @@ public:
 };
 
 // Implementation:
-
-inline Thread::Thread()
-    : m_joinable(false)
-{
-}
-
-template <class F>
-inline Thread::Thread(F func)
-    : m_joinable(true)
-{
-    std::unique_ptr<F> func2(new F(func));       // Throws
-    start(&Thread::entry_point<F>, func2.get()); // Throws
-    func2.release();
-}
-
-inline Thread::Thread(Thread&& thread) noexcept
-{
-#ifndef _WIN32
-    m_id = thread.m_id;
-    m_joinable = thread.m_joinable;
-    thread.m_joinable = false;
-#endif
-}
-
-template <class F>
-inline void Thread::start(F func)
-{
-    if (m_joinable)
-        std::terminate();
-    std::unique_ptr<F> func2(new F(func));       // Throws
-    start(&Thread::entry_point<F>, func2.get()); // Throws
-    func2.release();
-    m_joinable = true;
-}
-
-inline Thread::~Thread() noexcept
-{
-    if (m_joinable)
-        REALM_TERMINATE("Destruction of joinable thread");
-}
-
-inline bool Thread::joinable() noexcept
-{
-    return m_joinable;
-}
-
-inline void Thread::start(entry_func_type entry_func, void* arg)
-{
-#ifdef _WIN32
-    m_std_thread = std::thread(entry_func, arg);
-#else
-    const pthread_attr_t* attr = nullptr; // Use default thread attributes
-    int r = pthread_create(&m_id, attr, entry_func, arg);
-    if (REALM_UNLIKELY(r != 0))
-        create_failed(r); // Throws
-#endif
-}
-
-template <class F>
-inline void* Thread::entry_point(void* cookie) noexcept
-{
-    std::unique_ptr<F> func(static_cast<F*>(cookie));
-    try {
-        (*func)();
-    }
-    catch (...) {
-        std::terminate();
-    }
-    return 0;
-}
-
 
 inline Mutex::Mutex()
 {
@@ -806,7 +680,6 @@ void store_atomic(T& t_ref, T value, std::memory_order order)
 }
 
 
-} // namespace util
-} // namespace realm
+} // namespace realm::util
 
 #endif // REALM_UTIL_THREAD_HPP

--- a/src/realm/util/thread_exec_guard.hpp
+++ b/src/realm/util/thread_exec_guard.hpp
@@ -1,13 +1,13 @@
 #ifndef REALM_UTIL_THREAD_EXEC_GUARD_HPP
 #define REALM_UTIL_THREAD_EXEC_GUARD_HPP
 
-#include <exception>
-#include <utility>
-#include <string>
-
-#include <realm/util/thread.hpp>
 #include <realm/util/signal_blocker.hpp>
+#include <realm/util/thread.hpp>
 
+#include <exception>
+#include <string>
+#include <thread>
+#include <utility>
 
 namespace realm {
 namespace util {
@@ -48,7 +48,7 @@ public:
 private:
     struct State {
         R& runnable;
-        util::Thread thread;
+        std::thread thread;
         std::exception_ptr exception;
         State(R&) noexcept;
         ~State() noexcept;
@@ -114,7 +114,7 @@ private:
     struct State {
         R& runnable;
         P& parent;
-        util::Thread thread;
+        std::thread thread;
         std::exception_ptr exception;
         State(R&, P&) noexcept;
         ~State() noexcept;
@@ -209,7 +209,7 @@ inline void ThreadExecGuard<R>::State::start(const std::string* thread_name)
             exception = std::current_exception();
         }
     };
-    thread.start(std::move(run)); // Throws
+    thread = std::thread(std::move(run)); // Throws
 }
 
 template <class R>
@@ -299,7 +299,7 @@ inline void ThreadExecGuardWithParent<R, P>::State::start(const std::string* thr
             parent.stop();
         }
     };
-    thread.start(std::move(run)); // Throws
+    thread = std::thread(std::move(run)); // Throws
 }
 
 template <class R, class P>

--- a/test/test_thread.cpp
+++ b/test/test_thread.cpp
@@ -80,11 +80,6 @@ using namespace realm::util;
 
 namespace {
 
-void increment(int* i)
-{
-    ++*i;
-}
-
 struct Shared {
     Mutex m_mutex;
     int m_value;
@@ -252,30 +247,6 @@ void consumer_thread(QueueMonitor* queue, int* consumed_counts)
 } // anonymous namespace
 
 
-TEST(Thread_Join)
-{
-    int i = 0;
-    Thread thread(std::bind(&increment, &i));
-    CHECK(thread.joinable());
-    thread.join();
-    CHECK(!thread.joinable());
-    CHECK_EQUAL(1, i);
-}
-
-
-TEST(Thread_Start)
-{
-    int i = 0;
-    Thread thread;
-    CHECK(!thread.joinable());
-    thread.start(std::bind(&increment, &i));
-    CHECK(thread.joinable());
-    thread.join();
-    CHECK(!thread.joinable());
-    CHECK_EQUAL(1, i);
-}
-
-
 TEST(Thread_MutexLock)
 {
     Mutex mutex;
@@ -304,9 +275,9 @@ TEST(Thread_CriticalSection)
 {
     Shared shared;
     shared.m_value = 0;
-    Thread threads[10];
+    std::thread threads[10];
     for (int i = 0; i < 10; ++i)
-        threads[i].start(std::bind(&Shared::increment_10000_times, &shared));
+        threads[i] = std::thread(&Shared::increment_10000_times, &shared);
     for (int i = 0; i < 10; ++i)
         threads[i].join();
     CHECK_EQUAL(100000, shared.m_value);
@@ -318,9 +289,9 @@ TEST(Thread_EmulatedMutex_CriticalSection)
     TEST_PATH(path);
     SharedWithEmulated shared(path);
     shared.m_value = 0;
-    Thread threads[10];
+    std::thread threads[10];
     for (int i = 0; i < 10; ++i)
-        threads[i].start(std::bind(&SharedWithEmulated::increment_10000_times, &shared));
+        threads[i] = std::thread(&SharedWithEmulated::increment_10000_times, &shared);
     for (int i = 0; i < 10; ++i)
         threads[i].join();
     CHECK_EQUAL(100000, shared.m_value);
@@ -331,9 +302,9 @@ TEST(Thread_CriticalSection2)
 {
     Shared shared;
     shared.m_value = 0;
-    Thread threads[10];
+    std::thread threads[10];
     for (int i = 0; i < 10; ++i)
-        threads[i].start(std::bind(&Shared::increment_10000_times2, &shared));
+        threads[i] = std::thread(&Shared::increment_10000_times2, &shared);
     for (int i = 0; i < 10; ++i)
         threads[i].join();
     CHECK_EQUAL(100000, shared.m_value);
@@ -362,10 +333,7 @@ TEST_IF(Thread_RobustMutex, TEST_THREAD_ROBUSTNESS)
 
     // Check recovery by simulating a death
     robust.m_recover_called = false;
-    {
-        Thread thread(std::bind(&Robust::simulate_death, &robust));
-        thread.join();
-    }
+    std::thread(&Robust::simulate_death, &robust).join();
     CHECK(!robust.m_recover_called);
     robust.m_recover_called = false;
     robust.m_mutex.lock(std::bind(&Robust::recover, &robust));
@@ -374,10 +342,7 @@ TEST_IF(Thread_RobustMutex, TEST_THREAD_ROBUSTNESS)
 
     // One more round of recovery
     robust.m_recover_called = false;
-    {
-        Thread thread(std::bind(&Robust::simulate_death, &robust));
-        thread.join();
-    }
+    std::thread(&Robust::simulate_death, &robust).join();
     CHECK(!robust.m_recover_called);
     robust.m_recover_called = false;
     robust.m_mutex.lock(std::bind(&Robust::recover, &robust));
@@ -386,10 +351,7 @@ TEST_IF(Thread_RobustMutex, TEST_THREAD_ROBUSTNESS)
 
     // Simulate a case where recovery fails or is impossible
     robust.m_recover_called = false;
-    {
-        Thread thread(std::bind(&Robust::simulate_death, &robust));
-        thread.join();
-    }
+    std::thread(&Robust::simulate_death, &robust).join();
     CHECK(!robust.m_recover_called);
     robust.m_recover_called = false;
     CHECK_THROW(robust.m_mutex.lock(std::bind(&Robust::recover_throw, &robust)), RobustMutex::NotRecoverable);
@@ -419,18 +381,12 @@ TEST_IF(Thread_DeathDuringRecovery, TEST_THREAD_ROBUSTNESS)
 
     // Bring the mutex into the 'inconsistent' state
     robust.m_recover_called = false;
-    {
-        Thread thread(std::bind(&Robust::simulate_death, &robust));
-        thread.join();
-    }
+    std::thread(&Robust::simulate_death, &robust).join();
     CHECK(!robust.m_recover_called);
 
     // Die while recovering
     robust.m_recover_called = false;
-    {
-        Thread thread(std::bind(&Robust::simulate_death_during_recovery, &robust));
-        thread.join();
-    }
+    std::thread(&Robust::simulate_death_during_recovery, &robust).join();
     CHECK(robust.m_recover_called);
 
     // The mutex is still in the 'inconsistent' state if another
@@ -449,22 +405,13 @@ TEST_IF(Thread_DeathDuringRecovery, TEST_THREAD_ROBUSTNESS)
 
     // Try a double death during recovery
     robust.m_recover_called = false;
-    {
-        Thread thread(std::bind(&Robust::simulate_death, &robust));
-        thread.join();
-    }
+    std::thread(&Robust::simulate_death, &robust).join();
     CHECK(!robust.m_recover_called);
     robust.m_recover_called = false;
-    {
-        Thread thread(std::bind(&Robust::simulate_death_during_recovery, &robust));
-        thread.join();
-    }
+    std::thread(&Robust::simulate_death_during_recovery, &robust).join();
     CHECK(robust.m_recover_called);
     robust.m_recover_called = false;
-    {
-        Thread thread(std::bind(&Robust::simulate_death_during_recovery, &robust));
-        thread.join();
-    }
+    std::thread(&Robust::simulate_death_during_recovery, &robust).join();
     CHECK(robust.m_recover_called);
     robust.m_recover_called = false;
     robust.m_mutex.lock(std::bind(&Robust::recover, &robust));
@@ -482,14 +429,14 @@ TEST(Thread_CondVar)
     QueueMonitor queue;
     const int num_producers = 32;
     const int num_consumers = 32;
-    Thread producers[num_producers], consumers[num_consumers];
+    std::thread producers[num_producers], consumers[num_consumers];
     int consumed_counts[num_consumers][num_producers];
     memset(consumed_counts, 0, sizeof consumed_counts);
 
     for (int i = 0; i < num_producers; ++i)
-        producers[i].start(std::bind(&producer_thread, &queue, i));
+        producers[i] = std::thread(&producer_thread, &queue, i);
     for (int i = 0; i < num_consumers; ++i)
-        consumers[i].start(std::bind(&consumer_thread, &queue, &consumed_counts[i][0]));
+        consumers[i] = std::thread(&consumer_thread, &queue, &consumed_counts[i][0]);
     for (int i = 0; i < num_producers; ++i)
         producers[i].join();
     queue.close(); // Stop consumers when queue is empty
@@ -506,7 +453,6 @@ TEST(Thread_CondVar)
 
 TEST(Thread_MutexTryLock)
 {
-    Thread thread;
     Mutex base_mutex;
     std::unique_lock<Mutex> m(base_mutex, std::defer_lock);
 
@@ -540,7 +486,7 @@ TEST(Thread_MutexTryLock)
     CHECK(!m.owns_lock());
     CHECK(m.try_lock());
     CHECK(m.owns_lock());
-    thread.start(do_async);
+    std::thread thread(do_async);
     {
         std::unique_lock<std::mutex> guard(cv_lock);
         cv.wait(guard, [&] {
@@ -558,7 +504,6 @@ TEST(Thread_RobustMutexTryLock)
     if (!RobustMutex::is_robust_on_this_platform)
         return;
 
-    Thread thread;
     RobustMutex m;
     int times_recover_function_was_called = 0;
 
@@ -590,7 +535,7 @@ TEST(Thread_RobustMutexTryLock)
 
     // Check basic locking across threads.
     CHECK(m.try_lock(recover_function));
-    thread.start(do_async);
+    std::thread thread(do_async);
     {
         std::unique_lock<std::mutex> lock(control_mutex);
         control_cv.wait(lock, [&] {
@@ -610,7 +555,6 @@ TEST(Thread_RobustMutexTryLock)
                // because we are going to switch to native API soon and discard win32-pthread entirely
 NONCONCURRENT_TEST(Thread_InterprocessMutexTryLock)
 {
-    Thread thread;
     InterprocessMutex::SharedPart mutex_part;
 
     InterprocessMutex m;
@@ -644,7 +588,7 @@ NONCONCURRENT_TEST(Thread_InterprocessMutexTryLock)
 
     // Check basic locking across threads.
     CHECK(m.try_lock());
-    thread.start(do_async);
+    std::thread thread(do_async);
     {
         std::unique_lock<std::mutex> ul(cv_mutex);
         cv.wait(ul, [&] {
@@ -731,9 +675,8 @@ NONCONCURRENT_TEST(Thread_CondvarWaits)
     mutex.set_shared_part(mutex_part, path, "Thread_CondvarWaits_Mutex");
     changed.set_shared_part(condvar_part, path, "Thread_CondvarWaits_CondVar", default_options.temp_dir);
     changed.init_shared_part(condvar_part);
-    Thread signal_thread;
     signals = 0;
-    signal_thread.start(std::bind(signaller, &signals, &mutex, &changed));
+    std::thread signal_thread(signaller, &signals, &mutex, &changed);
     {
         std::lock_guard<InterprocessMutex> l(mutex);
         changed.wait(mutex, nullptr);
@@ -764,7 +707,6 @@ NONCONCURRENT_TEST(Thread_CondvarIsStateless)
     // Must have names because default_options.temp_dir is empty string on Windows
     mutex.set_shared_part(mutex_part, path, "Thread_CondvarIsStateless_Mutex");
     changed.set_shared_part(condvar_part, path, "Thread_CondvarIsStateless_CondVar", default_options.temp_dir);
-    Thread signal_thread;
     signal_state = 1;
     // send some signals:
     {
@@ -774,7 +716,7 @@ NONCONCURRENT_TEST(Thread_CondvarIsStateless)
     }
     // spawn a thread which will later do one more signal in order
     // to wake us up.
-    signal_thread.start(std::bind(wakeup_signaller, &signal_state, &mutex, &changed));
+    std::thread signal_thread(wakeup_signaller, &signal_state, &mutex, &changed);
     // Wait for a signal - the signals sent above should be lost, so
     // that this wait will actually wait for the thread to signal.
     {
@@ -839,9 +781,9 @@ NONCONCURRENT_TEST(Thread_CondvarNotifyAllWakeup)
     std::condition_variable control_cv;
 
     const size_t num_waiters = 10;
-    Thread waiters[num_waiters];
+    std::thread waiters[num_waiters];
     for (size_t i = 0; i < num_waiters; ++i) {
-        waiters[i].start(std::bind(waiter, &mutex, &changed, &control_mutex, &control_cv, &num_threads_holding_lock));
+        waiters[i] = std::thread(waiter, &mutex, &changed, &control_mutex, &control_cv, &num_threads_holding_lock);
     }
     {
         // allow all waiters to start and obtain the InterprocessCondVar

--- a/test/util/thread_wrapper.hpp
+++ b/test/util/thread_wrapper.hpp
@@ -22,8 +22,7 @@
 #include <exception>
 #include <string>
 #include <iostream>
-
-#include <realm/util/thread.hpp>
+#include <thread>
 
 namespace realm {
 namespace test_util {
@@ -37,9 +36,7 @@ public:
     void start(const F& func)
     {
         m_except = false;
-        m_thread.start([func, this] {
-            Runner<F>::run(func, this);
-        });
+        m_thread = std::thread(Runner<F>::run, func, this);
     }
 
     /// Returns 'true' if thread has thrown an exception. In that case
@@ -73,7 +70,7 @@ public:
     }
 
 private:
-    util::Thread m_thread;
+    std::thread m_thread;
     bool m_except;
     std::string m_except_msg;
 


### PR DESCRIPTION
This was a backport of std::thread to C++03 and we haven't needed it for a long time. std::thread doesn't expose set_name(), so that remains.

The other things in thread.hpp are still relevant for robust and process shared mutexes.