### PR TITLE
RCORE-2159 Make async_open_realm() return StatusWith<std::shared_ptr<Realm>>

### DIFF
--- a/test/object-store/sync/flx_migration.cpp
+++ b/test/object-store/sync/flx_migration.cpp
@@ -908,21 +908,16 @@ TEST_CASE("Async open + client reset", "[sync][flx][flx migration][baas]") {
         shared_object.persisted_properties.push_back({"oid_field", PropertyType::ObjectId | PropertyType::Nullable});
         config->schema = {shared_object, locally_added};
 
-        async_open_realm(*config, [&](ThreadSafeReference&& ref, std::exception_ptr error) {
-            REQUIRE(ref);
-            REQUIRE_FALSE(error);
+        auto realm = successfully_async_open_realm(*config);
 
-            auto realm = Realm::get_shared_realm(std::move(ref));
+        auto table = realm->read_group().get_table("class_Object");
+        REQUIRE(table->size() == 0);
+        REQUIRE(num_before_reset_notifications == 1);
+        REQUIRE(num_after_reset_notifications == 1);
 
-            auto table = realm->read_group().get_table("class_Object");
-            REQUIRE(table->size() == 0);
-            REQUIRE(num_before_reset_notifications == 1);
-            REQUIRE(num_after_reset_notifications == 1);
-
-            auto locally_added_table = realm->read_group().get_table("class_LocallyAdded");
-            REQUIRE(locally_added_table);
-            REQUIRE(locally_added_table->size() == 0);
-        });
+        auto locally_added_table = realm->read_group().get_table("class_LocallyAdded");
+        REQUIRE(locally_added_table);
+        REQUIRE(locally_added_table->size() == 0);
     }
 
     SECTION("initial state") {
@@ -941,21 +936,16 @@ TEST_CASE("Async open + client reset", "[sync][flx][flx migration][baas]") {
                 {"oid_field", PropertyType::ObjectId | PropertyType::Nullable});
             config->schema = {shared_object, locally_added};
 
-            async_open_realm(*config, [&](ThreadSafeReference&& ref, std::exception_ptr error) {
-                REQUIRE(ref);
-                REQUIRE_FALSE(error);
+            auto realm = successfully_async_open_realm(*config);
 
-                auto realm = Realm::get_shared_realm(std::move(ref));
+            auto table = realm->read_group().get_table("class_Object");
+            REQUIRE(table->size() == 1);
+            REQUIRE(num_before_reset_notifications == 1);
+            REQUIRE(num_after_reset_notifications == 1);
 
-                auto table = realm->read_group().get_table("class_Object");
-                REQUIRE(table->size() == 1);
-                REQUIRE(num_before_reset_notifications == 1);
-                REQUIRE(num_after_reset_notifications == 1);
-
-                auto locally_added_table = realm->read_group().get_table("class_LocallyAdded");
-                REQUIRE(locally_added_table);
-                REQUIRE(locally_added_table->size() == 0);
-            });
+            auto locally_added_table = realm->read_group().get_table("class_LocallyAdded");
+            REQUIRE(locally_added_table);
+            REQUIRE(locally_added_table->size() == 0);
         }
     }
 }

--- a/test/object-store/util/sync/sync_test_utils.cpp
+++ b/test/object-store/util/sync/sync_test_utils.cpp
@@ -287,26 +287,34 @@ void wait_for_advance(Realm& realm)
     realm.m_binding_context = nullptr;
 }
 
-void async_open_realm(const Realm::Config& config,
-                      util::UniqueFunction<void(ThreadSafeReference&& ref, std::exception_ptr e)> finish)
+StatusWith<std::shared_ptr<Realm>> async_open_realm(const Realm::Config& config)
 {
-    std::mutex mutex;
-    bool did_finish = false;
     auto task = Realm::get_synchronized_realm(config);
-    ThreadSafeReference tsr;
-    std::exception_ptr err = nullptr;
+    auto pf = util::make_promise_future<ThreadSafeReference>();
     task->start([&](ThreadSafeReference&& ref, std::exception_ptr e) {
-        std::lock_guard lock(mutex);
-        did_finish = true;
-        tsr = std::move(ref);
-        err = e;
+        if (e) {
+            try {
+                std::rethrow_exception(e);
+            }
+            catch (...) {
+                pf.promise.set_error(exception_to_status());
+            }
+        }
+        else {
+            pf.promise.emplace_value(std::move(ref));
+        }
     });
-    util::EventLoop::main().run_until([&] {
-        std::lock_guard lock(mutex);
-        return did_finish;
-    });
-    task->cancel(); // don't run the above notifier again on this session
-    finish(std::move(tsr), err);
+    auto sw = std::move(pf.future).get_no_throw();
+    if (sw.is_ok())
+        return Realm::get_shared_realm(std::move(sw.get_value()));
+    return sw.get_status();
+}
+
+std::shared_ptr<Realm> successfully_async_open_realm(const Realm::Config& config)
+{
+    auto status = async_open_realm(config);
+    REQUIRE(status.is_ok());
+    return status.get_value();
 }
 
 #endif // REALM_ENABLE_SYNC

--- a/test/object-store/util/sync/sync_test_utils.hpp
+++ b/test/object-store/util/sync/sync_test_utils.hpp
@@ -164,8 +164,8 @@ std::string get_compile_time_admin_url();
 
 void wait_for_advance(Realm& realm);
 
-void async_open_realm(const Realm::Config& config,
-                      util::UniqueFunction<void(ThreadSafeReference&& ref, std::exception_ptr e)> finish);
+StatusWith<std::shared_ptr<Realm>> async_open_realm(const Realm::Config& config);
+std::shared_ptr<Realm> successfully_async_open_realm(const Realm::Config& config);
 
 app::Response do_http_request(const app::Request& request);
 


### PR DESCRIPTION
This simplifies a lot of test code and seems to fix a case where we were opening a Realm on the wrong thread on Linux, although I'm not entirely sure how that was happening.

Fixes #7793.