### PR TITLE
RCORE-2134 touch up the GHA release process based on the first full run

### DIFF
--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -53,12 +53,6 @@ jobs:
         labels: no-jira-ticket
         add-paths: CHANGELOG.md
         commit-message: New changelog section to prepare for vNext
-    - name: Merge Pull Request
-      uses: juliangruber/merge-pull-request-action@9234b8714dda9a08f3d1df5b2a6a3abd7b695353 #! 1.3.1
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        number: ${{ steps.vnext-pr.outputs.pull-request-number }}
-        method: squash
     - name: 'Post to #appx-releases'
       uses: realm/ci-actions/release-to-slack@fa20eb972b9f018654fdb4e2c7afb52b0532f907
       with:

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -31,9 +31,9 @@ jobs:
       uses: ncipollo/release-action@2c591bcc8ecdcd2db72b97d6147f871fcd833ba5 #! 1.14.0
       with:
         bodyFile: extracted_changelog.md
-        name: ${{ steps.get-version.outputs.version }}
+        name: Realm Core v${{ steps.get-version.outputs.version }}
         commit: ${{ github.base_ref }}
-        tag: ${{ steps.get-version.outputs.version }}
+        tag: v${{ steps.get-version.outputs.version }}
         token: ${{ secrets.GITHUB_TOKEN }}
         draft: false
     - name: Update Changelog

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -60,3 +60,5 @@ jobs:
         sdk: Core
         webhook-url: ${{ secrets.SLACK_RELEASE_WEBHOOK }}
         version: ${{ steps.get-version.outputs.version }}
+    - name: Output PR URL
+      run: echo "Prepare vNext PR created: ${{ steps.vnext-pr.outputs.pull-request-url }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -24,6 +24,7 @@ jobs:
         run: tools/release-init.sh ${{ inputs.version }}
         shell: bash
       - name: Create Release PR
+        id: prepare-pr
         uses: peter-evans/create-pull-request@6d6857d36972b65feb161a90e484f2984215f83e #! 6.0.5
         with:
           branch: release/automated_v${{ inputs.version }}
@@ -37,3 +38,5 @@ jobs:
             dependencies.yml
             Package.swift
             CHANGELOG.md
+      - name: Output PR URL
+        run: echo "Prepare release PR created: ${{ steps.prepare-pr.outputs.pull-request-url }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -32,7 +32,7 @@ jobs:
           body-path: changes-since-last-tag.txt
           labels: no-jira-ticket
           commit-message: Prepare for release ${{ inputs.version }}
-          token: ${{ secrets.REALM_CI_PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           add-paths: |
             dependencies.yml
             Package.swift

--- a/doc/development/how-to-release.md
+++ b/doc/development/how-to-release.md
@@ -9,8 +9,10 @@ The core release process is automated with github [actions](https://github.com/r
 3. When ready, merge the PR. You can squash if there are only "prepare release" changes, but use a "merge-commit" strategy if there are functional changes added manually to the PR. On merge, the "make-release" action will run. This takes care of:
   - Making a tag
   - Publishing the release on Github
-  - Updating the Changelog
+  - Making a PR to update the Changelog with the new template section
   - Announcing the release in the #appx-releases slack channel
+
+4. Find the freshly generated PR that adds the new changelog section. Approve it and merge it.
 
 ## Previous process
 

--- a/doc/development/how-to-release.md
+++ b/doc/development/how-to-release.md
@@ -1,18 +1,18 @@
 The core release process is automated with github [actions](https://github.com/realm/realm-core/actions)
 
-1. Run the prepare-release action.
-  - input the base branch that you would like to make a release from (usually this will be "master").
-  - input the release version (eg. "10.14.7")
+1. Go to the prepare-release [action](https://github.com/realm/realm-core/actions/workflows/prepare-release.yml) and click the "Run workflow" dropdown.
+  - Input the base branch that you would like to make a release from (usually this will be "master").
+  - Input the release version (eg. "10.14.7")
 
 2. This will create a PR, which you should look over and get someone else on the team to review. Verify the changelog by checking the PR description which has a list of commits since the last tag was made. If any changes are required, commit them to this PR's branch.
 
-3. When ready, merge the PR. You can squash if there are only "prepare release" changes, but use a "merge-commit" strategy if there are functional changes added manually to the PR. On merge, the "make-release" action will run. This takes care of:
-  - Making a tag
-  - Publishing the release on Github
-  - Making a PR to update the Changelog with the new template section
-  - Announcing the release in the #appx-releases slack channel
+3. When ready, merge the PR. You can squash if there are only "prepare release" changes, but use a "merge-commit" strategy if there are functional changes added manually to the PR (note that if using a merge strategy, the last commit after merge will be the one tagged, so you may want to reorder the commits so that the 'prepare' commit comes last). On merge, the "make-release" action will run. This will:
+  - Make a tag
+  - Publish the release on Github
+  - Open a PR to update the Changelog with the new template section
+  - Announce the release in the #appx-releases slack channel
 
-4. Find the freshly generated PR that adds the new changelog section. Approve it and merge it.
+4. Find the newly generated PR that adds the new changelog section. Approve it and merge it.
 
 ## Previous process
 

--- a/doc/development/how-to-release.md
+++ b/doc/development/how-to-release.md
@@ -1,8 +1,8 @@
 The core release process is automated with github [actions](https://github.com/realm/realm-core/actions)
 
 1. Go to the prepare-release [action](https://github.com/realm/realm-core/actions/workflows/prepare-release.yml) and click the "Run workflow" dropdown.
-  - Input the base branch that you would like to make a release from (usually this will be "master").
-  - Input the release version (eg. "10.14.7")
+  - Select the base branch that you would like to make a release from (usually this will be "master") in the drop down.
+  - Enter the version of the new release (eg. "10.123.1" or "4.5.0-CustDemo")
 
 2. This will create a PR, which you should look over and get someone else on the team to review. Verify the changelog by checking the PR description which has a list of commits since the last tag was made. If any changes are required, commit them to this PR's branch.
 

--- a/tools/release-init.sh
+++ b/tools/release-init.sh
@@ -51,7 +51,8 @@ sed -i.bak -e "/.*\[#????\](https.*/d" "${project_dir}/CHANGELOG.md"
 rm "${project_dir}/CHANGELOG.md.bak" || exit 1
 
 # assumes that tags and history have been fetched
-git log $(git describe --tags --abbrev=0)..HEAD --oneline --no-merges > changes-since-last-tag.txt
+echo "commits since last tag:\n" > changes-since-last-tag.txt
+git log $(git describe --tags --abbrev=0)..HEAD --oneline --no-merges >> changes-since-last-tag.txt
 echo changes since last tag are
 cat changes-since-last-tag.txt
 


### PR DESCRIPTION
Related to https://github.com/realm/realm-core/pull/7566 https://github.com/realm/realm-core/pull/7726 and https://github.com/realm/realm-core/pull/7727

The make-release action failed near the [end](https://github.com/realm/realm-core/actions/runs/9216410854/job/25356630029):
```
Run juliangruber/merge-pull-request-action@9234b8714dda9a08f3d1df5b2a6a3abd7b695353
  with:
    github-token: ***
    number: 77[2](https://github.com/realm/realm-core/actions/runs/9216410854/job/25356630029#step:8:2)9
    method: squash
  env:
    PULL_REQUEST_NUMBER: 7729
Error: At least 1 approving review is required by reviewers with write access. - https://docs.github.com/articles/about-protected-branches
```
realm-core doesn't allow merging without reviewers which is a protection we have in place for a reason. 
Until we can come up with a smart way to automate this while keeping our protections in place, I'll make this a manual step in the release process.