### PR TITLE
RCORE-2134 GHA release script fixes

### DIFF
--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -51,6 +51,7 @@ jobs:
         draft: false
         base: ${{ github.base_ref }}
         labels: no-jira-ticket
+        add-paths: CHANGELOG.md
         commit-message: New changelog section to prepare for vNext
     - name: Merge Pull Request
       uses: juliangruber/merge-pull-request-action@9234b8714dda9a08f3d1df5b2a6a3abd7b695353 #! 1.3.1

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -18,7 +18,8 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
-          submodules: recursive
+          submodules: false
+          fetch-depth: 0 # include history and tags
       - name: Change Version
         run: tools/release-init.sh ${{ inputs.version }}
         shell: bash
@@ -32,8 +33,6 @@ jobs:
           labels: no-jira-ticket
           commit-message: Prepare for release ${{ inputs.version }}
           token: ${{ secrets.REALM_CI_PAT }}
-          delete-branch: true
-          base: ${{ github.ref }}
           add-paths: |
             dependencies.yml
             Package.swift

--- a/tools/release-init.sh
+++ b/tools/release-init.sh
@@ -50,8 +50,7 @@ sed -i.bak -e "1s/.*/$RELEASE_HEADER/" "${project_dir}/CHANGELOG.md" || exit 1
 sed -i.bak -e "/.*\[#????\](https.*/d" "${project_dir}/CHANGELOG.md"
 rm "${project_dir}/CHANGELOG.md.bak" || exit 1
 
-# on CI we use a shallow clone, so we may not have the tags yet
-git fetch --tags
+# assumes that tags and history have been fetched
 git log $(git describe --tags --abbrev=0)..HEAD --oneline --no-merges > changes-since-last-tag.txt
 echo changes since last tag are
 cat changes-since-last-tag.txt


### PR DESCRIPTION
Related to https://github.com/realm/realm-core/pull/7566 and https://github.com/realm/realm-core/pull/7726.
Fixes based on the error reported in this [run](https://github.com/realm/realm-core/actions/runs/9214708552/job/25351498106).

The error is
```
Rebasing commits made to branch 'master' on to base branch 'refs/heads/master'
  fatal: refusing to fetch into branch 'refs/heads/master' checked out at '/home/runner/work/realm-core/realm-core'
```

This is because I had set the `base` parameter unnecessarily, and the action wasn't smart enough to know that it should be a no-op. According to the [docs](https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#providing-a-consistent-base):

> There may be use cases where it makes sense to execute the workflow on a branch that is not the base of the pull request. In these cases, the base branch can be specified with the base action input. The action will attempt to rebase changes made during the workflow on to the actual base.
