### PR TITLE
RCORE-2131: Don't throw immediately when convertion of string to number fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 * A non-streaming progress notifier would not immediately call its callback after registration. Instead you would have to wait for a download message to be received to get your first update - if you were already caught up when you registered the notifier you could end up waiting a long time for the server to deliver a download that would call/expire your notifier ([#7627](https://github.com/realm/realm-core/issues/7627), since v14.6.0).
+* Comparing a numeric property with an argument list containing a string would throw. ([#7714](https://github.com/realm/realm-core/issues/7714), since v14.7.0)
 
 ### Breaking changes
 * None.

--- a/src/realm/parser/driver.cpp
+++ b/src/realm/parser/driver.cpp
@@ -1424,11 +1424,6 @@ std::unique_ptr<Subexpr> ConstantNode::visit(ParserDriver* drv, DataType hint)
             }
             else {
                 explain_value_message = util::format("argument %1 with value '%2'", explain_value_message, value);
-                if (!(m_target_table || Mixed::data_types_are_comparable(value.get_type(), hint) ||
-                      Mixed::is_numeric(hint) || (value.is_type(type_String) && hint == type_TypeOfValue))) {
-                    throw InvalidQueryArgError(
-                        util::format("Cannot compare %1 to a %2", explain_value_message, get_data_type_name(hint)));
-                }
             }
         }
     }
@@ -1465,6 +1460,13 @@ std::unique_ptr<Subexpr> ConstantNode::visit(ParserDriver* drv, DataType hint)
     }
 
     convert_if_needed(value);
+
+    if (type == Type::ARG && !(m_target_table || Mixed::data_types_are_comparable(value.get_type(), hint) ||
+                               (value.is_type(type_TypedLink) && hint == type_Link) ||
+                               (value.is_type(type_String) && hint == type_TypeOfValue))) {
+        throw InvalidQueryArgError(
+            util::format("Cannot compare %1 to a %2", explain_value_message, get_data_type_name(hint)));
+    }
 
     switch (value.get_type()) {
         case type_Int: {

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -2266,7 +2266,7 @@ TEST(Parser_list_of_primitive_ints)
         message,
         "Unsupported comparison operator 'endswith' against type 'int', right side must be a string or binary type");
     CHECK_THROW_ANY_GET_MESSAGE(verify_query(test_context, t, "integers == 'string'", 0), message);
-    CHECK_EQUAL(message, "Cannot convert 'string' to a number");
+    CHECK_EQUAL(message, "Unsupported comparison between type 'int' and type 'string'");
 }
 
 TEST_TYPES(Parser_list_of_primitive_strings, std::true_type, std::false_type)
@@ -3346,7 +3346,7 @@ TEST(Parser_BacklinkCount)
     std::string message;
     // backlink count requires comparison to a numeric type
     CHECK_THROW_ANY_GET_MESSAGE(verify_query(test_context, items, "@links.@count == 'string'", -1), message);
-    CHECK_EQUAL(message, "Cannot convert 'string' to a number");
+    CHECK_EQUAL(message, "Unsupported comparison between type 'int' and type 'string'");
     CHECK_THROW_ANY_GET_MESSAGE(verify_query(test_context, items, "@links.@count == 2018-04-09@14:21:0", -1),
                                 message);
     CHECK_EQUAL(message, "Unsupported comparison between type 'int' and type 'timestamp'");


### PR DESCRIPTION
The parser will throw later anyway if the comparison cannot be done.

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- Link to relevant issue this fixes -->
Fixes #7714

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [x] C-API, if public C++ API changed
* [x] `bindgen/spec.yml`, if public C++ API changed
