### PR TITLE
RCORE-1990 Fix packaging for windows

### DIFF
--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -761,7 +761,7 @@ tasks:
         fi
 
         cd build
-        $CPACK -C ${cmake_build_type|Debug} -G TGZ -D "CPACK_PACKAGE_FILE_NAME=realm-core-artifacts" ${package_flags|}
+        "$CPACK" -C ${cmake_build_type|Debug} -G TGZ -D "CPACK_PACKAGE_FILE_NAME=realm-core-artifacts" ${package_flags|}
   - command: s3.put
     params:
       aws_key: '${artifacts_aws_access_key}'


### PR DESCRIPTION
## What, How & Why?
The invocation of cpack on windows needs to be quoted when calling the cmake in `C:\Program Files`

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed
* [ ] `bindgen/spec.yml`, if public C++ API changed
