### PR TITLE
RCORE-2168: Replicate clear instruction unconditionally for nested collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* You could get unexpected merge results when assigning to a nested collection ([#7809](https://github.com/realm/realm-core/issues/7809), since v14.0.0)
 
 ### Breaking changes
 * None.

--- a/src/realm/dictionary.cpp
+++ b/src/realm/dictionary.cpp
@@ -823,10 +823,12 @@ size_t Dictionary::find_first(Mixed value) const
 
 void Dictionary::clear()
 {
-    if (size() > 0) {
-        if (Replication* repl = get_replication()) {
-            repl->dictionary_clear(*this);
-        }
+    auto sz = size();
+    Replication* repl = Base::get_replication();
+    if (repl && (sz > 0 || !m_col_key.is_collection() || m_level > 1)) {
+        repl->dictionary_clear(*this);
+    }
+    if (sz > 0) {
         CascadeState cascade_state(CascadeState::Mode::Strong);
         bool recurse = remove_backlinks(cascade_state);
 

--- a/src/realm/list.cpp
+++ b/src/realm/list.cpp
@@ -503,10 +503,12 @@ void Lst<Mixed>::remove(size_t from, size_t to)
 
 void Lst<Mixed>::clear()
 {
-    if (size() > 0) {
-        if (Replication* repl = Base::get_replication()) {
-            repl->list_clear(*this);
-        }
+    auto sz = size();
+    Replication* repl = Base::get_replication();
+    if (repl && (sz > 0 || !m_col_key.is_collection() || m_level > 1)) {
+        repl->list_clear(*this);
+    }
+    if (sz > 0) {
         CascadeState state;
         bool recurse = remove_backlinks(state);
 

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -6228,6 +6228,8 @@ TEST(Sync_NestedCollectionClear)
     auto foo = table_1->create_object_with_primary_key(123);
     foo.set_collection(col, CollectionType::List);
     foo.get_list<Mixed>(col_list).insert_collection(0, CollectionType::List);
+    auto foo1 = table_1->create_object_with_primary_key(456);
+    foo1.set_collection(col, CollectionType::Dictionary);
     tr_1->commit_and_continue_as_read();
 
     session_1.wait_for_upload_complete_or_client_stopped();
@@ -6244,6 +6246,10 @@ TEST(Sync_NestedCollectionClear)
         sub_list->clear();
         sub_list->add(1);
         sub_list->add(2);
+
+        auto dict = foo1.get_dictionary("any");
+        dict.clear();
+        dict.insert("age", 42);
 
         auto list_int = foo.get_list<Mixed>("ints");
         list_int.clear();
@@ -6267,6 +6273,11 @@ TEST(Sync_NestedCollectionClear)
         sub_list->add(3);
         sub_list->add(4);
 
+        auto bar1 = table_2->get_object_with_primary_key(456);
+        auto dict = bar1.get_dictionary("any");
+        dict.clear();
+        dict.insert("weight", 70);
+
         auto list_int = bar.get_list<Mixed>("ints");
         list_int.clear();
         list_int.add(3);
@@ -6286,6 +6297,9 @@ TEST(Sync_NestedCollectionClear)
 
     list = foo.get_list<Mixed>("any_list");
     CHECK_EQUAL(list.get_list(0)->size(), 2);
+
+    auto dict = foo1.get_dictionary("any");
+    CHECK_EQUAL(dict.size(), 1);
 
     auto list_int = foo.get_list<Mixed>("ints");
     CHECK_EQUAL(list_int.size(), 4); // We should stille have odd behavior for normal lists

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -6216,8 +6216,6 @@ TEST(Sync_NestedCollectionClear)
     Session session_1 = fixture.make_session(db_1, "/test");
     Session session_2 = fixture.make_session(db_2, "/test");
 
-    Timestamp now{std::chrono::system_clock::now()};
-
     auto tr_1 = db_1->start_write();
     auto tr_2 = db_2->start_read();
     auto table_1 = tr_1->add_table_with_primary_key("class_Table", type_Int, "id");

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -6302,7 +6302,7 @@ TEST(Sync_NestedCollectionClear)
     CHECK_EQUAL(dict.size(), 1);
 
     auto list_int = foo.get_list<Mixed>("ints");
-    CHECK_EQUAL(list_int.size(), 4); // We should stille have odd behavior for normal lists
+    CHECK_EQUAL(list_int.size(), 4); // We should still have odd behavior for normal lists
 
     CHECK(compare_groups(*tr_1, *tr_2));
 }

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -6228,7 +6228,9 @@ TEST(Sync_NestedCollectionClear)
 
     auto foo = table_1->create_object_with_primary_key(123);
     foo.set_collection(col, CollectionType::List);
-    foo.get_list<Mixed>(col_list).insert_collection(0, CollectionType::List);
+    auto parent_list = foo.get_list<Mixed>(col_list);
+    parent_list.insert_collection(0, CollectionType::List);
+    parent_list.insert_collection(1, CollectionType::Dictionary);
     auto foo1 = table_1->create_object_with_primary_key(456);
     foo1.set_collection(col, CollectionType::Dictionary);
     tr_1->commit_and_continue_as_read();
@@ -6247,6 +6249,10 @@ TEST(Sync_NestedCollectionClear)
         sub_list->clear();
         sub_list->add(1);
         sub_list->add(2);
+        auto sub_dict = list.get_dictionary(1);
+        sub_dict->clear();
+        sub_dict->insert("one", 1);
+        sub_dict->insert("two", 2);
 
         auto dict = foo1.get_dictionary("any");
         dict.clear();
@@ -6273,6 +6279,10 @@ TEST(Sync_NestedCollectionClear)
         sub_list->clear();
         sub_list->add(3);
         sub_list->add(4);
+        auto sub_dict = list.get_dictionary(1);
+        sub_dict->clear();
+        sub_dict->insert("three", 3);
+        sub_dict->insert("four", 4);
 
         auto bar1 = table_2->get_object_with_primary_key(456);
         auto dict = bar1.get_dictionary("any");
@@ -6298,6 +6308,7 @@ TEST(Sync_NestedCollectionClear)
 
     list = foo.get_list<Mixed>("any_list");
     CHECK_EQUAL(list.get_list(0)->size(), 2);
+    CHECK_EQUAL(list.get_dictionary(1)->size(), 2);
 
     auto dict = foo1.get_dictionary("any");
     CHECK_EQUAL(dict.size(), 1);


### PR DESCRIPTION
## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- Link to relevant issue this fixes -->
Fixes #7809

This change makes sure that a collection nested in a Mixed type always will contain the values that has been assigned to it by some client. Before this change you could end up having a combination of values assigned by different clients.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [x] C-API, if public C++ API changed
* [x] `bindgen/spec.yml`, if public C++ API changed
