### PR TITLE
RCORE-2183 Fix compacting a Realm file using the existing encryption key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* `DB::compact()` on an encrypted Realm without explicitly specifying a new encryption key would only work if the old key happened to be a valid nul-terminated string ([#7842](https://github.com/realm/realm-core/issues/7842), since v14.10.0).
 
 ### Breaking changes
 * None.

--- a/src/realm/db.cpp
+++ b/src/realm/db.cpp
@@ -1626,7 +1626,7 @@ bool DB::compact(bool bump_version_number, std::optional<const char*> output_enc
     }
     auto info = m_info;
     Durability dura = Durability(info->durability);
-    std::string key_buffer;
+    std::unique_ptr<char[]> key_buffer;
     const char* write_key = nullptr;
     if (output_encryption_key) {
         if (*output_encryption_key) {
@@ -1635,8 +1635,9 @@ bool DB::compact(bool bump_version_number, std::optional<const char*> output_enc
     }
 #if REALM_ENABLE_ENCRYPTION
     else if (auto encryption = m_alloc.get_file().get_encryption()) {
-        key_buffer = encryption->get_key();
-        write_key = key_buffer.data();
+        key_buffer = std::make_unique<char[]>(64);
+        memcpy(key_buffer.get(), encryption->get_key(), 64);
+        write_key = key_buffer.get();
     }
 #endif
     {
@@ -2184,7 +2185,7 @@ void DB::enable_wait_for_change()
     m_wait_for_change_enabled = true;
 }
 
-bool DB::needs_file_format_upgrade(const std::string& file, const std::vector<char>& encryption_key)
+bool DB::needs_file_format_upgrade(const std::string& file, Span<const char> encryption_key)
 {
     SlabAlloc alloc;
     SlabAlloc::Config cfg;
@@ -2192,6 +2193,7 @@ bool DB::needs_file_format_upgrade(const std::string& file, const std::vector<ch
     cfg.read_only = true;
     cfg.no_create = true;
     if (!encryption_key.empty()) {
+        REALM_ASSERT(encryption_key.size() == 64);
         cfg.encryption_key = encryption_key.data();
     }
     try {

--- a/src/realm/db.hpp
+++ b/src/realm/db.hpp
@@ -167,7 +167,7 @@ public:
 
     bool is_attached() const noexcept;
 
-    static bool needs_file_format_upgrade(const std::string& file, const std::vector<char>& encryption_key);
+    static bool needs_file_format_upgrade(const std::string& file, util::Span<const char> encryption_key);
 
     Allocator& get_alloc()
     {

--- a/src/realm/sync/noinst/server/server.hpp
+++ b/src/realm/sync/noinst/server/server.hpp
@@ -197,7 +197,7 @@ public:
         bool tcp_no_delay = false;
 
         /// An optional 64 byte key to encrypt all files with.
-        util::Optional<std::array<char, 64>> encryption_key;
+        std::optional<std::array<char, 64>> encryption_key;
 
         /// Sets a limit on the allowed accumulated size in bytes of buffered
         /// incoming changesets waiting to be processed. If left at zero, an

--- a/test/sync_fixtures.hpp
+++ b/test/sync_fixtures.hpp
@@ -456,8 +456,7 @@ public:
         // empty string.
         std::string server_public_key_path = test_server_key_path();
 
-        // Must be empty (encryption disabled) or contain 64 bytes.
-        std::string server_encryption_key;
+        std::optional<std::array<char, 64>> server_encryption_key;
 
         int server_max_protocol_version = 0;
 
@@ -529,7 +528,7 @@ public:
             config_2.disable_download_compaction = config.disable_download_compaction;
             config_2.tcp_no_delay = true;
             config_2.authorization_header_name = config.authorization_header_name;
-            config_2.encryption_key = make_crypt_key(config.server_encryption_key);
+            config_2.encryption_key = config.server_encryption_key;
             config_2.max_protocol_version = config.server_max_protocol_version;
             config_2.disable_download_for = std::move(config.server_disable_download_for);
             config_2.session_bootstrap_callback = std::move(config.server_session_bootstrap_callback);

--- a/test/test_shared.cpp
+++ b/test/test_shared.cpp
@@ -660,9 +660,8 @@ TEST(Shared_EncryptedRemap)
 TEST(Shared_Initial)
 {
     SHARED_GROUP_TEST_PATH(path);
-    std::vector<char> key;
 
-    CHECK_NOT(DB::needs_file_format_upgrade(path, key)); // File not created yet
+    CHECK_NOT(DB::needs_file_format_upgrade(path, {})); // File not created yet
 
     auto key_str = crypt_key();
     {
@@ -675,10 +674,7 @@ TEST(Shared_Initial)
             CHECK(rt.get_group().is_empty());
         }
     }
-    if (key_str) {
-        key.insert(key.end(), key_str, key_str + strlen(key_str));
-    }
-    CHECK_NOT(DB::needs_file_format_upgrade(path, key));
+    CHECK_NOT(DB::needs_file_format_upgrade(path, Span(key_str, 64)));
 }
 
 
@@ -2285,6 +2281,50 @@ TEST(Shared_EncryptionPageReadFailure)
             did_throw = true;
         }
         CHECK(did_throw);
+    }
+}
+
+TEST(Shared_KeyWithNulBytes)
+{
+    SHARED_GROUP_TEST_PATH(path);
+    std::array<char, 64> key;
+    for (size_t i = 0; i < key.size(); ++i)
+        key[i] = char(i % 2);
+
+    { // Create a file
+        DBRef db = DB::create(path, DBOptions(key.data()));
+        WriteTransaction wt(db);
+        wt.add_table("table");
+        wt.commit();
+    }
+
+    { // Reopen the file then compact it with the key obtained from the DB
+        DBRef db = DB::create(path, DBOptions(key.data()));
+        {
+            ReadTransaction rt(db);
+            CHECK(rt.get_table("table"));
+        }
+        db->compact();
+        {
+            ReadTransaction rt(db);
+            CHECK(rt.get_table("table"));
+        }
+    }
+
+    { // Compact with a different explicitly passed-in key
+        DBRef db = DB::create(path, DBOptions(key.data()));
+        {
+            ReadTransaction rt(db);
+            CHECK(rt.get_table("table"));
+        }
+        key[1]++;
+        db->compact(false, key.data());
+    }
+
+    { // Verify that the new key was used
+        DBRef db = DB::create(path, DBOptions(key.data()));
+        ReadTransaction rt(db);
+        CHECK(rt.get_table("table"));
     }
 }
 

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -5363,7 +5363,10 @@ TEST(Sync_ServerSideEncryption)
     std::string server_path;
     {
         ClientServerFixture::Config config;
-        config.server_encryption_key = crypt_key_2(always_encrypt);
+        if (auto key = crypt_key(always_encrypt)) {
+            config.server_encryption_key.emplace();
+            memcpy(config.server_encryption_key->data(), key, config.server_encryption_key->size());
+        }
         ClientServerFixture fixture(server_dir, test_context, std::move(config));
         fixture.start();
 

--- a/test/util/crypt_key.cpp
+++ b/test/util/crypt_key.cpp
@@ -35,7 +35,8 @@ const char* crypt_key(bool always)
 {
 #if REALM_ENABLE_ENCRYPTION
     if (always || g_always_encrypt)
-        return "1234567890123456789012345678901123456789012345678901234567890123";
+        return "\0"
+               "123456789012345678901234567890123456789012345678901234567890123";
 #else
     static_cast<void>(always);
 #endif

--- a/test/util/crypt_key.hpp
+++ b/test/util/crypt_key.hpp
@@ -36,9 +36,6 @@ namespace test_util {
 /// of always_encrypt().
 const char* crypt_key(bool always = false);
 
-/// Returns the empty string when, and only when crypt_key() returns null.
-std::string crypt_key_2(bool always = false);
-
 /// Returns true if global mode "always encrypt" is enabled.
 ///
 /// This function is thread-safe as long as there are no concurrent invocations
@@ -51,15 +48,6 @@ bool is_always_encrypt_enabled();
 /// prior to any invocation of crypt_key().
 void enable_always_encrypt();
 
-
-// Implementation
-
-inline std::string crypt_key_2(bool always)
-{
-    if (const char* key = crypt_key(always)) // Throws
-        return {key};
-    return {};
-}
 
 } // namespace test_util
 } // namespace realm


### PR DESCRIPTION
`compact()` stored the existing encryption key in a `std::string`, which expects a nul-terminated string, not a fixed-size buffer. If the key contained any nul bytes then the key would be truncated and garbage data would be used as the encryption key instead, and if it didn't then arbitrarily large additional amounts of memory would also be copied into the buffer. The tests happened to always use a nul-terminated string as the key and so worked by coincidence.

Fixes #7842.