### PR TITLE
RCORE-2155 Store FLX download progress in the Realm file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 -----------
 
 ### Internals
-* None.
+* FLX download estimates are now tracked in a multiprocess-compatible manner ([PR #7780](https://github.com/realm/realm-core/pull/7780)).
 
 ----------------------------------------------
 

--- a/src/realm/sync/history.hpp
+++ b/src/realm/sync/history.hpp
@@ -1,29 +1,12 @@
-
-#include <cstdint>
-#include <memory>
-#include <chrono>
-#include <string>
-
-#include <realm/impl/cont_transact_hist.hpp>
-#include <realm/sync/config.hpp>
-#include <realm/sync/instruction_replication.hpp>
-#include <realm/sync/protocol.hpp>
-#include <realm/sync/transform.hpp>
-#include <realm/sync/object_id.hpp>
-#include <realm/sync/instructions.hpp>
-
 #ifndef REALM_SYNC_HISTORY_HPP
 #define REALM_SYNC_HISTORY_HPP
 
+#include <realm/sync/protocol.hpp>
 
-namespace realm {
-namespace _impl {
-
-struct ObjectIDHistoryState;
-
-} // namespace _impl
-} // namespace realm
-
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <string>
 
 namespace realm {
 namespace sync {

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -1575,14 +1575,14 @@ void Session::integrate_changesets(const SyncProgress& progress, std::uint_fast6
                                        "received empty download message that was not the last in batch",
                                        ProtocolError::bad_progress);
         }
-        history.set_sync_progress(progress, &downloadable_bytes, version_info); // Throws
+        history.set_sync_progress(progress, downloadable_bytes, version_info); // Throws
         return;
     }
 
     std::vector<ProtocolErrorInfo> pending_compensating_write_errors;
     auto transact = get_db()->start_read();
     history.integrate_server_changesets(
-        progress, &downloadable_bytes, received_changesets, version_info, download_batch_state, logger, transact,
+        progress, downloadable_bytes, received_changesets, version_info, download_batch_state, logger, transact,
         [&](const TransactionRef&, util::Span<Changeset> changesets) {
             gather_pending_compensating_writes(changesets, &pending_compensating_write_errors);
         }); // Throws
@@ -1651,7 +1651,7 @@ void Session::on_changesets_integrated(version_type client_version, const SyncPr
             m_last_version_selected_for_upload = progress.upload.client_version;
         }
 
-        notify_upload_progress();
+        notify_sync_progress();
         check_for_upload_completion();
     }
 
@@ -1659,8 +1659,8 @@ void Session::on_changesets_integrated(version_type client_version, const SyncPr
 
     // notify also when final DOWNLOAD received with no changesets
     bool download_progressed = changesets_integrated || (!upload_progressed && resume_upload);
-    if (download_progressed)
-        notify_download_progress();
+    if (download_progressed && !upload_progressed)
+        notify_sync_progress();
 
     check_for_download_completion(); // Throws
 
@@ -2407,7 +2407,8 @@ Status Session::receive_download_message(const DownloadMessage& message)
                      progress.download.server_version, progress.download.last_integrated_client_version,
                      progress.latest_server_version.version, progress.latest_server_version.salt,
                      progress.upload.client_version, progress.upload.last_integrated_server_version,
-                     message.progress_estimate, last_in_batch, query_version, message.changesets.size()); // Throws
+                     message.downloadable.as_estimate(), last_in_batch, query_version,
+                     message.changesets.size()); // Throws
     }
     else {
         logger.debug("Received: DOWNLOAD(download_server_version=%1, download_client_version=%2, "
@@ -2417,7 +2418,7 @@ Status Session::receive_download_message(const DownloadMessage& message)
                      progress.download.server_version, progress.download.last_integrated_client_version,
                      progress.latest_server_version.version, progress.latest_server_version.salt,
                      progress.upload.client_version, progress.upload.last_integrated_server_version,
-                     message.downloadable_bytes, message.changesets.size()); // Throws
+                     message.downloadable.as_bytes(), message.changesets.size()); // Throws
     }
 
     // Ignore download messages when the client detects an error. This is to prevent transforming the same bad
@@ -2482,16 +2483,13 @@ Status Session::receive_download_message(const DownloadMessage& message)
     }
     REALM_ASSERT_EX(hook_action == SyncClientHookAction::NoAction, hook_action);
 
-    if (is_flx)
-        update_download_estimate(message.progress_estimate);
-
     if (process_flx_bootstrap_message(progress, batch_state, query_version, message.changesets)) {
         clear_resumption_delay_state();
         return Status::OK();
     }
 
-    uint64_t downloadable_bytes = is_flx ? 0 : message.downloadable_bytes;
-    initiate_integrate_changesets(downloadable_bytes, batch_state, progress, message.changesets); // Throws
+    initiate_integrate_changesets(message.downloadable.as_bytes(), batch_state, progress,
+                                  message.changesets); // Throws
 
     hook_action = call_debug_hook(SyncClientHookEvent::DownloadMessageIntegrated, progress, query_version,
                                   batch_state, message.changesets.size());

--- a/src/realm/sync/noinst/client_impl_base.hpp
+++ b/src/realm/sync/noinst/client_impl_base.hpp
@@ -1187,9 +1187,7 @@ private:
 
     void init_progress_handler();
     void enable_progress_notifications();
-    void notify_upload_progress();
-    void update_download_estimate(double download_estimate);
-    void notify_download_progress(const std::optional<uint64_t>& bootstrap_store_bytes = {});
+    void notify_sync_progress();
 
     friend class Connection;
 };

--- a/src/realm/sync/noinst/pending_bootstrap_store.cpp
+++ b/src/realm/sync/noinst/pending_bootstrap_store.cpp
@@ -197,7 +197,7 @@ void PendingBootstrapStore::add_batch(int64_t query_version, util::Optional<Sync
     m_has_pending = true;
 }
 
-bool PendingBootstrapStore::has_pending()
+bool PendingBootstrapStore::has_pending() const noexcept
 {
     return m_has_pending;
 }

--- a/src/realm/sync/noinst/pending_bootstrap_store.hpp
+++ b/src/realm/sync/noinst/pending_bootstrap_store.hpp
@@ -52,7 +52,7 @@ public:
     PendingBootstrapStore& operator=(const PendingBootstrapStore&) = delete;
 
     // True if there are pending changesets to process.
-    bool has_pending();
+    bool has_pending() const noexcept;
 
     struct PendingBatch {
         int64_t query_version = 0;

--- a/src/realm/sync/noinst/server/server_history.hpp
+++ b/src/realm/sync/noinst/server/server_history.hpp
@@ -451,8 +451,6 @@ public:
     // special conditions under which it can be called!
     SaltedVersion get_salted_server_version() const noexcept;
 
-    const ObjectIDHistoryState& get_object_id_history_state() const;
-
     // Overriding member functions in Replication
     void initialize(DB&) override;
     HistoryType get_history_type() const noexcept override;

--- a/src/realm/sync/tools/apply_to_state_command.cpp
+++ b/src/realm/sync/tools/apply_to_state_command.cpp
@@ -298,7 +298,7 @@ int main(int argc, const char** argv)
                              realm::sync::VersionInfo version_info;
                              auto transact = bool(flx_sync_arg) ? local_db->start_write() : local_db->start_read();
                              history.integrate_server_changesets(download_message.progress,
-                                                                 &download_message.downloadable_bytes,
+                                                                 download_message.downloadable_bytes,
                                                                  download_message.changesets, version_info,
                                                                  download_message.batch_state, *logger, transact);
                          },

--- a/src/realm/sync/transform.cpp
+++ b/src/realm/sync/transform.cpp
@@ -1,5 +1,6 @@
 #include <realm/sync/transform.hpp>
 
+#include <realm/sync/changeset_encoder.hpp>
 #include <realm/sync/noinst/changeset_index.hpp>
 #include <realm/sync/noinst/protocol_codec.hpp>
 

--- a/test/object-store/benchmarks/client_reset.cpp
+++ b/test/object-store/benchmarks/client_reset.cpp
@@ -80,7 +80,7 @@ struct BenchmarkLocalClientReset : public reset_utils::TestClientReset {
         progress.upload.client_version = current_version;
         progress.upload.last_integrated_server_version = current_version;
         sync::VersionInfo info_out;
-        history_local->set_sync_progress(progress, nullptr, info_out);
+        history_local->set_sync_progress(progress, 0, info_out);
 
         constexpr int64_t shared_pk = -42;
         {

--- a/test/object-store/util/sync/sync_test_utils.cpp
+++ b/test/object-store/util/sync/sync_test_utils.cpp
@@ -391,7 +391,7 @@ struct FakeLocalClientReset : public TestClientReset {
             progress.upload.client_version = current_version;
             progress.upload.last_integrated_server_version = current_version;
             sync::VersionInfo info_out;
-            history_local->set_sync_progress(progress, nullptr, info_out);
+            history_local->set_sync_progress(progress, 0, info_out);
         }
         {
             local_realm->begin_transaction();

--- a/test/test_client_reset.cpp
+++ b/test/test_client_reset.cpp
@@ -845,7 +845,7 @@ void mark_as_synchronized(DB& db)
     progress.upload.client_version = current_version;
     progress.upload.last_integrated_server_version = current_version;
     sync::VersionInfo info_out;
-    history.set_sync_progress(progress, nullptr, info_out);
+    history.set_sync_progress(progress, 0, info_out);
     history.set_client_file_ident({1, 0}, false);
 }
 
@@ -1433,7 +1433,7 @@ TEST(ClientReset_Recover_UpdatesRemoteServerVersions)
 
         sync::VersionInfo info_out;
         auto& history = static_cast<ClientReplication*>(db_fresh->get_replication())->get_history();
-        history.set_sync_progress(progress, nullptr, info_out);
+        history.set_sync_progress(progress, 0, info_out);
     }
 
     expect_reset(test_context, db, db_fresh, ClientResyncMode::Recover, nullptr);
@@ -1493,13 +1493,14 @@ TEST(ClientReset_Recover_UploadableBytes)
 
     auto& history = static_cast<ClientReplication*>(db->get_replication())->get_history();
     uint_fast64_t unused, pre_reset_uploadable_bytes;
-    history.get_upload_download_bytes(db.get(), unused, unused, unused, pre_reset_uploadable_bytes, unused);
+    DownloadableProgress unused_progress;
+    history.get_upload_download_bytes(db.get(), unused, unused_progress, unused, pre_reset_uploadable_bytes, unused);
     CHECK_GREATER(pre_reset_uploadable_bytes, 0);
 
     expect_reset(test_context, db, db_fresh, ClientResyncMode::Recover, nullptr);
 
     uint_fast64_t post_reset_uploadable_bytes;
-    history.get_upload_download_bytes(db.get(), unused, unused, unused, post_reset_uploadable_bytes, unused);
+    history.get_upload_download_bytes(db.get(), unused, unused_progress, unused, post_reset_uploadable_bytes, unused);
     CHECK_GREATER(post_reset_uploadable_bytes, 0);
     CHECK_GREATER(pre_reset_uploadable_bytes, post_reset_uploadable_bytes);
 }
@@ -1648,7 +1649,7 @@ void apply_changes(DB& src, DB& dst)
 
     util::NullLogger logger;
     VersionInfo new_version;
-    dst_history.integrate_server_changesets(dst_progress, nullptr, remote_changesets, new_version,
+    dst_history.integrate_server_changesets(dst_progress, 0, remote_changesets, new_version,
                                             DownloadBatchState::SteadyState, logger, dst.start_read());
 }
 

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -6882,7 +6882,7 @@ TEST(Sync_SetAndGetEmptyReciprocalChangeset)
     uint_fast64_t downloadable_bytes = 0;
     VersionInfo version_info;
     auto transact = db->start_read();
-    history.integrate_server_changesets(progress, &downloadable_bytes, server_changesets_encoded, version_info,
+    history.integrate_server_changesets(progress, downloadable_bytes, server_changesets_encoded, version_info,
                                         DownloadBatchState::SteadyState, *test_context.logger, transact);
 
     bool is_compressed = false;
@@ -6925,7 +6925,7 @@ TEST(Sync_InvalidChangesetFromServer)
 
     VersionInfo version_info;
     auto transact = db->start_read();
-    CHECK_THROW_EX(history.integrate_server_changesets({}, nullptr, util::Span(&server_changeset, 1), version_info,
+    CHECK_THROW_EX(history.integrate_server_changesets({}, 0, util::Span(&server_changeset, 1), version_info,
                                                        DownloadBatchState::SteadyState, *test_context.logger,
                                                        transact),
                    sync::IntegrationException,
@@ -6973,7 +6973,7 @@ TEST(Sync_ServerVersionsSkippedFromDownloadCursor)
     uint_fast64_t downloadable_bytes = 0;
     VersionInfo version_info;
     auto transact = db->start_read();
-    history.integrate_server_changesets(progress, &downloadable_bytes, server_changesets_encoded, version_info,
+    history.integrate_server_changesets(progress, downloadable_bytes, server_changesets_encoded, version_info,
                                         DownloadBatchState::SteadyState, *test_context.logger, transact);
 
     version_type current_version;
@@ -7060,7 +7060,7 @@ TEST(Sync_NonIncreasingServerVersions)
     uint_fast64_t downloadable_bytes = 0;
     VersionInfo version_info;
     auto transact = db->start_read();
-    history.integrate_server_changesets(progress, &downloadable_bytes, server_changesets_encoded, version_info,
+    history.integrate_server_changesets(progress, downloadable_bytes, server_changesets_encoded, version_info,
                                         DownloadBatchState::SteadyState, *test_context.logger, transact);
 }
 


### PR DESCRIPTION
Multiprocess sync needs this information to be available to non-sync-agent processes, which means storing it in the Realm file like the other progress information. For FLX we previously were always writing 0 to the downloadable_progress field in the history compartment, so we can reuse that field and don't have to make any schema changes. It's an integer field, so the double is stored as a fixed-point value with five digits of precision.

Pending bootstrap bytes similarly need to be read from the Realm file rather than passed directly to SessionWrapper, but that was already being persisted.

The separate notify_upload_progress() and notify_download_progress() functions and `only_if_new_uploadable_data ` flag don't work in a multiprocess context. We need to determine what notifications should be sent based entirely on the previous and current state of the progress information, as that's all that secondary processes have access to. This turned out to not really be a problem.

This should have no functional changes by itself, so no changes to the tests other than updating them to reflect downloadable_bytes no longer being a `uint64_t*`.

Fixes #7779.