### PR TITLE
Optimize IntegerNode::find_first_local

### DIFF
--- a/src/realm/array.hpp
+++ b/src/realm/array.hpp
@@ -392,7 +392,11 @@ public:
     template <class cond>
     size_t find_first(int64_t value, size_t start = 0, size_t end = size_t(-1)) const
     {
+        static cond c;
         REALM_ASSERT(start <= m_size && (end <= m_size || end == size_t(-1)) && start <= end);
+        if (end - start == 1) {
+            return c(get(start), value) ? start : realm::not_found;
+        }
         // todo, would be nice to avoid this in order to speed up find_first loops
         QueryStateFindFirst state;
         Finder finder = m_vtable->finder[cond::condition];

--- a/src/realm/array_integer_tpl.hpp
+++ b/src/realm/array_integer_tpl.hpp
@@ -104,13 +104,17 @@ bool ArrayIntNull::find_impl(value_type opt_value, size_t start, size_t end, Que
 template <class cond>
 size_t ArrayIntNull::find_first(value_type value, size_t start, size_t end) const
 {
+    static cond c;
+    REALM_ASSERT(start <= m_size && (end <= m_size || end == size_t(-1)) && start <= end);
+    if (end - start == 1) {
+        std::optional<int64_t> opt_int = get(start);
+        return c(opt_int, value, !opt_int, !value) ? start : realm::not_found;
+    }
+
     QueryStateFindFirst state;
     find_impl<cond>(value, start, end, &state);
 
-    if (state.match_count() > 0)
-        return to_size_t(state.m_state);
-    else
-        return not_found;
+    return static_cast<size_t>(state.m_state);
 }
 
 template <class cond>

--- a/src/realm/query_engine.hpp
+++ b/src/realm/query_engine.hpp
@@ -425,6 +425,17 @@ public:
 
     size_t find_first_local(size_t start, size_t end) override
     {
+        TConditionFunction c;
+        if (end - start == 1) {
+            if constexpr (std::is_same_v<TConditionValue, int64_t>) {
+                return c(this->m_leaf->get(start), this->m_value) ? start : realm::not_found;
+            }
+            else {
+                std::optional<int64_t> opt_int = this->m_leaf->get(start);
+                return c(opt_int, this->m_value, !opt_int, !this->m_value) ? start : realm::not_found;
+            }
+        }
+
         return this->m_leaf->template find_first<TConditionFunction>(this->m_value, start, end);
     }
 

--- a/src/realm/query_engine.hpp
+++ b/src/realm/query_engine.hpp
@@ -425,17 +425,6 @@ public:
 
     size_t find_first_local(size_t start, size_t end) override
     {
-        TConditionFunction c;
-        if (end - start == 1) {
-            if constexpr (std::is_same_v<TConditionValue, int64_t>) {
-                return c(this->m_leaf->get(start), this->m_value) ? start : realm::not_found;
-            }
-            else {
-                std::optional<int64_t> opt_int = this->m_leaf->get(start);
-                return c(opt_int, this->m_value, !opt_int, !this->m_value) ? start : realm::not_found;
-            }
-        }
-
         return this->m_leaf->template find_first<TConditionFunction>(this->m_value, start, end);
     }
 
@@ -586,11 +575,6 @@ public:
             }
             else if (m_index_evaluator) {
                 return m_index_evaluator->do_search_index(BaseType::m_cluster, start, end);
-            }
-            else if (end - start == 1) {
-                if (this->m_leaf->get(start) == this->m_value) {
-                    s = start;
-                }
             }
             else {
                 s = this->m_leaf->template find_first<Equal>(this->m_value, start, end);

--- a/test/test_query.cpp
+++ b/test/test_query.cpp
@@ -706,17 +706,18 @@ TEST(Query_NextGenSyntaxMonkey0)
     }
 }
 
-TEST(Query_NextGenSyntaxMonkey)
+TEST_TYPES(Query_NextGenSyntaxMonkey, std::true_type, std::false_type)
 {
+    static const bool nullable = TEST_TYPE::value;
     Random random(random_int<unsigned long>()); // Seed from slow global generator
     for (int iter = 1; iter < 5 * (TEST_DURATION * TEST_DURATION * TEST_DURATION + 1); iter++) {
         // Set 'rows' to at least '* 20' else some tests will give 0 matches and bad coverage
         const size_t rows = 1 + random.draw_int_mod<size_t>(REALM_MAX_BPNODE_SIZE * 20 *
                                                             (TEST_DURATION * TEST_DURATION * TEST_DURATION + 1));
         Table table;
-        auto col_int0 = table.add_column(type_Int, "first");
-        auto col_int1 = table.add_column(type_Int, "second");
-        auto col_int2 = table.add_column(type_Int, "third");
+        auto col_int0 = table.add_column(type_Int, "first", nullable);
+        auto col_int1 = table.add_column(type_Int, "second", nullable);
+        auto col_int2 = table.add_column(type_Int, "third", nullable);
 
         for (size_t r = 0; r < rows; r++) {
             Obj obj = table.create_object();

--- a/test/util/test_path.cpp
+++ b/test/util/test_path.cpp
@@ -148,7 +148,7 @@ bool initialize_test_path(int argc, const char* argv[])
         return false;
     }
     g_resource_path = File::resolve("resources", directory) + "/";
-    g_path_prefix = directory;
+    g_path_prefix = std::string(directory) + "/";
 #endif
 
     if (argc > 0) {


### PR DESCRIPTION
If you are just testing one element, use simple compare instead of leaf->find_first. This will speed up queries where secondary nodes are IntegerNodes.

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- Link to relevant issue this fixes -->

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed
* [ ] `bindgen/spec.yml`, if public C++ API changed
