### PR TITLE
Add a check to verify the base commit build status in the release process

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -30,7 +30,7 @@ jobs:
           branch: release/automated_v${{ inputs.version }}
           title: Prepare for ${{ inputs.version }}
           draft: false
-          body-path: changes-since-last-tag.txt
+          body-path: pr-body.txt
           labels: no-jira-ticket
           commit-message: Prepare for release ${{ inputs.version }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -110,4 +110,4 @@ ssh_agent_commands.sh
 
 # release script artifacts
 extracted_changelog.md
-changes-since-last-tag.txt
+pr-body.txt


### PR DESCRIPTION
As discussed in the round table today, we'd like the automated process to check that the base branch is in a releasable state. This gives us confidence in the release, and allows us to skip evergreen checks on "changelog/version" only changes in the release process.

These script changes use the Github API to check the status of the commit being released. It writes the status in the "prepare" PR description along with a link to the build page. This is a non-blocking way of quickly seeing the state of the build without requiring that it pass to release. This allows us to manually inspect the build and make a release even if there are failing checks that have been deemed "sporadic failures" by the releaser.
