### PR TITLE
Replace app_config_get_sync_client_config with _set_sync_client_config

### DIFF
--- a/src/realm.h
+++ b/src/realm.h
@@ -3018,7 +3018,7 @@ RLM_API void realm_app_config_set_metadata_mode(realm_app_config_t*,
 RLM_API void realm_app_config_set_metadata_encryption_key(realm_app_config_t*, const uint8_t[64]) RLM_API_NOEXCEPT;
 RLM_API void realm_app_config_set_security_access_group(realm_app_config_t*, const char*) RLM_API_NOEXCEPT;
 
-RLM_API realm_sync_client_config_t* realm_app_config_get_sync_client_config(realm_app_config_t*) RLM_API_NOEXCEPT;
+RLM_API void realm_app_config_set_sync_client_config(realm_app_config_t* config, realm_sync_client_config_t* sync_client_config) RLM_API_NOEXCEPT;
 
 /**
  * Get an existing @a realm_app_credentials_t and return it's json representation

--- a/src/realm/object-store/c_api/app.cpp
+++ b/src/realm/object-store/c_api/app.cpp
@@ -272,6 +272,11 @@ RLM_API void realm_app_config_set_security_access_group(realm_app_config_t* conf
     config->security_access_group = group;
 }
 
+RLM_API void realm_app_config_set_sync_client_config(realm_app_config_t* config, realm_sync_client_config_t* sync_client_config) noexcept
+{
+    config->sync_client_config = *sync_client_config;
+}
+
 RLM_API const char* realm_app_credentials_serialize_as_json(realm_app_credentials_t* app_credentials) noexcept
 {
     return wrap_err([&] {


### PR DESCRIPTION
## What, How & Why?
It appears app_config_get_sync_client_config was never implemented and even if it was, it's not clear to me how it was supposed to be used. We do have a method to create a new sync client config already, so I figured we probably want to use that and then set the client config on the app config, but it's possible the original intention was different. Opening this as a draft to clarify things and will clean it up for review after we're aligned on the expected API.

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed
* [ ] `bindgen/spec.yml`, if public C++ API changed
