### PR TITLE
No need to have`IntegerCompressor::set_direct`

### DIFF
--- a/src/realm/integer_compressor.cpp
+++ b/src/realm/integer_compressor.cpp
@@ -221,16 +221,6 @@ void IntegerCompressor::get_chunk_flex(const Array& arr, size_t ndx, int64_t res
     FlexCompressor::get_chunk(arr.m_integer_compressor, ndx, res);
 }
 
-void IntegerCompressor::set_packed(Array& arr, size_t ndx, int64_t val)
-{
-    PackedCompressor::set_direct(arr.m_integer_compressor, ndx, val);
-}
-
-void IntegerCompressor::set_flex(Array& arr, size_t ndx, int64_t val)
-{
-    FlexCompressor::set_direct(arr.m_integer_compressor, ndx, val);
-}
-
 template <class Cond>
 bool IntegerCompressor::find_packed(const Array& arr, int64_t val, size_t begin, size_t end, size_t base_index,
                                     QueryStateBase* st)
@@ -250,7 +240,7 @@ void IntegerCompressor::set_vtable(Array& arr)
     static const Array::VTable vtable_packed = {get_packed,
                                                 get_chunk_packed,
                                                 get_all_packed,
-                                                set_packed,
+                                                nullptr,
                                                 {
                                                     find_packed<Equal>,
                                                     find_packed<NotEqual>,
@@ -260,7 +250,7 @@ void IntegerCompressor::set_vtable(Array& arr)
     static const Array::VTable vtable_flex = {get_flex,
                                               get_chunk_flex,
                                               get_all_flex,
-                                              set_flex,
+                                              nullptr,
                                               {
                                                   find_flex<Equal>,
                                                   find_flex<NotEqual>,

--- a/src/realm/integer_compressor.hpp
+++ b/src/realm/integer_compressor.hpp
@@ -70,8 +70,6 @@ private:
 
     static void get_chunk_packed(const Array& arr, size_t ndx, int64_t res[8]);
     static void get_chunk_flex(const Array& arr, size_t ndx, int64_t res[8]);
-    static void set_packed(Array& arr, size_t ndx, int64_t val);
-    static void set_flex(Array& arr, size_t ndx, int64_t val);
     // query interface
     template <class Cond>
     static bool find_packed(const Array& arr, int64_t val, size_t begin, size_t end, size_t base_index,

--- a/src/realm/integer_flex_compressor.hpp
+++ b/src/realm/integer_flex_compressor.hpp
@@ -40,7 +40,6 @@ public:
     static int64_t get(const IntegerCompressor&, size_t);
     static std::vector<int64_t> get_all(const IntegerCompressor&, size_t, size_t);
     static void get_chunk(const IntegerCompressor&, size_t, int64_t[8]);
-    static void set_direct(const IntegerCompressor&, size_t, int64_t);
 
     template <typename Cond>
     static bool find_all(const Array&, int64_t, size_t, size_t, size_t, QueryStateBase*);
@@ -140,17 +139,6 @@ inline void FlexCompressor::get_chunk(const IntegerCompressor& c, size_t ndx, in
     for (; index < 8; ++index) {
         res[index++] = get(c, i++);
     }
-}
-
-inline void FlexCompressor::set_direct(const IntegerCompressor& c, size_t ndx, int64_t value)
-{
-    const auto offset = c.v_width() * c.v_size();
-    const auto ndx_w = c.ndx_width();
-    const auto v_w = c.v_width();
-    const auto data = c.data();
-    BfIterator ndx_iterator{data, offset, ndx_w, ndx_w, ndx};
-    BfIterator data_iterator{data, 0, v_w, v_w, static_cast<size_t>(*ndx_iterator)};
-    data_iterator.set_value(value);
 }
 
 template <typename T>

--- a/src/realm/integer_packed_compressor.hpp
+++ b/src/realm/integer_packed_compressor.hpp
@@ -40,7 +40,6 @@ public:
     static int64_t get(const IntegerCompressor&, size_t);
     static std::vector<int64_t> get_all(const IntegerCompressor& c, size_t b, size_t e);
     static void get_chunk(const IntegerCompressor&, size_t, int64_t res[8]);
-    static void set_direct(const IntegerCompressor&, size_t, int64_t);
 
     template <typename Cond>
     static bool find_all(const Array&, int64_t, size_t, size_t, size_t, QueryStateBase*);
@@ -98,12 +97,6 @@ inline std::vector<int64_t> PackedCompressor::get_all(const IntegerCompressor& c
         }
     }
     return res;
-}
-
-inline void PackedCompressor::set_direct(const IntegerCompressor& c, size_t ndx, int64_t value)
-{
-    BfIterator it{c.data(), 0, c.v_width(), c.v_width(), ndx};
-    it.set_value(value);
 }
 
 inline void PackedCompressor::get_chunk(const IntegerCompressor& c, size_t ndx, int64_t res[8])


### PR DESCRIPTION
## What, How & Why?
We can never call `set_direct` or in general set a value in a compressed array, because every change to any array is done after `copy_on_write()` (which decompresses the array)

