### PR TITLE
RCORE-2160 Make upload completion reporting multiprocess-compatible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Fixed a change of mode from Strong to All when removing links from an embedded object that links to a tombstone. This affects sync apps that use embedded objects which have a `Lst<Mixed>` that contains a link to another top level object which has been deleted by another sync client (creating a tombstone locally). In this particular case, the switch would cause any remaining link removals to recursively delete the destination object if there were no other links to it. ([#7828](https://github.com/realm/realm-core/issues/7828), since 14.0.0-beta.0)
 * Fixed removing backlinks from the wrong objects if the link came from a nested list, nested dictionary, top-level dictionary, or list of mixed, and the source table had more than 256 objects. This could manifest as `array_backlink.cpp:112: Assertion failed: int64_t(value >> 1) == key.value` when removing an object. ([#7594](https://github.com/realm/realm-core/issues/7594), since v11 for dictionaries)
 * Fixed the collapse/rejoin of clusters which contained nested collections with links. This could manifest as `array.cpp:319: Array::move() Assertion failed: begin <= end [2, 1]` when removing an object. ([#7839](https://github.com/realm/realm-core/issues/7839), since the introduction of nested collections in v14.0.0-beta.0)
+* wait_for_upload_completion() was inconsistent in how it handled commits which did not produce any changesets to upload. Previously it would sometimes complete immediately if all commits waiting to be uploaded were empty, and at other times it would wait for a server roundtrip. It will now always complete immediately. ([PR #7796](https://github.com/realm/realm-core/pull/7796)).
 
 ### Breaking changes
 * None.
@@ -20,6 +21,7 @@
 
 ### Internals
 * Fixed `Table::remove_object_recursive` which wouldn't recursively follow links through a single `Mixed` property. This feature is exposed publicly on `Table` but no SDK currently uses it, so this is considered internal. ([#7829](https://github.com/realm/realm-core/issues/7829), likely since the introduction of Mixed)
+* Upload completion is now tracked in a multiprocess-compatible manner ([PR #7796](https://github.com/realm/realm-core/pull/7796)).
 
 ----------------------------------------------
 

--- a/src/realm/chunked_binary.cpp
+++ b/src/realm/chunked_binary.cpp
@@ -45,6 +45,13 @@ bool ChunkedBinaryData::is_null() const
     return chunk.is_null();
 }
 
+bool ChunkedBinaryData::empty() const
+{
+    BinaryIterator copy = m_begin;
+    BinaryData chunk = copy.get_next();
+    return chunk.size() == 0;
+}
+
 char ChunkedBinaryData::operator[](size_t index) const
 {
     BinaryIterator copy = m_begin;

--- a/src/realm/chunked_binary.hpp
+++ b/src/realm/chunked_binary.hpp
@@ -54,6 +54,9 @@ public:
     /// the first chunk points to the nullptr.
     bool is_null() const;
 
+    /// Equivalent to `size() == 0`, but O(1) rather than O(N).
+    bool empty() const;
+
     /// FIXME: O(n)
     char operator[](size_t index) const;
 

--- a/src/realm/sync/noinst/client_history_impl.cpp
+++ b/src/realm/sync/noinst/client_history_impl.cpp
@@ -157,7 +157,7 @@ std::vector<ClientHistory::LocalChange> ClientHistory::get_local_changes(version
             // find_sync_history_entry() returns 0 to indicate not found and
             // otherwise adds 1 to the version, and then get_reciprocal_transform()
             // subtracts 1 from the version
-            if (auto changeset = get_reciprocal_transform(version + 1, compressed); changeset.size()) {
+            if (auto changeset = get_reciprocal_transform(version + 1, compressed); !changeset.empty()) {
                 changesets.push_back({version, changeset});
             }
         }
@@ -344,7 +344,7 @@ void ClientHistory::set_sync_progress(const SyncProgress& progress, Downloadable
     ensure_updated(local_version); // Throws
     prepare_for_write();           // Throws
 
-    update_sync_progress(progress, downloadable_bytes, wt); // Throws
+    update_sync_progress(progress, downloadable_bytes); // Throws
 
     // Note: This transaction produces an empty changeset. Empty changesets are
     // not uploaded to the server.
@@ -489,17 +489,17 @@ void ClientHistory::integrate_server_changesets(
         // During the bootstrap phase in flexible sync, the server sends multiple download messages with the same
         // synthetic server version that represents synthetic changesets generated from state on the server.
         if (batch_state == DownloadBatchState::LastInBatch && changesets_to_integrate.empty()) {
-            update_sync_progress(progress, downloadable_bytes, transact); // Throws
+            update_sync_progress(progress, downloadable_bytes); // Throws
         }
         // Always update progress for download messages from steady state.
         else if (batch_state == DownloadBatchState::SteadyState && !changesets_to_integrate.empty()) {
             auto partial_progress = progress;
             partial_progress.download.server_version = last_changeset.remote_version;
             partial_progress.download.last_integrated_client_version = last_changeset.last_integrated_local_version;
-            update_sync_progress(partial_progress, downloadable_bytes, transact); // Throws
+            update_sync_progress(partial_progress, downloadable_bytes); // Throws
         }
         else if (batch_state == DownloadBatchState::SteadyState && changesets_to_integrate.empty()) {
-            update_sync_progress(progress, downloadable_bytes, transact); // Throws
+            update_sync_progress(progress, downloadable_bytes); // Throws
         }
         if (run_in_write_tr) {
             run_in_write_tr(transact, changesets_for_cb);
@@ -610,13 +610,13 @@ size_t ClientHistory::transform_and_apply_server_changesets(util::Span<Changeset
 }
 
 
-void ClientHistory::get_upload_download_bytes(DB* db, std::uint_fast64_t& downloaded_bytes,
+void ClientHistory::get_upload_download_state(DB& db, std::uint_fast64_t& downloaded_bytes,
                                               DownloadableProgress& downloadable_bytes,
                                               std::uint_fast64_t& uploaded_bytes,
                                               std::uint_fast64_t& uploadable_bytes,
-                                              std::uint_fast64_t& snapshot_version)
+                                              std::uint_fast64_t& snapshot_version, version_type& uploaded_version)
 {
-    TransactionRef rt = db->start_read(); // Throws
+    TransactionRef rt = db.start_read(); // Throws
     version_type current_client_version = rt->get_version();
 
     downloaded_bytes = 0;
@@ -624,19 +624,51 @@ void ClientHistory::get_upload_download_bytes(DB* db, std::uint_fast64_t& downlo
     uploaded_bytes = 0;
     uploadable_bytes = 0;
     snapshot_version = current_client_version;
+    uploaded_version = 0;
 
     using gf = _impl::GroupFriend;
-    if (ref_type ref = gf::get_history_ref(*rt)) {
-        Array root(db->get_alloc());
-        root.init_from_ref(ref);
-        downloaded_bytes = root.get_as_ref_or_tagged(s_progress_downloaded_bytes_iip).get_as_int();
-        downloadable_bytes = root.get_as_ref_or_tagged(s_progress_downloadable_bytes_iip).get_as_int();
-        uploadable_bytes = root.get_as_ref_or_tagged(s_progress_uploadable_bytes_iip).get_as_int();
-        uploaded_bytes = root.get_as_ref_or_tagged(s_progress_uploaded_bytes_iip).get_as_int();
+    ref_type ref = gf::get_history_ref(*rt);
+    if (!ref)
+        return;
+
+    Array root(db.get_alloc());
+    root.init_from_ref(ref);
+    downloaded_bytes = root.get_as_ref_or_tagged(s_progress_downloaded_bytes_iip).get_as_int();
+    downloadable_bytes = root.get_as_ref_or_tagged(s_progress_downloadable_bytes_iip).get_as_int();
+    uploadable_bytes = root.get_as_ref_or_tagged(s_progress_uploadable_bytes_iip).get_as_int();
+    uploaded_bytes = root.get_as_ref_or_tagged(s_progress_uploaded_bytes_iip).get_as_int();
+
+    uploaded_version = root.get_as_ref_or_tagged(s_progress_upload_client_version_iip).get_as_int();
+    if (uploaded_version == current_client_version)
+        return;
+
+    BinaryColumn changesets(db.get_alloc());
+    changesets.init_from_ref(root.get_as_ref(s_changesets_iip));
+    IntegerBpTree origin_file_idents(db.get_alloc());
+    origin_file_idents.init_from_ref(root.get_as_ref(s_origin_file_idents_iip));
+
+    // `base_version` is the oldest version we have history for. If this is
+    // greater than uploaded_version, all of the versions in between the two had
+    // empty changesets and did not need to be uploaded. If this is less than
+    // uploaded_version, we have changesets which have been uploaded but the
+    // server has not yet told us we can delete and we may need to use for merging.
+    auto base_version = current_client_version - changesets.size();
+    if (uploaded_version < base_version) {
+        uploaded_version = base_version;
+    }
+
+    auto count = size_t(current_client_version - uploaded_version);
+    for (size_t i = changesets.size() - count; i < changesets.size(); ++i) {
+        if (origin_file_idents.get(i) == 0) {
+            size_t pos = 0;
+            if (changesets.get_at(i, pos).size() != 0)
+                break;
+        }
+        ++uploaded_version;
     }
 }
 
-void ClientHistory::get_upload_download_bytes(DB* db, std::uint_fast64_t& downloaded_bytes,
+void ClientHistory::get_upload_download_state(DB* db, std::uint_fast64_t& downloaded_bytes,
                                               std::uint_fast64_t& uploaded_bytes)
 {
     TransactionRef rt = db->start_read(); // Throws
@@ -711,7 +743,7 @@ auto ClientHistory::find_sync_history_entry(Arrays& arrays, version_type base_ve
         bool not_from_server = (origin_file_ident == 0);
         if (not_from_server) {
             ChunkedBinaryData chunked_changeset(arrays.changesets, offset + i);
-            if (chunked_changeset.size() > 0) {
+            if (!chunked_changeset.empty()) {
                 entry.origin_file_ident = file_ident_type(origin_file_ident);
                 entry.remote_version = last_integrated_server_version;
                 entry.origin_timestamp = timestamp_type(arrays.origin_timestamps.get(offset + i));
@@ -845,8 +877,7 @@ void ClientHistory::add_sync_history_entry(const HistoryEntry& entry)
 }
 
 
-void ClientHistory::update_sync_progress(const SyncProgress& progress, DownloadableProgress downloadable_bytes,
-                                         TransactionRef)
+void ClientHistory::update_sync_progress(const SyncProgress& progress, DownloadableProgress downloadable_bytes)
 {
     Array& root = m_arrays->root;
 

--- a/src/realm/sync/noinst/client_history_impl.hpp
+++ b/src/realm/sync/noinst/client_history_impl.hpp
@@ -254,9 +254,9 @@ public:
         util::Logger&, const TransactionRef& transact,
         util::UniqueFunction<void(const TransactionRef&, util::Span<Changeset>)> run_in_write_tr = nullptr);
 
-    static void get_upload_download_bytes(DB*, std::uint_fast64_t&, DownloadableProgress&, std::uint_fast64_t&,
-                                          std::uint_fast64_t&, std::uint_fast64_t&);
-    static void get_upload_download_bytes(DB*, std::uint_fast64_t&, std::uint_fast64_t&);
+    static void get_upload_download_state(DB&, std::uint_fast64_t&, DownloadableProgress&, std::uint_fast64_t&,
+                                          std::uint_fast64_t&, std::uint_fast64_t&, version_type&);
+    static void get_upload_download_state(DB*, std::uint_fast64_t&, std::uint_fast64_t&);
 
     // Overriding member functions in realm::TransformHistory
     version_type find_history_entry(version_type, version_type, HistoryEntry&) const noexcept override;
@@ -411,7 +411,7 @@ private:
     void prepare_for_write();
     Replication::version_type add_changeset(BinaryData changeset, BinaryData sync_changeset);
     void add_sync_history_entry(const HistoryEntry&);
-    void update_sync_progress(const SyncProgress&, DownloadableProgress downloadable_bytes, TransactionRef);
+    void update_sync_progress(const SyncProgress&, DownloadableProgress downloadable_bytes);
     void trim_ct_history();
     void trim_sync_history();
     void do_trim_sync_history(std::size_t n);

--- a/test/object-store/sync/flx_sync.cpp
+++ b/test/object-store/sync/flx_sync.cpp
@@ -730,6 +730,7 @@ TEST_CASE("flx: client reset", "[sync][flx][client reset][baas]") {
                 REQUIRE(mode == ClientResyncMode::Recover);
                 auto subs = local_realm->get_latest_subscription_set();
                 subs.get_state_change_notification(sync::SubscriptionSet::State::Complete).get();
+                subs.refresh();
                 // make sure that the subscription for "foo" survived the reset
                 size_t count_of_foo = count_queries_with_str(subs, util::format("\"%1\"", str_field_value));
                 REQUIRE(subs.state() == sync::SubscriptionSet::State::Complete);

--- a/test/object-store/util/sync/sync_test_utils.cpp
+++ b/test/object-store/util/sync/sync_test_utils.cpp
@@ -745,7 +745,7 @@ struct BaasFLXClientReset : public TestClientReset {
         if (m_on_post_local) {
             m_on_post_local(realm);
         }
-        wait_for_upload(*realm);
+        wait_for_download(*realm);
         if (m_on_post_reset) {
             m_on_post_reset(realm);
         }

--- a/test/test_client_reset.cpp
+++ b/test/test_client_reset.cpp
@@ -1494,13 +1494,16 @@ TEST(ClientReset_Recover_UploadableBytes)
     auto& history = static_cast<ClientReplication*>(db->get_replication())->get_history();
     uint_fast64_t unused, pre_reset_uploadable_bytes;
     DownloadableProgress unused_progress;
-    history.get_upload_download_bytes(db.get(), unused, unused_progress, unused, pre_reset_uploadable_bytes, unused);
+    version_type unused_version;
+    history.get_upload_download_state(*db, unused, unused_progress, unused, pre_reset_uploadable_bytes, unused,
+                                      unused_version);
     CHECK_GREATER(pre_reset_uploadable_bytes, 0);
 
     expect_reset(test_context, db, db_fresh, ClientResyncMode::Recover, nullptr);
 
     uint_fast64_t post_reset_uploadable_bytes;
-    history.get_upload_download_bytes(db.get(), unused, unused_progress, unused, post_reset_uploadable_bytes, unused);
+    history.get_upload_download_state(*db, unused, unused_progress, unused, post_reset_uploadable_bytes, unused,
+                                      unused_version);
     CHECK_GREATER(post_reset_uploadable_bytes, 0);
     CHECK_GREATER(pre_reset_uploadable_bytes, post_reset_uploadable_bytes);
 }


### PR DESCRIPTION
Rather than tracking a bunch of derived state in-memory, check for upload completion by checking if there are any unuploaded changesets. This is both multiprocess-compatible and is more precise than the old checks, which had some false-negatives and minor inconsistencies. Previously creating local commits which produced empty changesets and then calling wait_for_upload_completion() would complete immediately, but pausing and then resuming the session would make it wait until the new session performed the upload scan, which didn't happen until after download completion.

The synchronous completion waits (which are hopefully only used in tests) are now just thin wrappers around the async waits. This exposed a small inconsistency around when completion happened when the sync client is stopped, which is something we don't expose publicly so changing it should be fine.