### PR TITLE
Prepare for 14.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
-# NEXT RELEASE
+# 14.8.0 Release notes
 
 ### Enhancements
-* <New feature description> (PR [#????](https://github.com/realm/realm-core/pull/????))
 * Add vendor support to the Android Blueprint (PR [#7614](https://github.com/realm/realm-core/pull/7614)).
 
 ### Fixed
@@ -3236,7 +3235,6 @@
 * Added `TableView::update_query()`
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Fix race potentially allowing frozen transactions to access incomplete search index accessors. (Since v6)
 * Fix queries for null on non-nullable indexed integer columns returning results for zero entries. (Since v6)
 * Fix queries for null on a indexed ObjectId column returning results for the zero ObjectId. (Since v10)

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@
 import PackageDescription
 import Foundation
 
-let versionStr = "14.7.0"
+let versionStr = "14.8.0"
 let versionPieces = versionStr.split(separator: "-")
 let versionCompontents = versionPieces[0].split(separator: ".")
 let versionExtra = versionPieces.count > 1 ? versionPieces[1] : ""

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -1,5 +1,5 @@
 PACKAGE_NAME: realm-core
-VERSION: 14.7.0
+VERSION: 14.8.0
 OPENSSL_VERSION: 3.2.0
 ZLIB_VERSION: 1.2.13
 # https://github.com/10gen/baas/commits


### PR DESCRIPTION
Commits since the last release:

4cfdcd65b GHA release script fixes (#7727)
e3d053b2d update scripts for CI (#7726)
94c8f6772 RCORE-2134 automate the release process (#7566)
5d1d15067 fix fuzzer bootstrap when encryption key is not provided (#7722)
3648014ff RCORE-2131: Don't throw immediately when convertion of string to number fails (#7715)
de18fc379 RCORE-1997 RCORE-2113 Add baas artifact generation to evergreen (#7692)
37be84048 Delete the old pre-c++11 Thread implementation (#7696)
93d5fffbd Add vendor support to Android blueprints (#7614)
4b38b44a5 Upload also the realm file when the fuzzer fails (#7700)
0c72dc336 Fix error message
c6cb1ef17 Removed duplicate library warning when building realm2json (#7710)
c280bdb17 RCORE-2099 Restore progress notifier behavior when sync session is already caught up (#7681)
4f84a0cab Update release note
