### PR TITLE
Remove mention of --link-depth in realm2json.cpp

### DIFF
--- a/src/realm/exec/realm2json.cpp
+++ b/src/realm/exec/realm2json.cpp
@@ -4,12 +4,10 @@
 
 const char* legend =
     "Simple tool to output the JSON representation of a Realm:\n"
-    "  realm2json [--link-depth N] [--output-mode N] <.realm file>\n"
+    "  realm2json [--output-mode N] <.realm file>\n"
     "\n"
     "Options:\n"
     " --schema: Just output the schema of the realm\n"
-    " --link-depth: How deep to traverse linking objects (use -1 for infinite). See test_json.cpp "
-    "for more details. Defaults to 0.\n"
     " --output-mode: Optional formatting for the output \n"
     "      0 - JSON Object\n"
     "      1 - MongoDB Extended JSON (XJSON)\n"


### PR DESCRIPTION
## What, How & Why?

Handling link depth and `--link-depth` was removed in v14.0.0 or specifically 9169fa1c9ae32b8317a7239ffd436d8287759947.
From changes in test_json.cpp it looks like it now defaults to 0, is it worth explaining the change in the tool?

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed
* [ ] `bindgen/spec.yml`, if public C++ API changed
