### PR TITLE
RCORE-2188 fix gcc warnings and add a ubuntu 2404 GCC runner

### DIFF
--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -1440,6 +1440,15 @@ buildvariants:
   tasks:
   - name: compile_local_tests
 
+- name: ubuntu-2404-GCC
+  display_name: "Ubuntu 24.04 arm64 (native GCC)"
+  run_on: ubuntu2404-arm64-large
+  expansions:
+    fetch_missing_dependencies: On
+    disable_tests_against_baas: On
+  tasks:
+  - name: compile_local_tests
+
 - name: ubuntu-encryption-tsan
   display_name: "Ubuntu (Encryption Enabled w/TSAN)"
   run_on: ubuntu2204-arm64-small
@@ -1488,7 +1497,7 @@ buildvariants:
   - name: generate-sync-corpus
 
 - name: ubuntu2004-arm64
-  display_name: "Ubuntu 20.04 ARM64 (Clang 11 release benchmarks)"
+  display_name: "Ubuntu 20.04 ARM64 (GCC 9 release benchmarks)"
   run_on: ubuntu2004-arm64-large
   expansions:
     cmake_url: "https://s3.amazonaws.com/static.realm.io/evergreen-assets/cmake-3.26.3-linux-aarch64.tar.gz"

--- a/src/external/s2/s2polygonbuilder.cc
+++ b/src/external/s2/s2polygonbuilder.cc
@@ -180,9 +180,8 @@ S2Loop* S2PolygonBuilder::AssembleLoop(S2Point const& v0, S2Point const& v1,
   path.push_back(v1);
   index[v1] = 1;
   while (path.size() >= 2) {
-    // Note that "v0" and "v1" become invalid if "path" is modified.
-    S2Point const& v0 = path.end()[-2];
-    S2Point const& v1 = path.end()[-1];
+    S2Point const v0 = path.end()[-2];
+    S2Point const v1 = path.end()[-1];
     S2Point v2;
     bool v2_found = false;
     EdgeSet::const_iterator candidates = edges_->find(v1);

--- a/src/realm/sync/noinst/client_reset_recovery.cpp
+++ b/src/realm/sync/noinst/client_reset_recovery.cpp
@@ -129,14 +129,11 @@ struct ListPath {
             ColumnKey,
         } type;
 
-        bool operator==(const Element& other) const noexcept;
-        bool operator!=(const Element& other) const noexcept;
         bool operator<(const Element& other) const noexcept;
     };
 
     void append(const Element& item);
     bool operator<(const ListPath& other) const noexcept;
-    bool operator==(const ListPath& other) const noexcept;
     std::string path_to_string(Transaction& remote, const InterningBuffer& buffer);
 
     using const_iterator = typename std::vector<Element>::const_iterator;
@@ -419,26 +416,6 @@ ListPath::Element::Element(ColKey key)
 {
 }
 
-bool ListPath::Element::operator==(const Element& other) const noexcept
-{
-    if (type == other.type) {
-        switch (type) {
-            case Type::InternKey:
-                return intern_key == other.intern_key;
-            case Type::ListIndex:
-                return index == other.index;
-            case Type::ColumnKey:
-                return col_key == other.col_key;
-        }
-    }
-    return false;
-}
-
-bool ListPath::Element::operator!=(const Element& other) const noexcept
-{
-    return !(operator==(other));
-}
-
 bool ListPath::Element::operator<(const Element& other) const noexcept
 {
     if (type < other.type) {
@@ -474,19 +451,6 @@ bool ListPath::operator<(const ListPath& other) const noexcept
         return true;
     }
     return std::lexicographical_compare(m_path.begin(), m_path.end(), other.m_path.begin(), other.m_path.end());
-}
-
-bool ListPath::operator==(const ListPath& other) const noexcept
-{
-    if (m_table_key == other.m_table_key && m_obj_key == other.m_obj_key && m_path.size() == other.m_path.size()) {
-        for (size_t i = 0; i < m_path.size(); ++i) {
-            if (m_path[i] != other.m_path[i]) {
-                return false;
-            }
-        }
-        return true;
-    }
-    return false;
 }
 
 std::string ListPath::path_to_string(Transaction& remote, const InterningBuffer& buffer)

--- a/src/realm/util/cli_args.cpp
+++ b/src/realm/util/cli_args.cpp
@@ -1,7 +1,9 @@
 #include "realm/util/cli_args.hpp"
-#include <string>
-#include <errno.h>
+
 #include <algorithm>
+#include <cerrno>
+#include <cstdint>
+#include <string>
 
 namespace realm::util {
 


### PR DESCRIPTION
Mainline commits are hitting another warning after https://github.com/realm/realm-core/pull/7851 was merged, due to more unused methods. We didn't catch these warnings on patch builds because the runner that is failing is a ubuntu variant that only runs on mainline commits (benchmarks). This adds a patch build runner that will help us discover these types of warnings on PRs.

The warning causing the failure was:
```
[2024/06/28 11:01:27.139] FAILED: src/realm/sync/CMakeFiles/Sync.dir/RelWithDebInfo/noinst/client_reset_recovery.cpp.o
[2024/06/28 11:01:27.140] /usr/bin/c++ -D_LARGEFILE64_SOURCE -D_LARGEFILE_SOURCE -D_LIBCPP_REMOVE_TRANSITIVE_INCLUDES -D_POSIX_C_SOURCE=200112L -DCMAKE_INTDIR=\"RelWithDebInfo\" -I/data/mci/767ecea29c5786b2cf212408cae2c839/realm-core/src -I/data/mci/767ecea29c5786b2cf212408cae2c839/realm-core/build/src -O2 -g -DNDEBUG -std=c++17 -fPIC -fvisibility=hidden -Wall -Wextra -Wempty-body -Wparentheses -Wunknown-pragmas -Wunreachable-code -Wunused-parameter -Wno-missing-field-initializers -Wno-psabi -Wno-redundant-move -pthread -Werror -MD -MT src/realm/sync/CMakeFiles/Sync.dir/RelWithDebInfo/noinst/client_reset_recovery.cpp.o -MF src/realm/sync/CMakeFiles/Sync.dir/RelWithDebInfo/noinst/client_reset_recovery.cpp.o.d -o src/realm/sync/CMakeFiles/Sync.dir/RelWithDebInfo/noinst/client_reset_recovery.cpp.o -c /data/mci/767ecea29c5786b2cf212408cae2c839/realm-core/src/realm/sync/noinst/client_reset_recovery.cpp
[2024/06/28 11:01:27.140] /data/mci/767ecea29c5786b2cf212408cae2c839/realm-core/src/realm/sync/noinst/client_reset_recovery.cpp:479:6: error: 'bool {anonymous}::ListPath::operator==(const {anonymous}::ListPath&) const' defined but not used [-Werror=unused-function]
[2024/06/28 11:01:27.140]   479 | bool ListPath::operator==(const ListPath& other) const noexcept
[2024/06/28 11:01:27.140]       |      ^~~~~~~~
[2024/06/28 11:01:27.140] cc1plus: all warnings being treated as errors
```

Fixes https://github.com/realm/realm-core/issues/7855
Related to https://github.com/realm/realm-core/pull/7845