### PR TITLE
RCORE-2184 remove unused method now that FlatMap uses the < comparator

### DIFF
--- a/src/realm/sync/noinst/client_reset_recovery.cpp
+++ b/src/realm/sync/noinst/client_reset_recovery.cpp
@@ -137,7 +137,6 @@ struct ListPath {
     void append(const Element& item);
     bool operator<(const ListPath& other) const noexcept;
     bool operator==(const ListPath& other) const noexcept;
-    bool operator!=(const ListPath& other) const noexcept;
     std::string path_to_string(Transaction& remote, const InterningBuffer& buffer);
 
     using const_iterator = typename std::vector<Element>::const_iterator;
@@ -488,11 +487,6 @@ bool ListPath::operator==(const ListPath& other) const noexcept
         return true;
     }
     return false;
-}
-
-bool ListPath::operator!=(const ListPath& other) const noexcept
-{
-    return !(operator==(other));
 }
 
 std::string ListPath::path_to_string(Transaction& remote, const InterningBuffer& buffer)


### PR DESCRIPTION
Part of https://github.com/realm/realm-core/pull/7845 which caused this warning on [CI](https://evergreen.mongodb.com/version/realm_core_stable_98fe08e8bce3927f857270a0a3ee76a117baac5c?redirect_spruce_users=true):

```
[2024/06/27 10:26:05.490] FAILED: src/realm/sync/CMakeFiles/Sync.dir/RelWithDebInfo/noinst/client_reset_recovery.cpp.o
[2024/06/27 10:26:05.490] /usr/bin/c++ -D_LARGEFILE64_SOURCE -D_LARGEFILE_SOURCE -D_LIBCPP_REMOVE_TRANSITIVE_INCLUDES -D_POSIX_C_SOURCE=200112L -DCMAKE_INTDIR=\"RelWithDebInfo\" -I/data/mci/6bf986cc686e1d44d0a88c98eaefe20e/realm-core/src -I/data/mci/6bf986cc686e1d44d0a88c98eaefe20e/realm-core/build/src -O2 -g -DNDEBUG -std=c++17 -fPIC -fvisibility=hidden -Wall -Wextra -Wempty-body -Wparentheses -Wunknown-pragmas -Wunreachable-code -Wunused-parameter -Wno-missing-field-initializers -Wno-psabi -Wno-redundant-move -pthread -Werror -MD -MT src/realm/sync/CMakeFiles/Sync.dir/RelWithDebInfo/noinst/client_reset_recovery.cpp.o -MF src/realm/sync/CMakeFiles/Sync.dir/RelWithDebInfo/noinst/client_reset_recovery.cpp.o.d -o src/realm/sync/CMakeFiles/Sync.dir/RelWithDebInfo/noinst/client_reset_recovery.cpp.o -c /data/mci/6bf986cc686e1d44d0a88c98eaefe20e/realm-core/src/realm/sync/noinst/client_reset_recovery.cpp
[2024/06/27 10:26:05.490] /data/mci/6bf986cc686e1d44d0a88c98eaefe20e/realm-core/src/realm/sync/noinst/client_reset_recovery.cpp:493:6: error: 'bool {anonymous}::ListPath::operator!=(const {anonymous}::ListPath&) const' defined but not used [-Werror=unused-function]
[2024/06/27 10:26:05.490]   493 | bool ListPath::operator!=(const ListPath& other) const noexcept
[2024/06/27 10:26:05.490]       |      ^~~~~~~~
[2024/06/27 10:26:05.490] cc1plus: all warnings being treated as errors
```

The custom `operator!=` is no longer used in the implementation of FlatMap because it now relies solely on `operator<`
