### PR TITLE
Add missing flag to Android blueprint

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -156,6 +156,7 @@ cc_defaults {
         "-DREALM_ENABLE_ENCRYPTION=1",
         "-DREALM_ENABLE_SYNC=1",
         "-DREALM_ENABLE_GEOSPATIAL=1",
+        "-DREALM_APP_SERVICES=1",
         "-DREALM_HAVE_EPOLL=1",
         "-DREALM_AOSP_VENDOR=1",
         "-Wno-non-virtual-dtor",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Add a missing file from the bid library to the android blueprint. (PR [#7738](https://github.com/realm/realm-core/pull/7738))
+* Add a missing `REALM_APP_SERVICES` flag to the android blueprint. (PR [#7755](https://github.com/realm/realm-core/pull/7755))
 
 ### Breaking changes
 * None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Add a missing file from the bid library to the android blueprint. (PR [#7738](https://github.com/realm/realm-core/pull/7738))
-* Add a missing `REALM_APP_SERVICES` flag to the android blueprint. (PR [#7755](https://github.com/realm/realm-core/pull/7755))
+* Add missing `REALM_APP_SERVICES` flag to the android blueprint. (PR [#7755](https://github.com/realm/realm-core/pull/7755))
 
 ### Breaking changes
 * None.

--- a/src/realm/mixed.cpp
+++ b/src/realm/mixed.cpp
@@ -870,6 +870,7 @@ std::ostream& operator<<(std::ostream& out, const Mixed& m)
                 break;
             case type_Mixed:
                 REALM_ASSERT(false);
+                REALM_FALLTHROUGH;
             default:
                 if (m.is_type(type_List)) {
                     out << "list";

--- a/src/realm/mixed.cpp
+++ b/src/realm/mixed.cpp
@@ -869,7 +869,6 @@ std::ostream& operator<<(std::ostream& out, const Mixed& m)
                 out << util::serializer::print_value(m.uuid_val);
                 break;
             case type_Mixed:
-                REALM_ASSERT(false);
                 REALM_FALLTHROUGH;
             default:
                 if (m.is_type(type_List)) {


### PR DESCRIPTION
## What, How & Why?
Adds missing `REALM_APP_SERVICES` flag to blueprint and addresses warning in `mixed` due to lack of break or fall through.

## ☑️ ToDos
* [x] 📝 Changelog update
