### PR TITLE
Building for Windows using C++20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * Fixed `Table::remove_object_recursive` which wouldn't recursively follow links through a single `Mixed` property. This feature is exposed publicly on `Table` but no SDK currently uses it, so this is considered internal. ([#7829](https://github.com/realm/realm-core/issues/7829), likely since the introduction of Mixed)
 * Upload completion is now tracked in a multiprocess-compatible manner ([PR #7796](https://github.com/realm/realm-core/pull/7796)).
 * The local realm will assume the the client file ident of the fresh realm during a client reset. ([PR #7850](https://github.com/realm/realm-core/pull/7850))
+* Building using C++20 on Windows.
 
 ----------------------------------------------
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,6 +129,9 @@ if(MSVC)
     # We use these in our AtomicSharedPtr implementation and it can't move
     # to atomic<shared_ptr<T>> because NotificationToken relies on movability.
     add_compile_options(/D_SILENCE_CXX20_OLD_SHARED_PTR_ATOMIC_SUPPORT_DEPRECATION_WARNING)
+
+    # Enable __cplusplus macro
+    add_compile_options(/Zc:__cplusplus)
 else()
     add_compile_options(-Wall -Wextra -Wempty-body -Wparentheses -Wunknown-pragmas -Wunreachable-code -Wunused-parameter -Wno-missing-field-initializers)
     # TODO: Remove this when fixed

--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -430,7 +430,7 @@ functions:
       script: |-
         if ls crash-*> /dev/null 2>&1; then
           echo "Found crash file"
-          #Rename the crash file and the realm file. 
+          #Rename the crash file and the realm file.
           #If there is a crash, this will signal that something needs to be uploaded.
           mv crash-* realm-fuzzer-crash.txt
           mv fuzz-realm.realm fuzzer_realm.realm
@@ -459,7 +459,7 @@ functions:
       bucket: mciuploads
       permissions: public-read
       content_type: application/x-binary
-      display_name: Realm File 
+      display_name: Realm File
       optional: true
 
   - command: shell.exec
@@ -515,7 +515,7 @@ functions:
         set -o verbose
 
         TOP_DIR=$(pwd)
-        
+
         HANG_ANALYZER_PATH=$TOP_DIR/evergreen/hang_analyzer
         REQUIREMENTS_PATH=$HANG_ANALYZER_PATH/requirements.txt
 
@@ -1166,7 +1166,7 @@ tasks:
             ./build/test/${cmake_build_type|Debug}-iphonesimulator/realm-combined-tests.app \
             'io.realm.CombinedTests' \
             $TEST_RESULTS_FILE
- 
+
 - name: generate-sync-corpus
   tags: [ "for_nightly_tests" ]
   exec_timeout_secs: 1800
@@ -1393,6 +1393,19 @@ buildvariants:
   - name: compile_test
   - name: lint
 
+- name: ubuntu-cpp20
+  display_name: "Ubuntu C++20"
+  run_on: ubuntu2404-arm64-large
+  expansions:
+    fetch_missing_dependencies: On
+    c_compiler: "/opt/clang+llvm/bin/clang"
+    cxx_compiler: "/opt/clang+llvm/bin/clang++"
+    clang_format: "/opt/clang+llvm/bin/clang-format"
+    extra_flags: -DCMAKE_CXX_STANDARD=20
+  tasks:
+  - name: compile_test
+  - name: lint
+
 - name: ubuntu-no-session-multiplexing
   display_name: "Ubuntu (Sync Multiplexing Disabled)"
   run_on: ubuntu2204-arm64-large
@@ -1469,7 +1482,7 @@ buildvariants:
     fetch_missing_dependencies: On
     c_compiler: "/opt/clang+llvm/bin/clang"
     cxx_compiler: "/opt/clang+llvm/bin/clang++"
-    run_with_encryption: 1 
+    run_with_encryption: 1
     enable_asan: On
     cmake_build_type: RelWithDebInfo
   tasks:
@@ -1492,7 +1505,7 @@ buildvariants:
     cxx_compiler: "./clang_binaries/bin/clang++"
     python3: /opt/mongodbtoolchain/v3/bin/python3
   tasks:
-  - name: compile_test_and_package 
+  - name: compile_test_and_package
   - name: benchmarks
   - name: generate-sync-corpus
 
@@ -1979,5 +1992,3 @@ buildvariants:
 #     no_tests: On
 #   tasks:
 #   - name: compile_only
-
-

--- a/src/external/bson/bson-decimal128.c
+++ b/src/external/bson/bson-decimal128.c
@@ -374,7 +374,7 @@ _mul_64x64 (uint64_t left,                 /* IN */
  * Returns:
  *    The lowercased character.
  */
-char
+static char
 _dec128_tolower (char c)
 {
    if (isupper (c)) {
@@ -395,7 +395,7 @@ _dec128_tolower (char c)
  * Returns:
  *    true if the strings are equal, false otherwise.
  */
-bool
+static bool
 _dec128_istreq (const char *a, /* IN */
                 const char *b /* IN */)
 {

--- a/src/external/bson/bson-iter.c
+++ b/src/external/bson/bson-iter.c
@@ -631,7 +631,7 @@ fill_data_fields:
       subtype = *(iter->raw + iter->d2);
 
       if (subtype == BSON_SUBTYPE_BINARY_DEPRECATED) {
-         int32_t binary_len;
+         uint32_t binary_len;
 
          if (l < 4) {
             iter->err_off = o;

--- a/src/realm/util/file.cpp
+++ b/src/realm/util/file.cpp
@@ -378,7 +378,7 @@ std::string make_temp_file(const char* prefix)
         throw SystemError(error, get_last_error_msg("GetTempFileName() failed: ", error));
     }
 
-#ifdef __cplusplus < 202002L
+#if __cplusplus < 202002L
     return std::filesystem::path(buffer).u8string();
 #else
     return std::filesystem::path(buffer).string();
@@ -1581,7 +1581,7 @@ std::string File::get_path() const
 std::string File::resolve(const std::string& path, const std::string& base_dir)
 {
 #if REALM_HAVE_STD_FILESYSTEM
-#ifdef __cplusplus < 202002L
+#if __cplusplus < 202002L
     return (u8path(base_dir) / u8path(path)).lexically_normal().u8string();
 #else
     return (u8path(base_dir) / u8path(path)).lexically_normal().string();
@@ -1627,7 +1627,7 @@ std::string File::resolve(const std::string& path, const std::string& base_dir)
 std::string File::parent_dir(const std::string& path)
 {
 #if REALM_HAVE_STD_FILESYSTEM
-#ifdef __cplusplus < 202002L
+#if __cplusplus < 202002L
     return u8path(path).parent_path().u8string(); // Throws
 #else
     return u8path(path).parent_path().string(); // Throws
@@ -1880,7 +1880,7 @@ bool DirScanner::next(std::string& name)
     const std::filesystem::directory_iterator end;
     if (m_iterator == end)
         return false;
-#ifdef __cplusplus < 202002L
+#if __cplusplus < 202002L
     name = m_iterator->path().filename().u8string();
 #else
     name = m_iterator->path().filename().string();

--- a/src/realm/util/file.cpp
+++ b/src/realm/util/file.cpp
@@ -128,7 +128,22 @@ struct WindowsFileHandleHolder {
 #endif
 
 #if REALM_HAVE_STD_FILESYSTEM
+#if __cplusplus < 202002L
 using std::filesystem::u8path;
+inline std::string path_to_string(const std::filesystem::path& path)
+{
+    return path.u8string();
+}
+#else
+inline std::string path_to_string(const std::filesystem::path& path)
+{
+    return reinterpret_cast<const char*>(path.u8string().c_str());
+}
+inline auto u8path(const std::string& str)
+{
+    return std::filesystem::path(reinterpret_cast<const char8_t*>(str.c_str()));
+};
+#endif
 
 void throwIfCreateDirectoryError(std::error_code error, const std::string& path)
 {
@@ -340,11 +355,7 @@ std::string make_temp_dir()
         }
         break;
     }
-#if __cplusplus < 202002L
-    return path.u8string();
-#else
-    return path.string();
-#endif
+    return path_to_string(path);
 
 #else // POSIX.1-2008 version
 
@@ -378,11 +389,7 @@ std::string make_temp_file(const char* prefix)
         throw SystemError(error, get_last_error_msg("GetTempFileName() failed: ", error));
     }
 
-#if __cplusplus < 202002L
-    return std::filesystem::path(buffer).u8string();
-#else
-    return std::filesystem::path(buffer).string();
-#endif
+    return path_to_string(std::filesystem::path(buffer));
 
 #else // POSIX.1-2008 version
 
@@ -1581,11 +1588,7 @@ std::string File::get_path() const
 std::string File::resolve(const std::string& path, const std::string& base_dir)
 {
 #if REALM_HAVE_STD_FILESYSTEM
-#if __cplusplus < 202002L
-    return (u8path(base_dir) / u8path(path)).lexically_normal().u8string();
-#else
-    return (u8path(base_dir) / u8path(path)).lexically_normal().string();
-#endif
+    return path_to_string((u8path(base_dir) / u8path(path)).lexically_normal());
 #else
     char dir_sep = '/';
     std::string path_2 = path;
@@ -1627,11 +1630,7 @@ std::string File::resolve(const std::string& path, const std::string& base_dir)
 std::string File::parent_dir(const std::string& path)
 {
 #if REALM_HAVE_STD_FILESYSTEM
-#if __cplusplus < 202002L
-    return u8path(path).parent_path().u8string(); // Throws
-#else
-    return u8path(path).parent_path().string(); // Throws
-#endif
+    return path_to_string(u8path(path).parent_path()); // Throws
 #else
     auto is_sep = [](char c) -> bool {
         return c == '/' || c == '\\';
@@ -1880,11 +1879,7 @@ bool DirScanner::next(std::string& name)
     const std::filesystem::directory_iterator end;
     if (m_iterator == end)
         return false;
-#if __cplusplus < 202002L
-    name = m_iterator->path().filename().u8string();
-#else
-    name = m_iterator->path().filename().string();
-#endif
+    name = path_to_string(m_iterator->path().filename());
     m_iterator++;
     return true;
 }

--- a/src/realm/util/file.cpp
+++ b/src/realm/util/file.cpp
@@ -340,7 +340,11 @@ std::string make_temp_dir()
         }
         break;
     }
+#if __cplusplus < 202002L
     return path.u8string();
+#else
+    return path.string();
+#endif
 
 #else // POSIX.1-2008 version
 
@@ -374,7 +378,11 @@ std::string make_temp_file(const char* prefix)
         throw SystemError(error, get_last_error_msg("GetTempFileName() failed: ", error));
     }
 
+#ifdef __cplusplus < 202002L
     return std::filesystem::path(buffer).u8string();
+#else
+    return std::filesystem::path(buffer).string();
+#endif
 
 #else // POSIX.1-2008 version
 
@@ -1573,7 +1581,11 @@ std::string File::get_path() const
 std::string File::resolve(const std::string& path, const std::string& base_dir)
 {
 #if REALM_HAVE_STD_FILESYSTEM
+#ifdef __cplusplus < 202002L
     return (u8path(base_dir) / u8path(path)).lexically_normal().u8string();
+#else
+    return (u8path(base_dir) / u8path(path)).lexically_normal().string();
+#endif
 #else
     char dir_sep = '/';
     std::string path_2 = path;
@@ -1615,7 +1627,11 @@ std::string File::resolve(const std::string& path, const std::string& base_dir)
 std::string File::parent_dir(const std::string& path)
 {
 #if REALM_HAVE_STD_FILESYSTEM
+#ifdef __cplusplus < 202002L
     return u8path(path).parent_path().u8string(); // Throws
+#else
+    return u8path(path).parent_path().string(); // Throws
+#endif
 #else
     auto is_sep = [](char c) -> bool {
         return c == '/' || c == '\\';
@@ -1864,7 +1880,11 @@ bool DirScanner::next(std::string& name)
     const std::filesystem::directory_iterator end;
     if (m_iterator == end)
         return false;
+#ifdef __cplusplus < 202002L
     name = m_iterator->path().filename().u8string();
+#else
+    name = m_iterator->path().filename().string();
+#endif
     m_iterator++;
     return true;
 }

--- a/test/benchmark-common-tasks/main.cpp
+++ b/test/benchmark-common-tasks/main.cpp
@@ -581,7 +581,7 @@ template <typename Type>
 struct BenchmarkMixedCaseInsensitiveEqual : public BenchmarkWithType<Type> {
     using Base = BenchmarkWithType<Type>;
     using underlying_type = typename Type::underlying_type;
-    BenchmarkMixedCaseInsensitiveEqual<Type>()
+    BenchmarkMixedCaseInsensitiveEqual()
         : BenchmarkWithType<Type>()
     {
         BenchmarkWithType<Type>::set_name_with_prefix("QueryInsensitiveEqual");
@@ -610,7 +610,7 @@ template <typename Type>
 struct BenchmarkRangeForType : public BenchmarkWithType<Type> {
     using Base = BenchmarkWithType<Type>;
     using underlying_type = typename Type::underlying_type;
-    BenchmarkRangeForType<Type>()
+    BenchmarkRangeForType()
         : BenchmarkWithType<Type>()
     {
         BenchmarkWithType<Type>::set_name_with_prefix("QueryRange");
@@ -647,7 +647,7 @@ template <typename Type>
 struct BenchmarkCreateIndexForType : public BenchmarkWithType<Type> {
     using Base = BenchmarkWithType<Type>;
     using underlying_type = typename Type::underlying_type;
-    BenchmarkCreateIndexForType<Type>()
+    BenchmarkCreateIndexForType()
         : BenchmarkWithType<Type>()
     {
         BenchmarkWithType<Type>::set_name_with_prefix("CreateIndexFor");
@@ -669,7 +669,7 @@ template <typename Type>
 struct BenchmarkInsertToIndexForType : public BenchmarkWithType<Type> {
     using Base = BenchmarkWithType<Type>;
     using underlying_type = typename Type::underlying_type;
-    BenchmarkInsertToIndexForType<Type>()
+    BenchmarkInsertToIndexForType()
         : BenchmarkWithType<Type>()
     {
         BenchmarkWithType<Type>::set_name_with_prefix("InsertWithIndex");
@@ -706,7 +706,7 @@ template <typename Type>
 struct BenchmarkInsertPKToIndexForType : public BenchmarkWithType<Type> {
     using Base = BenchmarkWithType<Type>;
     using underlying_type = typename Type::underlying_type;
-    BenchmarkInsertPKToIndexForType<Type>()
+    BenchmarkInsertPKToIndexForType()
         : BenchmarkWithType<Type>()
     {
         BenchmarkWithType<Type>::set_name_with_prefix("InsertPK");
@@ -739,7 +739,7 @@ template <typename Type>
 struct BenchmarkEraseObjectForType : public BenchmarkWithType<Type> {
     using Base = BenchmarkWithType<Type>;
     using underlying_type = typename Type::underlying_type;
-    BenchmarkEraseObjectForType<Type>()
+    BenchmarkEraseObjectForType()
         : BenchmarkWithType<Type>()
     {
         BenchmarkWithType<Type>::set_name_with_prefix("EraseObject");
@@ -760,7 +760,7 @@ template <typename Type, size_t NUM_CONDITIONS>
 struct BenchmarkParsedChainedOrEquality : public BenchmarkWithType<Type> {
     using Base = BenchmarkWithType<Type>;
     using underlying_type = typename Type::underlying_type;
-    BenchmarkParsedChainedOrEquality<Type, NUM_CONDITIONS>()
+    BenchmarkParsedChainedOrEquality()
         : BenchmarkWithType<Type>()
     {
         BenchmarkWithType<Type>::set_name_with_prefix(util::format("QueryChainedOrEquality_%1", NUM_CONDITIONS));
@@ -803,7 +803,7 @@ template <typename Type, size_t NUM_CONDITIONS>
 struct BenchmarkParsedIn : public BenchmarkWithType<Type> {
     using Base = BenchmarkWithType<Type>;
     using underlying_type = typename Type::underlying_type;
-    BenchmarkParsedIn<Type, NUM_CONDITIONS>()
+    BenchmarkParsedIn()
         : BenchmarkWithType<Type>()
     {
         BenchmarkWithType<Type>::set_name_with_prefix(util::format("QueryParsedIN_%1", NUM_CONDITIONS));

--- a/test/util/test_path.cpp
+++ b/test/util/test_path.cpp
@@ -134,7 +134,7 @@ bool initialize_test_path(int argc, const char* argv[])
     }
     PathCchRemoveFileSpec(path, MAX_PATH);
     SetCurrentDirectory(path);
-    g_path_prefix = std::filesystem::path(path).u8string();
+    g_path_prefix = std::string(reinterpret_cast<const char*>(std::filesystem::path(path).u8string().c_str()));
     g_resource_path = g_path_prefix + "\\resources\\";
 #else
     char executable[PATH_MAX];


### PR DESCRIPTION
## What, How & Why?

This PR tries to address the following:

* Recently Core has been change to leave the [decision about the C++ standard to the SDKs](https://github.com/realm/realm-core/pull/7802)
* Bindgen generates code with [`requires`](https://en.cppreference.com/w/cpp/keyword/requires) which is new keyword in C++20: [node template](https://github.com/realm/realm-js/blob/main/packages/realm/bindgen/src/templates/node.ts#L354) and [jsi template](https://github.com/realm/realm-js/blob/main/packages/realm/bindgen/src/templates/jsi.ts#L427)
* Core's file operations are using [`u8string()`](https://github.com/realm/realm-core/blob/master/src/realm/util/file.cpp#L343) on Windows, and signature has changed between [C++17 and C++20](https://en.cppreference.com/w/cpp/filesystem/path/string) with the implication that Core only supports C++17 on Windows

## ☑️ ToDos
* [x] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* ~[ ] C-API, if public C++ API changed~
* ~[ ] `bindgen/spec.yml`, if public C++ API changed~
