### PR TITLE
RCORE-2134 fix output syntax

### DIFF
--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -61,7 +61,8 @@ jobs:
         webhook-url: ${{ secrets.SLACK_RELEASE_WEBHOOK }}
         version: ${{ steps.get-version.outputs.version }}
     - name: Output PR URL
-      run: echo "Prepare vNext PR created: $VNEXT_PR_URL" >> $GITHUB_STEP_SUMMARY
+      run: |
+        echo "Prepare vNext PR created: $VNEXT_PR_URL" >> $GITHUB_STEP_SUMMARY
       shell: bash
       env:
         VNEXT_PR_URL: ${{ steps.vnext-pr.outputs.pull-request-url }}

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -61,4 +61,7 @@ jobs:
         webhook-url: ${{ secrets.SLACK_RELEASE_WEBHOOK }}
         version: ${{ steps.get-version.outputs.version }}
     - name: Output PR URL
-      run: echo "Prepare vNext PR created: ${{ steps.vnext-pr.outputs.pull-request-url }}" >> $GITHUB_STEP_SUMMARY
+      run: echo "Prepare vNext PR created: $VNEXT_PR_URL" >> $GITHUB_STEP_SUMMARY
+      shell: bash
+      env:
+        VNEXT_PR_URL: ${{ steps.vnext-pr.outputs.pull-request-url }}

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -39,7 +39,8 @@ jobs:
             Package.swift
             CHANGELOG.md
       - name: Output PR URL
-        run: echo "Prepare release PR created: $PREPARE_PR_URL" >> $GITHUB_STEP_SUMMARY
+        run: |
+          echo "Prepare release PR created: $PREPARE_PR_URL" >> $GITHUB_STEP_SUMMARY
         shell: bash
         env:
           PREPARE_PR_URL: ${{ steps.prepare-pr.outputs.pull-request-url }}

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -39,4 +39,7 @@ jobs:
             Package.swift
             CHANGELOG.md
       - name: Output PR URL
-        run: echo "Prepare release PR created: ${{ steps.prepare-pr.outputs.pull-request-url }}" >> $GITHUB_STEP_SUMMARY
+        run: echo "Prepare release PR created: $PREPARE_PR_URL" >> $GITHUB_STEP_SUMMARY
+        shell: bash
+        env:
+          PREPARE_PR_URL: ${{ steps.prepare-pr.outputs.pull-request-url }}


### PR DESCRIPTION
https://github.com/realm/realm-core/pull/7730 added a summary, but the syntax didn't work: https://github.com/realm/realm-core/actions/runs/9323985651/workflow


## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed
* [ ] `bindgen/spec.yml`, if public C++ API changed
