### PR TITLE
Removed duplicate library warning when building realm2json

### DIFF
--- a/src/realm/exec/CMakeLists.txt
+++ b/src/realm/exec/CMakeLists.txt
@@ -65,7 +65,7 @@ set_target_properties(Realm2JSON PROPERTIES
     OUTPUT_NAME "realm2json"
     DEBUG_POSTFIX ${CMAKE_DEBUG_POSTFIX}
 )
-target_link_libraries(Realm2JSON Storage QueryParser Sync)
+target_link_libraries(Realm2JSON Sync QueryParser)
 list(APPEND ExecTargetsToInstall Realm2JSON)
 endif()
 


### PR DESCRIPTION
## What, How & Why?
Updated target link libraries list for the `realm2json` executable to remove the "duplicate libraries" warning:
```
[552/847] Linking CXX executable src/realm/exec/realm2json-dbg
ld: warning: ignoring duplicate libraries: 'src/realm/librealm-dbg.a'
```

The link libraries for `realm2json` were updated to match that of the `SyncServer` in _src/realm/sync/noinst/server/CMakeLists.txt_, which imports the same libraries.

## ☑️ ToDos
* ~~[ ] 📝 Changelog update~~
* ~~[ ] 🚦 Tests (or not relevant)~~
* ~~[ ] C-API, if public C++ API changed~~
* ~~[ ] `bindgen/spec.yml`, if public C++ API changed~~
