### PR TITLE
RCORE-2174 Bootstrap store is not being reset if initial subscription bootstrap is interrupted by role change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* Fix data from a previous interrupted bootstrap was potentially being included with the bootstrap data during retry attempt
-  and complete bootstraps were potentially not being applied if the session restarted once fully downloaded. ([#7827](https://github.com/realm/realm-core/issues/7827), since 14.8.0)
 * `DB::compact()` on an encrypted Realm without explicitly specifying a new encryption key would only work if the old key happened to be a valid nul-terminated string ([#7842](https://github.com/realm/realm-core/issues/7842), since v14.10.0).
+* If a sync session is interrupted by a disconnect or restart while downloading a bootstrap, stale data from the previous
+  bootstrap may be included when the session reconnects and downloads the bootstrap. This can lead to objects stored in
+  the database that do not match the actual state of the server and potentially leading to compensating writes.
+  ([#7827](https://github.com/realm/realm-core/issues/7827), since v12.0.0)
 
 ### Breaking changes
 * None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Fix pending bootstrap store was not applying a pending bootstrap or clearing a partial bootstrap when the session is restarted. ([#7827](https://github.com/realm/realm-core/issues/7827), since 14.8.0)
 
 ### Breaking changes
 * None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,7 @@
 * Fixed removing backlinks from the wrong objects if the link came from a nested list, nested dictionary, top-level dictionary, or list of mixed, and the source table had more than 256 objects. This could manifest as `array_backlink.cpp:112: Assertion failed: int64_t(value >> 1) == key.value` when removing an object. ([#7594](https://github.com/realm/realm-core/issues/7594), since v11 for dictionaries)
 * Fixed the collapse/rejoin of clusters which contained nested collections with links. This could manifest as `array.cpp:319: Array::move() Assertion failed: begin <= end [2, 1]` when removing an object. ([#7839](https://github.com/realm/realm-core/issues/7839), since the introduction of nested collections in v14.0.0-beta.0)
 * wait_for_upload_completion() was inconsistent in how it handled commits which did not produce any changesets to upload. Previously it would sometimes complete immediately if all commits waiting to be uploaded were empty, and at other times it would wait for a server roundtrip. It will now always complete immediately. ([PR #7796](https://github.com/realm/realm-core/pull/7796)).
-* If a sync session is interrupted by a disconnect or restart while downloading a bootstrap, stale data from the previous
-  bootstrap may be included when the session reconnects and downloads the bootstrap. This can lead to objects stored in
-  the database that do not match the actual state of the server and potentially leading to compensating writes.
-  ([#7827](https://github.com/realm/realm-core/issues/7827), since v12.0.0)
+* If a sync session is interrupted by a disconnect or restart while downloading a bootstrap, stale data from the previous bootstrap may be included when the session reconnects and downloads the bootstrap. This can lead to objects stored in the database that do not match the actual state of the server and potentially leading to compensating writes. ([#7827](https://github.com/realm/realm-core/issues/7827), since v12.0.0)
 
 ### Breaking changes
 * None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* Fix pending bootstrap store was not applying a pending bootstrap or clearing a partial bootstrap when the session is restarted. ([#7827](https://github.com/realm/realm-core/issues/7827), since 14.8.0)
+* Fix data from a previous interrupted bootstrap was potentially being included with the bootstrap data during retry attempt
+  and complete bootstraps were potentially not being applied if the session restarted once fully downloaded. ([#7827](https://github.com/realm/realm-core/issues/7827), since 14.8.0)
 
 ### Breaking changes
 * None.

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -869,8 +869,6 @@ void SessionImpl::process_pending_flx_bootstrap()
     if (!m_is_flx_sync_session || m_state != State::Active) {
         return;
     }
-    // Should never be called if session is not active
-    REALM_ASSERT_EX(m_state == SessionImpl::Active, m_state);
     auto bootstrap_store = m_wrapper.get_flx_pending_bootstrap_store();
     if (!bootstrap_store->has_pending()) {
         return;

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -850,7 +850,7 @@ bool SessionImpl::process_flx_bootstrap_message(const SyncProgress& progress, Do
     }
 
     try {
-        process_pending_flx_bootstrap();
+        process_pending_flx_bootstrap(); // throws
     }
     catch (const IntegrationException& e) {
         on_integration_failure(e);

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -1524,10 +1524,18 @@ void Session::cancel_resumption_delay()
 
     logger.debug("Resumed"); // Throws
 
-    process_pending_flx_bootstrap();
-
     if (unbind_process_complete())
         initiate_rebind(); // Throws
+
+    try {
+        process_pending_flx_bootstrap(); // throws
+    }
+    catch (const IntegrationException& error) {
+        on_integration_failure(error);
+    }
+    catch (...) {
+        on_integration_failure(IntegrationException(exception_to_status()));
+    }
 
     m_conn.one_more_active_unsuspended_session(); // Throws
     if (m_try_again_activation_timer) {
@@ -1735,7 +1743,7 @@ void Session::activate()
     m_conn.one_more_active_unsuspended_session(); // Throws
 
     try {
-        process_pending_flx_bootstrap();
+        process_pending_flx_bootstrap(); // throws
     }
     catch (const IntegrationException& error) {
         on_integration_failure(error);

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -1524,6 +1524,8 @@ void Session::cancel_resumption_delay()
 
     logger.debug("Resumed"); // Throws
 
+    process_pending_flx_bootstrap();
+
     if (unbind_process_complete())
         initiate_rebind(); // Throws
 

--- a/src/realm/sync/noinst/client_impl_base.hpp
+++ b/src/realm/sync/noinst/client_impl_base.hpp
@@ -1550,16 +1550,17 @@ inline void ClientImpl::Session::initiate_rebind()
 inline void ClientImpl::Session::reset_protocol_state() noexcept
 {
     // clang-format off
-    m_enlisted_to_send                 = false;
-    m_bind_message_sent                = false;
-    m_error_to_send                    = false;
-    m_ident_message_sent               = false;
-    m_unbind_message_sent              = false;
-    m_unbind_message_send_complete     = false;
-    m_error_message_received           = false;
-    m_unbound_message_received         = false;
-    m_client_error                     = util::none;
-    m_upload_progress                  = m_progress.upload;
+    m_enlisted_to_send                    = false;
+    m_bind_message_sent                   = false;
+    m_error_to_send                       = false;
+    m_ident_message_sent = false;
+    m_unbind_message_sent = false;
+    m_unbind_message_send_complete = false;
+    m_error_message_received = false;
+    m_unbound_message_received = false;
+    m_client_error = util::none;
+
+    m_upload_progress = m_progress.upload;
     m_last_version_selected_for_upload = m_upload_progress.client_version;
     m_last_download_mark_sent          = m_last_download_mark_received;
     // clang-format on

--- a/src/realm/sync/noinst/client_impl_base.hpp
+++ b/src/realm/sync/noinst/client_impl_base.hpp
@@ -1550,17 +1550,16 @@ inline void ClientImpl::Session::initiate_rebind()
 inline void ClientImpl::Session::reset_protocol_state() noexcept
 {
     // clang-format off
-    m_enlisted_to_send                    = false;
-    m_bind_message_sent                   = false;
-    m_error_to_send                       = false;
-    m_ident_message_sent = false;
-    m_unbind_message_sent = false;
-    m_unbind_message_send_complete = false;
-    m_error_message_received = false;
-    m_unbound_message_received = false;
-    m_client_error = util::none;
-
-    m_upload_progress = m_progress.upload;
+    m_enlisted_to_send                 = false;
+    m_bind_message_sent                = false;
+    m_error_to_send                    = false;
+    m_ident_message_sent               = false;
+    m_unbind_message_sent              = false;
+    m_unbind_message_send_complete     = false;
+    m_error_message_received           = false;
+    m_unbound_message_received         = false;
+    m_client_error                     = util::none;
+    m_upload_progress                  = m_progress.upload;
     m_last_version_selected_for_upload = m_upload_progress.client_version;
     m_last_download_mark_sent          = m_last_download_mark_received;
     // clang-format on

--- a/test/object-store/sync/flx_role_change.cpp
+++ b/test/object-store/sync/flx_role_change.cpp
@@ -776,9 +776,8 @@ TEST_CASE("flx: role changes during bootstrap complete successfully", "[sync][fl
     }
     SECTION("Role change during subscription bootstrap") {
         auto realm_1 = Realm::get_shared_realm(config);
-        /// TODO: update to:
-        ///       bool initial_subscription = GENERATE(false, true);
-        bool initial_subscription = true;
+        bool initial_subscription = GENERATE(false, true);
+
         if (initial_subscription) {
             auto table = realm_1->read_group().get_table("class_Person");
             auto role_col = table->get_column_key("role");
@@ -802,9 +801,10 @@ TEST_CASE("flx: role changes during bootstrap complete successfully", "[sync][fl
         // The test will update the rule to change access from all records to only the employee
         // records while a new subscription for all Person entries is being bootstrapped.
         update_role(default_rule, {{"role", "employee"}});
+
+        // Set up a new bootstrap while offline
         realm_1->sync_session()->shutdown_and_wait();
         {
-            // Set up a new bootstrap while offline
             auto table = realm_1->read_group().get_table("class_Person");
             auto new_subs = realm_1->get_latest_subscription_set().make_mutable_copy();
             new_subs.clear();


### PR DESCRIPTION
## What, How & Why?
It was discovered during testing of role changes while the realm is currently downloading a bootstrap, that the pending bootstrap store is not being reset when the session reconnects after the 200 error is received from the server due to the role change.
This issue is likely related to #7707 where the bootstrap is not being applied if it has been completely downloaded when the connection (and possibly session) are restarted.

Fixes #7827 

## ☑️ ToDos
* [X] 📝 Changelog update
* [X] 🚦 Tests (or not relevant)
* ~~[ ] C-API, if public C++ API changed~~
* ~~[ ] `bindgen/spec.yml`, if public C++ API changed~~