### PR TITLE
RCORE-2172 Fix race condition in "unregister connection change listener" test while listener is being unregistered

### DIFF
--- a/test/object-store/sync/session/connection_change_notifications.cpp
+++ b/test/object-store/sync/session/connection_change_notifications.cpp
@@ -83,7 +83,7 @@ TEST_CASE("sync: Connection state changes", "[sync][session][connection change]"
         REQUIRE(sessions_are_disconnected(*session));
         // ensure callback 1 was not called anymore
         REQUIRE(listener1_call_cnt == listener1_called);
-        REQUIRE(listener2_called == true);
+        REQUIRE(listener2_called);
     }
 
     SECTION("unregister connection change listener during callback") {
@@ -112,6 +112,6 @@ TEST_CASE("sync: Connection state changes", "[sync][session][connection change]"
         user->log_out();
         REQUIRE(sessions_are_disconnected(*session));
         REQUIRE(listener1_call_cnt == 1); // Only called once before unregister
-        REQUIRE(listener2_called == true);
+        REQUIRE(listener2_called);
     }
 }

--- a/test/object-store/sync/session/connection_change_notifications.cpp
+++ b/test/object-store/sync/session/connection_change_notifications.cpp
@@ -54,11 +54,44 @@ TEST_CASE("sync: Connection state changes", "[sync][session][connection change]"
     }
 
     SECTION("unregister connection change listener") {
+        auto session = sync_session(
+            user, "/connection-state-changes-2", [](auto, auto) {}, SyncSessionStopPolicy::AfterChangesUploaded);
+
+        EventLoop::main().run_until([&] {
+            return sessions_are_active(*session);
+        });
+        EventLoop::main().run_until([&] {
+            return sessions_are_connected(*session);
+        });
+
+        std::atomic<size_t> listener1_call_cnt(0);
+        std::atomic<bool> listener2_called(false);
+
+        auto token1 = session->register_connection_change_callback(
+            [&](SyncSession::ConnectionState, SyncSession::ConnectionState) {
+                listener1_call_cnt = listener1_call_cnt + 1;
+            });
+        session->unregister_connection_change_callback(token1);
+        // One call may have been in progress when unregistered
+        REQUIRE(listener1_call_cnt <= 1);
+        size_t listener1_called = listener1_call_cnt;
+
+        session->register_connection_change_callback([&](SyncSession::ConnectionState, SyncSession::ConnectionState) {
+            listener2_called = true;
+        });
+        user->log_out();
+        REQUIRE(sessions_are_disconnected(*session));
+        // ensure callback 1 was not called anymore
+        REQUIRE(listener1_call_cnt == listener1_called);
+        REQUIRE(listener2_called == true);
+    }
+
+    SECTION("unregister connection change listener during callback") {
         uint64_t token1;
         std::atomic<int> listener1_call_cnt(0);
         std::atomic<bool> listener2_called(false);
         auto session = sync_session(
-            user, "/connection-state-changes-2", [](auto, auto) {}, SyncSessionStopPolicy::AfterChangesUploaded);
+            user, "/connection-state-changes-3", [](auto, auto) {}, SyncSessionStopPolicy::AfterChangesUploaded);
         token1 = session->register_connection_change_callback(
             [&](SyncSession::ConnectionState, SyncSession::ConnectionState) {
                 listener1_call_cnt = listener1_call_cnt + 1;
@@ -78,7 +111,7 @@ TEST_CASE("sync: Connection state changes", "[sync][session][connection change]"
 
         user->log_out();
         REQUIRE(sessions_are_disconnected(*session));
-        REQUIRE(listener1_call_cnt == 1);
+        REQUIRE(listener1_call_cnt == 1); // Only called once before unregister
         REQUIRE(listener2_called == true);
     }
 }


### PR DESCRIPTION
## What, How & Why?
Updated the "unregister connection change listener" so it registers a callback when the session is first created and unregisters the callback when it is called the first time. There is a call count variable that is updated every time this callback is called and verified that it is only called one time during the test.

Fixes #7823 

## ☑️ ToDos
* ~~[ ] 📝 Changelog update~~
* [X] 🚦 Tests (or not relevant)
* ~~[ ] C-API, if public C++ API changed~~
* ~~[ ] `bindgen/spec.yml`, if public C++ API changed~~
