### PR TITLE
RCORE-2145: Output InRealmHistory when compacting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Add a missing file from the bid library to the android blueprint. (PR [#7738](https://github.com/realm/realm-core/pull/7738))
+* After compacting, a file upgrade would be triggered. This could cause loss of data if schema mode is SoftResetFile ([#7747](https://github.com/realm/realm-core/issues/7747), since 14.0.0)
 
 ### Breaking changes
 * None.

--- a/src/realm/group.cpp
+++ b/src/realm/group.cpp
@@ -951,8 +951,7 @@ auto Group::DefaultTableWriter::write_history(_impl::OutputStream& out) -> Histo
                                                          m_group->m_top.get_ref(), version, history_type,
                                                          history_schema_version);
         REALM_ASSERT(history_type != Replication::hist_None);
-        if (!m_should_write_history ||
-            (history_type != Replication::hist_SyncClient && history_type != Replication::hist_SyncServer)) {
+        if (!m_should_write_history || history_type == Replication::hist_None) {
             return info; // Only sync history should be preserved when writing to a new file
         }
         info.type = history_type;


### PR DESCRIPTION
This will ensure that the current history version is written, so that an upgrade will not be required when opening the file.

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- Link to relevant issue this fixes -->
Fixes #7747 

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [x] C-API, if public C++ API changed
* [x] `bindgen/spec.yml`, if public C++ API changed
