### PR TITLE
Upload also the realm file when the fuzzer fails

### DIFF
--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -431,6 +431,7 @@ functions:
         if ls crash-*> /dev/null 2>&1; then
           echo "Found crash file"
           mv crash-* realm-fuzzer-crash.txt
+          mv fuzz-test.realm fuzzer_realm.realm
         fi
 
   - command: s3.put
@@ -443,7 +444,20 @@ functions:
       bucket: mciuploads
       permissions: public-read
       content_type: text/plain
-      display_name: Fuzzer crash report
+      display_name: Crash input file
+      optional: true
+
+  - command: s3.put
+    params:
+      working_dir: realm-core/build/test/realm-fuzzer
+      aws_key: '${artifacts_aws_access_key}'
+      aws_secret: '${artifacts_aws_secret_key}'
+      local_file: 'realm-core/build/test/realm-fuzzer/fuzzer_realm.realm'
+      remote_file: '${project}/${branch_name}/${task_id}/${execution}/fuzzer_realm.realm'
+      bucket: mciuploads
+      permissions: public-read
+      content_type: application/x-binary
+      display_name: Realm File 
       optional: true
 
   - command: shell.exec
@@ -451,6 +465,7 @@ functions:
       working_dir: realm-core/build/test/realm-fuzzer
       script: |-
         rm realm-fuzzer-crash.txt
+        mv fuzzer_realm.realm fuzz-test.realm
 
   "run hang analyzer":
   - command: shell.exec

--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -454,8 +454,8 @@ functions:
       working_dir: realm-core/build/test/realm-fuzzer
       aws_key: '${artifacts_aws_access_key}'
       aws_secret: '${artifacts_aws_secret_key}'
-      local_file: 'realm-core/build/test/realm-fuzzer/fuzz-realm.realm'
-      remote_file: '${project}/${branch_name}/${task_id}/${execution}/fuzz-realm.realm'
+      local_file: 'realm-core/build/test/realm-fuzzer/fuzzer_realm.realm'
+      remote_file: '${project}/${branch_name}/${task_id}/${execution}/fuzzer_realm.realm'
       bucket: mciuploads
       permissions: public-read
       content_type: application/x-binary
@@ -468,7 +468,7 @@ functions:
       script: |-
         #remove the crash file and the realm produced by the fuzzer run
         rm realm-fuzzer-crash.txt
-        rm fuzz-realm.realm
+        rm fuzzer_realm.realm
 
   "run hang analyzer":
   - command: shell.exec

--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -430,8 +430,10 @@ functions:
       script: |-
         if ls crash-*> /dev/null 2>&1; then
           echo "Found crash file"
+          #Rename the crash file and the realm file. 
+          #If there is a crash, this will signal that something needs to be uploaded.
           mv crash-* realm-fuzzer-crash.txt
-          mv fuzz-test.realm fuzzer_realm.realm
+          mv fuzz-realm.realm fuzzer_realm.realm
         fi
 
   - command: s3.put
@@ -452,8 +454,8 @@ functions:
       working_dir: realm-core/build/test/realm-fuzzer
       aws_key: '${artifacts_aws_access_key}'
       aws_secret: '${artifacts_aws_secret_key}'
-      local_file: 'realm-core/build/test/realm-fuzzer/fuzzer_realm.realm'
-      remote_file: '${project}/${branch_name}/${task_id}/${execution}/fuzzer_realm.realm'
+      local_file: 'realm-core/build/test/realm-fuzzer/fuzz-realm.realm'
+      remote_file: '${project}/${branch_name}/${task_id}/${execution}/fuzz-realm.realm'
       bucket: mciuploads
       permissions: public-read
       content_type: application/x-binary
@@ -464,8 +466,9 @@ functions:
     params:
       working_dir: realm-core/build/test/realm-fuzzer
       script: |-
+        #remove the crash file and the realm produced by the fuzzer run
         rm realm-fuzzer-crash.txt
-        mv fuzzer_realm.realm fuzz-test.realm
+        rm fuzz-realm.realm
 
   "run hang analyzer":
   - command: shell.exec


### PR DESCRIPTION
## What, How & Why?
Upload also the realm file if the fuzzer fails, in order to reply the fuzzer locally using the input crash file and apply it to the same input file.

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed
* [ ] `bindgen/spec.yml`, if public C++ API changed
