### PR TITLE
Fix ref to fuzz object during cnf bootstrap

### DIFF
--- a/test/realm-fuzzer/fuzz_engine.cpp
+++ b/test/realm-fuzzer/fuzz_engine.cpp
@@ -42,7 +42,7 @@ static const char* to_hex(char c)
 int FuzzEngine::run_fuzzer(const std::string& input, const std::string& name, bool enable_logging,
                            const std::string& path)
 {
-    auto configure = [&](auto fuzzer) {
+    auto configure = [&](auto& fuzzer) {
         try {
             FuzzConfigurator cnf(fuzzer, input, false, name);
             if (enable_logging) {
@@ -52,16 +52,19 @@ int FuzzEngine::run_fuzzer(const std::string& input, const std::string& name, bo
             return cnf;
         }
         catch (const EndOfFile& e) {
-            throw std::runtime_error{"Realm cnf is invalid"};
+            throw e;
         }
     };
 
     try {
         FuzzObject fuzzer;
-        auto cnf = configure(fuzzer);
+        FuzzConfigurator cnf = configure(fuzzer);
+        REALM_ASSERT(&fuzzer == &cnf.get_fuzzer());
         do_fuzz(cnf);
     }
-    catch (const EndOfFile&) {
+    catch (const EndOfFile& e) {
+    }
+    catch (...) {
     }
     return 0;
 }


### PR DESCRIPTION
## What, How & Why?
This should truly fix the ASAN issue. The fuzzer object was passed by copy, thus its reference was wrong.
Fixes: https://github.com/realm/realm-core/issues/7716

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed
* [ ] `bindgen/spec.yml`, if public C++ API changed
