### PR TITLE
RCORE-2184 Fix util::FlatMap to use Compare to check equality as well as ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Internals
 * FLX download estimates are now tracked in a multiprocess-compatible manner ([PR #7780](https://github.com/realm/realm-core/pull/7780)).
+* Fixed util::FlatMap so it uses the custom Compare for both ordering and equality checking so you can use util::FlatMap with case-insensitive string keys ([PR #7845](https://github.com/realm/realm-core/pull/7845)).
 
 ----------------------------------------------
 

--- a/test/test_util_flat_map.cpp
+++ b/test/test_util_flat_map.cpp
@@ -58,11 +58,57 @@ TEST(Util_FlatMap_Basic)
 
 TEST(Util_FlatMap_Construct)
 {
-    util::FlatMap<std::string, size_t> map({{"foo", 1}, {"bar", 2}, {"ape", 3}});
+    const std::initializer_list<std::pair<std::string, size_t>> init{{"foo", 1}, {"bar", 2}, {"ape", 3}};
+    util::FlatMap<std::string, size_t> map(init);
     CHECK_EQUAL(map.size(), 3);
     CHECK_EQUAL(map.count("foo"), 1);
     CHECK_EQUAL(map.count("bar"), 1);
     CHECK_EQUAL(map.count("ape"), 1);
+
+    std::vector<std::pair<std::string, size_t>> vector{init};
+    util::FlatMap<std::string, size_t> map_from_vector(std::move(vector));
+    CHECK_EQUAL(map_from_vector.size(), 3);
+    CHECK_EQUAL(map_from_vector.count("foo"), 1);
+    CHECK_EQUAL(map_from_vector.count("bar"), 1);
+    CHECK_EQUAL(map_from_vector.count("ape"), 1);
+
+    util::FlatMap<std::string, size_t> map_from_iterators(init.begin(), init.end());
+    CHECK_EQUAL(map_from_iterators.size(), 3);
+    CHECK_EQUAL(map_from_iterators.count("foo"), 1);
+    CHECK_EQUAL(map_from_iterators.count("bar"), 1);
+    CHECK_EQUAL(map_from_iterators.count("ape"), 1);
+}
+
+class HeterogeneousCaseInsensitiveCompare {
+public:
+    using is_transparent = std::true_type;
+    template <class A, class B>
+    bool operator()(const A& a, const B& b) const noexcept
+    {
+        return comp(std::string_view(a), std::string_view(b));
+    }
+
+private:
+    bool comp(std::string_view a, std::string_view b) const noexcept
+    {
+        auto cmp = [](char lhs, char rhs) {
+            return std::tolower(lhs, std::locale::classic()) < std::tolower(rhs, std::locale::classic());
+        };
+        return std::lexicographical_compare(begin(a), end(a), begin(b), end(b), cmp);
+    }
+};
+
+TEST(Util_FlatMap_CustomComparator)
+{
+    util::FlatMap<std::string, size_t, HeterogeneousCaseInsensitiveCompare> map({{"foo", 1}, {"FOO", 2}, {"bar", 3}});
+
+    CHECK_EQUAL(map.size(), 2);
+    auto it_and_inserted = map.insert({"FoO", 5});
+    CHECK_NOT(it_and_inserted.second);
+    CHECK(it_and_inserted.first == map.find("Foo"));
+    CHECK_EQUAL(map["FOO"], 1);
+    CHECK_EQUAL(map.at("fOo"), 1);
+    CHECK_EQUAL(map.at("BaR"), 3);
 }
 
 #endif // TEST_UTIL_FLAT_MAP

--- a/test/test_util_flat_map.cpp
+++ b/test/test_util_flat_map.cpp
@@ -81,7 +81,6 @@ TEST(Util_FlatMap_Construct)
 
 class HeterogeneousCaseInsensitiveCompare {
 public:
-    using is_transparent = std::true_type;
     template <class A, class B>
     bool operator()(const A& a, const B& b) const noexcept
     {


### PR DESCRIPTION
## What, How & Why?
This does what it says on the tin. I ran across this while changing HTTPHeaders to be a flat map and discovered util::FlatMap doesn't actually implement the semantics of std::map.

I also added some additional constructors so you can construct a FlatMap from an initializer_list or pair of iterators the way you can construct a std::map or std::vector.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed
* [ ] `bindgen/spec.yml`, if public C++ API changed
