### PR TITLE
RCORE-2132 fix fuzzer bootstrap when encryption key is not provided

### DIFF
--- a/test/realm-fuzzer/fuzz_configurator.cpp
+++ b/test/realm-fuzzer/fuzz_configurator.cpp
@@ -38,10 +38,12 @@ void FuzzConfigurator::setup_realm_config()
     m_config.scheduler = realm::util::Scheduler::make_dummy();
     if (m_use_encryption) {
         const char* key = m_fuzzer.get_encryption_key();
-        const char* i = key;
-        while (*i != '\0') {
-            m_config.encryption_key.push_back(*i);
-            i++;
+        if (key) {
+            const char* i = key;
+            while (*i != '\0') {
+                m_config.encryption_key.push_back(*i);
+                i++;
+            }
         }
     }
 }


### PR DESCRIPTION
## What, How & Why?
Fixes: https://github.com/realm/realm-core/issues/7716

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed
* [ ] `bindgen/spec.yml`, if public C++ API changed
