### PR TITLE
Fix XCode warning after 'notifications-fuzzer' directory was removed

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -546,7 +546,6 @@ let package = Package(
                 "benchmarks",
                 "c_api",
                 "geospatial.cpp",
-                "notifications-fuzzer",
                 "query.json",
                 "sync-metadata-v4.realm",
                 "sync-metadata-v5.realm",


### PR DESCRIPTION
## What, How & Why?
A bunch of old obsolete test files were removed as part of PR #7695, but an exclude entry for one of the items removed was still in the `Package.swift` xcode project file, which led to a warning when that file was opened in XCode. This PR removes that line that is no longer used to remove the warning.

## ☑️ ToDos
* ~~[ ] 📝 Changelog update~~
* ~~[ ] 🚦 Tests (or not relevant)~~
* ~~[ ] C-API, if public C++ API changed~~
* ~~[ ] `bindgen/spec.yml`, if public C++ API changed~~
