### PR TITLE
RCORE-2140 Work around a VC++ bug in util::overload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 -----------
 
 ### Internals
-* None.
+* Work around a bug in VC++ that resulted in runtime errors when running the tests in a debug build (#[7741](https://github.com/realm/realm-core/issues/7741)).
 
 ----------------------------------------------
 

--- a/src/realm/sync/changeset.cpp
+++ b/src/realm/sync/changeset.cpp
@@ -44,30 +44,15 @@ InternString Changeset::find_string(StringData string) const noexcept
 
 PrimaryKey Changeset::get_key(const Instruction::PrimaryKey& key) const noexcept
 {
-    // we do not use the expected `mpark::visit(overload...` because in MSVC 2019 this
-    // code produces a segfault for something that works on other compilers.
-    // See https://github.com/realm/realm-core/issues/4624
-    if (const auto int64_ptr = mpark::get_if<int64_t>(&key)) {
-        return *int64_ptr;
-    }
-    else if (const auto intern_string_ptr = mpark::get_if<InternString>(&key)) {
-        return this->get_string(*intern_string_ptr);
-    }
-    else if (const auto monostate_ptr = mpark::get_if<mpark::monostate>(&key)) {
-        return *monostate_ptr;
-    }
-    else if (const auto global_key_ptr = mpark::get_if<GlobalKey>(&key)) {
-        return *global_key_ptr;
-    }
-    else if (const auto oid_ptr = mpark::get_if<ObjectId>(&key)) {
-        return *oid_ptr;
-    }
-    else if (const auto uuid_ptr = mpark::get_if<UUID>(&key)) {
-        return *uuid_ptr;
-    }
-    else {
-        REALM_UNREACHABLE(); // unhandled primary key type
-    }
+    return mpark::visit(overload{
+                            [this](InternString str) -> PrimaryKey {
+                                return get_string(str);
+                            },
+                            [](auto otherwise) -> PrimaryKey {
+                                return otherwise;
+                            },
+                        },
+                        key);
 }
 
 bool Changeset::operator==(const Changeset& that) const noexcept

--- a/src/realm/util/overload.hpp
+++ b/src/realm/util/overload.hpp
@@ -23,6 +23,15 @@ namespace realm::util {
 template <class... Ts>
 struct overload : Ts... {
     using Ts::operator()...;
+#ifdef _MSC_VER
+    // https://developercommunity.visualstudio.com/t/runtime-stack-corruption-using-stdvisit/346200
+    // A bug in VC++'s Empty Base Optimization causes it to compute the wrong
+    // size if both the type and the last base class have zero size. This
+    // results in the stack pointer being adjusted incorrectly if the final
+    // lambda passed to overload has no captures. Making overload non-zero size
+    // prevents this.
+    char dummy = 0;
+#endif
 };
 template <class... Ts>
 overload(Ts...) -> overload<Ts...>;


### PR DESCRIPTION
util::overload hits https://developercommunity.visualstudio.com/t/runtime-stack-corruption-using-stdvisit/346200, which has been fixed in the latest version of Visual Studio but not the version we have installed on evergreen (including on the vsCurrent builders). We switched away from using it in one place in https://github.com/realm/realm-core/pull/4825 due to this bug, but the core tests also hit this when run with debug runtime checks enabled. This change works around the bug so that util::overload works.