### PR TITLE
The GHA release script requires a token in the environment

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -23,6 +23,8 @@ jobs:
       - name: Change Version
         run: tools/release-init.sh ${{ inputs.version }}
         shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # the gh command in the release script requires this token
       - name: Create Release PR
         id: prepare-pr
         uses: peter-evans/create-pull-request@6d6857d36972b65feb161a90e484f2984215f83e #! 6.0.5


### PR DESCRIPTION
Starting a release [failed](https://github.com/realm/realm-core/actions/runs/9421105486/job/25954419353) due to not finding the github token in the environment. Related to the changes in https://github.com/realm/realm-core/pull/7775. This was [documented](https://docs.github.com/en/actions/using-workflows/using-github-cli-in-workflows) as a requirement, but somehow I missed this and it wasn't required when I tested the script locally because I was signed in to my account. This should fix it.