### PR TITLE
RCORE-2191 Add support for multi-process subscription state change notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Internals
 * Fix emscripten build and add emscripten debug/release compile tasks to evergreen. ([PR #7916](https://github.com/realm/realm-core/pull/7916))
+* Subscription set state change notifications now work in a multiprocess-compatible manner ([PR #7862](https://github.com/realm/realm-core/pull/7862)).
 
 ----------------------------------------------
 

--- a/src/realm/sync/noinst/client_history_impl.cpp
+++ b/src/realm/sync/noinst/client_history_impl.cpp
@@ -423,7 +423,7 @@ void ClientHistory::integrate_server_changesets(
     const SyncProgress& progress, DownloadableProgress downloadable_bytes,
     util::Span<const RemoteChangeset> incoming_changesets, VersionInfo& version_info, DownloadBatchState batch_state,
     util::Logger& logger, const TransactionRef& transact,
-    util::UniqueFunction<void(const TransactionRef&, util::Span<Changeset>)> run_in_write_tr)
+    util::UniqueFunction<void(const Transaction&, util::Span<Changeset>)> run_in_write_tr)
 {
     REALM_ASSERT(incoming_changesets.size() != 0);
     REALM_ASSERT(
@@ -502,7 +502,7 @@ void ClientHistory::integrate_server_changesets(
             update_sync_progress(progress, downloadable_bytes); // Throws
         }
         if (run_in_write_tr) {
-            run_in_write_tr(transact, changesets_for_cb);
+            run_in_write_tr(*transact, changesets_for_cb);
         }
 
         // The reason we can use the `origin_timestamp`, and the `origin_file_ident`
@@ -610,14 +610,13 @@ size_t ClientHistory::transform_and_apply_server_changesets(util::Span<Changeset
 }
 
 
-void ClientHistory::get_upload_download_state(DB& db, std::uint_fast64_t& downloaded_bytes,
+void ClientHistory::get_upload_download_state(Transaction& rt, Allocator& alloc, std::uint_fast64_t& downloaded_bytes,
                                               DownloadableProgress& downloadable_bytes,
                                               std::uint_fast64_t& uploaded_bytes,
                                               std::uint_fast64_t& uploadable_bytes,
                                               std::uint_fast64_t& snapshot_version, version_type& uploaded_version)
 {
-    TransactionRef rt = db.start_read(); // Throws
-    version_type current_client_version = rt->get_version();
+    version_type current_client_version = rt.get_version();
 
     downloaded_bytes = 0;
     downloadable_bytes = uint64_t(0);
@@ -627,11 +626,11 @@ void ClientHistory::get_upload_download_state(DB& db, std::uint_fast64_t& downlo
     uploaded_version = 0;
 
     using gf = _impl::GroupFriend;
-    ref_type ref = gf::get_history_ref(*rt);
+    ref_type ref = gf::get_history_ref(rt);
     if (!ref)
         return;
 
-    Array root(db.get_alloc());
+    Array root(alloc);
     root.init_from_ref(ref);
     downloaded_bytes = root.get_as_ref_or_tagged(s_progress_downloaded_bytes_iip).get_as_int();
     downloadable_bytes = root.get_as_ref_or_tagged(s_progress_downloadable_bytes_iip).get_as_int();
@@ -642,9 +641,9 @@ void ClientHistory::get_upload_download_state(DB& db, std::uint_fast64_t& downlo
     if (uploaded_version == current_client_version)
         return;
 
-    BinaryColumn changesets(db.get_alloc());
+    BinaryColumn changesets(alloc);
     changesets.init_from_ref(root.get_as_ref(s_changesets_iip));
-    IntegerBpTree origin_file_idents(db.get_alloc());
+    IntegerBpTree origin_file_idents(alloc);
     origin_file_idents.init_from_ref(root.get_as_ref(s_origin_file_idents_iip));
 
     // `base_version` is the oldest version we have history for. If this is

--- a/src/realm/sync/noinst/client_history_impl.hpp
+++ b/src/realm/sync/noinst/client_history_impl.hpp
@@ -252,10 +252,11 @@ public:
         const SyncProgress& progress, DownloadableProgress downloadable_bytes,
         util::Span<const RemoteChangeset> changesets, VersionInfo& new_version, DownloadBatchState download_type,
         util::Logger&, const TransactionRef& transact,
-        util::UniqueFunction<void(const TransactionRef&, util::Span<Changeset>)> run_in_write_tr = nullptr);
+        util::UniqueFunction<void(const Transaction&, util::Span<Changeset>)> run_in_write_tr = nullptr);
 
-    static void get_upload_download_state(DB&, std::uint_fast64_t&, DownloadableProgress&, std::uint_fast64_t&,
-                                          std::uint_fast64_t&, std::uint_fast64_t&, version_type&);
+    static void get_upload_download_state(Transaction&, Allocator& alloc, std::uint_fast64_t&, DownloadableProgress&,
+                                          std::uint_fast64_t&, std::uint_fast64_t&, std::uint_fast64_t&,
+                                          version_type&);
     static void get_upload_download_state(DB*, std::uint_fast64_t&, std::uint_fast64_t&);
 
     /// Record the current download progress.

--- a/src/realm/sync/noinst/client_impl_base.hpp
+++ b/src/realm/sync/noinst/client_impl_base.hpp
@@ -784,10 +784,6 @@ public:
     /// \brief Gets the migration store associated with this Session.
     MigrationStore* get_migration_store();
 
-    /// Update internal client state when a flx subscription becomes complete outside
-    /// of the normal sync process. This can happen during client reset.
-    void on_flx_sync_version_complete(int64_t version);
-
     /// If this session is currently suspended, resume it immediately.
     ///
     /// It is an error to call this function before activation of the session,
@@ -928,7 +924,6 @@ private:
     //@}
 
     void on_flx_sync_error(int64_t version, std::string_view err_msg);
-    void on_flx_sync_progress(int64_t version, DownloadBatchState batch_state);
 
     // Processes an FLX download message, if it's a bootstrap message. If it's not a bootstrap
     // message then this is a noop and will return false. Otherwise this will return true
@@ -940,8 +935,6 @@ private:
 
     bool client_reset_if_needed();
     void handle_pending_client_reset_acknowledgement();
-
-    void update_subscription_version_info();
 
     void gather_pending_compensating_writes(util::Span<Changeset> changesets, std::vector<ProtocolErrorInfo>* out);
 
@@ -1115,7 +1108,7 @@ private:
     Status receive_mark_message(request_ident_type);
     Status receive_unbound_message();
     Status receive_error_message(const ProtocolErrorInfo& info);
-    Status receive_query_error_message(int error_code, std::string_view message, int64_t query_version);
+    void receive_query_error_message(int error_code, std::string_view message, int64_t query_version);
     Status receive_test_command_response(request_ident_type, std::string_view body);
 
     void initiate_rebind();

--- a/src/realm/sync/noinst/client_reset.hpp
+++ b/src/realm/sync/noinst/client_reset.hpp
@@ -74,8 +74,7 @@ ClientResyncMode reset_precheck_guard(const TransactionRef& wt_local, ClientResy
 // to the fresh Realm. Then the local Realm will have its client file ident set to
 // the file ident from the fresh realm
 bool perform_client_reset_diff(DB& db, sync::ClientReset& reset_config, util::Logger& logger,
-                               sync::SubscriptionStore* sub_store,
-                               util::FunctionRef<void(int64_t)> on_flx_version_complete);
+                               sync::SubscriptionStore* sub_store);
 
 } // namespace _impl::client_reset
 } // namespace realm

--- a/src/realm/sync/noinst/client_reset_operation.cpp
+++ b/src/realm/sync/noinst/client_reset_operation.cpp
@@ -52,7 +52,7 @@ bool is_fresh_path(const std::string& path)
 }
 
 bool perform_client_reset(util::Logger& logger, DB& db, sync::ClientReset&& reset_config,
-                          sync::SubscriptionStore* sub_store, util::FunctionRef<void(int64_t)> on_flx_version)
+                          sync::SubscriptionStore* sub_store)
 {
     REALM_ASSERT(reset_config.mode != ClientResyncMode::Manual);
     REALM_ASSERT(reset_config.fresh_copy);
@@ -97,8 +97,7 @@ bool perform_client_reset(util::Logger& logger, DB& db, sync::ClientReset&& rese
     if (notify_after) {
         previous_state = db.start_frozen(frozen_before_state_version);
     }
-    bool did_recover =
-        client_reset::perform_client_reset_diff(db, reset_config, logger, sub_store, on_flx_version); // throws
+    bool did_recover = client_reset::perform_client_reset_diff(db, reset_config, logger, sub_store); // throws
 
     if (notify_after) {
         notify_after(previous_state->get_version_of_current_transaction(), did_recover);

--- a/src/realm/sync/noinst/client_reset_operation.hpp
+++ b/src/realm/sync/noinst/client_reset_operation.hpp
@@ -21,7 +21,6 @@
 
 #include <realm/db.hpp>
 #include <realm/util/functional.hpp>
-#include <realm/util/function_ref.hpp>
 #include <realm/util/logger.hpp>
 #include <realm/sync/client_base.hpp>
 #include <realm/sync/config.hpp>
@@ -39,7 +38,7 @@ std::string get_fresh_path_for(const std::string& realm_path);
 bool is_fresh_path(const std::string& realm_path);
 
 bool perform_client_reset(util::Logger& logger, DB& db, sync::ClientReset&& reset_config,
-                          sync::SubscriptionStore* sub_store, util::FunctionRef<void(int64_t)> on_flx_version);
+                          sync::SubscriptionStore* sub_store);
 
 } // namespace realm::_impl::client_reset
 

--- a/src/realm/sync/noinst/pending_bootstrap_store.cpp
+++ b/src/realm/sync/noinst/pending_bootstrap_store.cpp
@@ -29,6 +29,7 @@
 #include "realm/sync/noinst/protocol_codec.hpp"
 #include "realm/sync/noinst/sync_metadata_schema.hpp"
 #include "realm/sync/protocol.hpp"
+#include "realm/sync/subscriptions.hpp"
 #include "realm/sync/transform.hpp"
 #include "realm/util/assert.hpp"
 #include "realm/util/buffer.hpp"
@@ -61,9 +62,11 @@ constexpr static std::string_view c_progress_latest_server_version_salt("latest_
 
 } // namespace
 
-PendingBootstrapStore::PendingBootstrapStore(DBRef db, util::Logger& logger)
+PendingBootstrapStore::PendingBootstrapStore(DBRef db, util::Logger& logger,
+                                             std::shared_ptr<SubscriptionStore> subscription_store)
     : m_db(std::move(db))
     , m_logger(logger)
+    , m_subscription_store(std::move(subscription_store))
 {
     std::vector<SyncMetadataTable> internal_tables{
         {&m_table,
@@ -129,8 +132,7 @@ PendingBootstrapStore::PendingBootstrapStore(DBRef db, util::Logger& logger)
 
 void PendingBootstrapStore::add_batch(int64_t query_version, util::Optional<SyncProgress> progress,
                                       DownloadableProgress download_progress,
-                                      const _impl::ClientProtocol::ReceivedChangesets& changesets,
-                                      bool* created_new_batch_out)
+                                      const _impl::ClientProtocol::ReceivedChangesets& changesets)
 {
     std::vector<util::AppendBuffer<char>> compressed_changesets;
     compressed_changesets.reserve(changesets.size());
@@ -181,11 +183,11 @@ void PendingBootstrapStore::add_batch(int64_t query_version, util::Optional<Sync
 
     ClientHistory::set_download_progress(*tr, download_progress);
 
-    tr->commit();
-
-    if (created_new_batch_out) {
-        *created_new_batch_out = did_create;
+    if (did_create) {
+        m_subscription_store->begin_bootstrap(*tr, query_version);
     }
+
+    tr->commit();
 
     if (did_create) {
         m_logger.debug(util::LogCategory::changeset,
@@ -202,6 +204,7 @@ void PendingBootstrapStore::add_batch(int64_t query_version, util::Optional<Sync
                        "Finalized pending bootstrap object with %1 changesets for query version %2", total_changesets,
                        query_version);
     }
+
     m_has_pending = true;
 }
 
@@ -210,27 +213,19 @@ bool PendingBootstrapStore::has_pending() const noexcept
     return m_has_pending;
 }
 
-void PendingBootstrapStore::clear()
-{
-    auto tr = m_db->start_write();
-    clear(*tr);
-    tr->commit();
-}
-
-void PendingBootstrapStore::clear(Transaction& wt)
+void PendingBootstrapStore::clear(Transaction& wt, int64_t query_version)
 {
     auto bootstrap_table = wt.get_table(m_table);
     bootstrap_table->clear();
+    if (m_has_pending) {
+        m_subscription_store->cancel_bootstrap(wt, query_version);
+    }
     m_has_pending = false;
 }
 
-PendingBootstrapStore::PendingBatch PendingBootstrapStore::peek_pending(size_t limit_in_bytes)
+PendingBootstrapStore::PendingBatch PendingBootstrapStore::peek_pending(Transaction& tr, size_t limit_in_bytes)
 {
-    auto tr = m_db->start_read();
-    auto bootstrap_table = tr->get_table(m_table);
-    if (bootstrap_table->is_empty()) {
-        return {};
-    }
+    auto bootstrap_table = tr.get_table(m_table);
 
     // We should only have one pending bootstrap at a time.
     REALM_ASSERT(bootstrap_table->size() == 1);
@@ -249,7 +244,7 @@ PendingBootstrapStore::PendingBatch PendingBootstrapStore::peek_pending(size_t l
             progress_obj.get<int64_t>(m_progress_download_client_version);
         progress.upload.last_integrated_server_version = progress_obj.get<int64_t>(m_progress_upload_server_version);
         progress.upload.client_version = progress_obj.get<int64_t>(m_progress_upload_client_version);
-        ret.progress = std::move(progress);
+        ret.progress = progress;
     }
 
     auto changeset_list = bootstrap_obj.get_linklist(m_changesets);
@@ -310,14 +305,10 @@ PendingBootstrapStore::PendingBatchStats PendingBootstrapStore::pending_stats()
     return stats;
 }
 
-void PendingBootstrapStore::pop_front_pending(const TransactionRef& tr, size_t count)
+void PendingBootstrapStore::pop_front_pending(const Transaction& tr, size_t count)
 {
-    REALM_ASSERT_3(tr->get_transact_stage(), ==, DB::transact_Writing);
-    auto bootstrap_table = tr->get_table(m_table);
-    if (bootstrap_table->is_empty()) {
-        return;
-    }
-
+    REALM_ASSERT_3(tr.get_transact_stage(), ==, DB::transact_Writing);
+    auto bootstrap_table = tr.get_table(m_table);
     // We should only have one pending bootstrap at a time.
     REALM_ASSERT(bootstrap_table->size() == 1);
 
@@ -333,18 +324,22 @@ void PendingBootstrapStore::pop_front_pending(const TransactionRef& tr, size_t c
         }
     }
 
+    int64_t query_version = bootstrap_obj.get<int64_t>(m_query_version);
     if (changeset_list.is_empty()) {
         m_logger.debug(util::LogCategory::changeset, "Removing pending bootstrap obj for query version %1",
-                       bootstrap_obj.get<int64_t>(m_query_version));
+                       query_version);
         bootstrap_obj.remove();
     }
     else {
         m_logger.debug(util::LogCategory::changeset,
-                       "Removing pending bootstrap batch for query version %1. %2 changeset remaining",
-                       bootstrap_obj.get<int64_t>(m_query_version), changeset_list.size());
+                       "Removing pending bootstrap batch for query version %1. %2 changeset remaining", query_version,
+                       changeset_list.size());
     }
 
     m_has_pending = !bootstrap_table->is_empty();
+    if (!m_has_pending) {
+        m_subscription_store->complete_bootstrap(tr, query_version);
+    }
 }
 
 } // namespace realm::sync

--- a/src/realm/sync/noinst/pending_bootstrap_store.hpp
+++ b/src/realm/sync/noinst/pending_bootstrap_store.hpp
@@ -22,8 +22,6 @@
 #include "realm/list.hpp"
 #include "realm/obj.hpp"
 #include "realm/object-store/c_api/util.hpp"
-#include "realm/sync/protocol.hpp"
-#include "realm/sync/noinst/protocol_codec.hpp"
 #include "realm/sync/transform.hpp"
 #include "realm/util/buffer.hpp"
 #include "realm/util/logger.hpp"
@@ -32,6 +30,8 @@
 #include <stdexcept>
 
 namespace realm::sync {
+
+class SubscriptionStore;
 
 class PendingBootstrapException : public std::runtime_error {
 public:
@@ -42,11 +42,10 @@ public:
 // that are sent across multiple download messages.
 class PendingBootstrapStore {
 public:
-    // Constructs from a DBRef. Constructing is destructive - since pending bootstraps are only valid for the
-    // session they occurred in, this will drop/clear all data when the bootstrap store is constructed.
+    // Constructs from a DBRef.
     //
     // Underneath this creates a table which stores each download message's changesets.
-    explicit PendingBootstrapStore(DBRef db, util::Logger& logger);
+    PendingBootstrapStore(DBRef db, util::Logger& logger, std::shared_ptr<SubscriptionStore> subscription_store);
 
     PendingBootstrapStore(const PendingBootstrapStore&) = delete;
     PendingBootstrapStore& operator=(const PendingBootstrapStore&) = delete;
@@ -64,7 +63,7 @@ public:
 
     // Returns the next batch (download message) of changesets if it exists. The transaction must be in the reading
     // state.
-    PendingBatch peek_pending(size_t limit_in_bytes);
+    PendingBatch peek_pending(Transaction& tr, size_t limit_in_bytes);
 
     struct PendingBatchStats {
         int64_t query_version = 0;
@@ -75,22 +74,19 @@ public:
 
     // Removes the first set of changesets from the current pending bootstrap batch. The transaction must be in the
     // writing state.
-    void pop_front_pending(const TransactionRef& tr, size_t count);
+    void pop_front_pending(const Transaction& tr, size_t count);
 
     // Adds a set of changesets to the store.
     void add_batch(int64_t query_version, util::Optional<SyncProgress> progress,
-                   DownloadableProgress download_progress, const std::vector<RemoteChangeset>& changesets,
-                   bool* created_new_batch);
+                   DownloadableProgress download_progress, const std::vector<RemoteChangeset>& changesets);
 
-    void clear();
-    void clear(Transaction& wt);
-
+    void clear(Transaction& wt, int64_t query_version);
 
 private:
     DBRef m_db;
     // The pending_bootstrap_store is tied to the lifetime of a session, so a shared_ptr is not needed
     util::Logger& m_logger;
-    _impl::ClientProtocol m_client_protocol;
+    std::shared_ptr<SubscriptionStore> m_subscription_store;
 
     TableKey m_cursor_table;
 

--- a/src/realm/sync/subscriptions.cpp
+++ b/src/realm/sync/subscriptions.cpp
@@ -91,7 +91,7 @@ SubscriptionSet::State state_from_storage(int64_t value)
     }
 }
 
-int64_t state_to_storage(SubscriptionSet::State state)
+constexpr int64_t state_to_storage(SubscriptionSet::State state)
 {
     switch (state) {
         case SubscriptionSet::State::Pending:
@@ -109,7 +109,7 @@ int64_t state_to_storage(SubscriptionSet::State state)
     }
 }
 
-size_t state_to_order(SubscriptionSet::State needle)
+constexpr size_t state_to_order(SubscriptionSet::State needle)
 {
     using State = SubscriptionSet::State;
     switch (needle) {
@@ -442,12 +442,6 @@ util::Future<SubscriptionSet::State> SubscriptionSet::get_state_change_notificat
     auto mgr = get_flx_subscription_store(); // Throws
 
     util::CheckedLockGuard lk(mgr->m_pending_notifications_mutex);
-    // If we've already been superseded by another version getting completed, then we should skip registering
-    // a notification because it may never fire.
-    if (mgr->m_min_outstanding_version > version()) {
-        return util::Future<State>::make_ready(State::Superseded);
-    }
-
     State cur_state = state();
     std::string err_str = error_str();
 
@@ -486,33 +480,69 @@ void SubscriptionSet::get_state_change_notification(
     });
 }
 
-void SubscriptionStore::process_notifications(State new_state, int64_t version, std::string_view error_str)
+void SubscriptionStore::report_progress()
 {
-    std::list<SubscriptionStore::NotificationRequest> to_finish;
-    {
-        util::CheckedLockGuard lk(m_pending_notifications_mutex);
-        splice_if(m_pending_notifications, to_finish, [&](auto& req) {
-            return (req.version == version &&
-                    (new_state == State::Error || state_to_order(new_state) >= state_to_order(req.notify_when))) ||
-                   (new_state == State::Complete && req.version < version);
-        });
+    TransactionRef tr;
+    report_progress(tr);
+}
 
-        if (new_state == State::Complete) {
-            m_min_outstanding_version = version;
-        }
-    }
+void SubscriptionStore::report_progress(TransactionRef& tr)
+{
+    util::CheckedUniqueLock lk(m_pending_notifications_mutex);
+    if (m_pending_notifications.empty())
+        return;
 
-    for (auto& req : to_finish) {
-        if (new_state == State::Error && req.version == version) {
-            req.promise.set_error({ErrorCodes::SubscriptionFailed, error_str});
+    if (!tr)
+        tr = m_db->start_read();
+    auto sub_sets = tr->get_table(m_sub_set_table);
+
+    struct NotificationCompletion {
+        util::Promise<State> promise;
+        std::string_view error_str;
+        State state;
+    };
+    std::vector<NotificationCompletion> to_finish;
+    m_pending_notifications.remove_if([&](NotificationRequest& req) {
+        Obj obj = sub_sets->get_object_with_primary_key(req.version);
+        if (!obj) {
+            to_finish.push_back({std::move(req.promise), {}, State::Superseded});
+            return true;
         }
-        else if (req.version < version) {
-            req.promise.emplace_value(State::Superseded);
+
+        auto state = state_from_storage(obj.get<int64_t>(m_sub_set_state));
+        if (state_to_order(state) < state_to_order(req.notify_when))
+            return false;
+
+        std::string_view error_str;
+        if (state == State::Error) {
+            error_str = std::string_view(obj.get<StringData>(m_sub_set_error_str));
+        }
+        to_finish.push_back({std::move(req.promise), error_str, state});
+        return true;
+    });
+    lk.unlock();
+
+    for (auto& [promise, error_str, state] : to_finish) {
+        if (state == State::Error) {
+            promise.set_error({ErrorCodes::SubscriptionFailed, error_str});
         }
         else {
-            req.promise.emplace_value(new_state);
+            promise.emplace_value(state);
         }
     }
+}
+
+int64_t SubscriptionStore::get_downloading_query_version(Transaction& tr) const
+{
+    auto sub_sets = tr.get_table(m_sub_set_table);
+    ObjKey key;
+    const Mixed states[] = {
+        state_to_storage(SubscriptionSet::State::Complete),
+        state_to_storage(SubscriptionSet::State::AwaitingMark),
+        state_to_storage(SubscriptionSet::State::Bootstrapping),
+    };
+    sub_sets->where().in(m_sub_set_state, std::begin(states), std::end(states)).max(m_sub_set_version_num, &key);
+    return key ? sub_sets->get_object(key).get<int64_t>(m_sub_set_version_num) : 0;
 }
 
 SubscriptionSet MutableSubscriptionSet::commit()
@@ -541,14 +571,11 @@ SubscriptionSet MutableSubscriptionSet::commit()
         new_sub.set(mgr->m_sub_query_str, StringData(sub.query_string));
     }
     m_obj.set(mgr->m_sub_set_state, state_to_storage(m_state));
-    if (!m_error_str.empty()) {
-        m_obj.set(mgr->m_sub_set_error_str, StringData(m_error_str));
-    }
 
     const auto flx_version = version();
     m_tr->commit_and_continue_as_read();
 
-    mgr->process_notifications(m_state, flx_version, std::string_view(error_str()));
+    mgr->report_progress(m_tr);
 
     return mgr->get_refreshed(m_obj.get_key(), flx_version, m_tr->get_version_of_current_transaction());
 }
@@ -701,20 +728,15 @@ Obj SubscriptionStore::get_active(const Transaction& tr)
     // There should always be at least one SubscriptionSet - the zeroth subscription set for schema instructions.
     REALM_ASSERT(!sub_sets->is_empty());
 
-    DescriptorOrdering descriptor_ordering;
-    descriptor_ordering.append_sort(SortDescriptor{{{sub_sets->get_primary_key_column()}}, {false}});
-    descriptor_ordering.append_limit(LimitDescriptor{1});
-    auto res = sub_sets->where()
-                   .equal(m_sub_set_state, state_to_storage(SubscriptionSet::State::Complete))
-                   .Or()
-                   .equal(m_sub_set_state, state_to_storage(SubscriptionSet::State::AwaitingMark))
-                   .find_all(descriptor_ordering);
+    ObjKey key;
+    sub_sets->where()
+        .equal(m_sub_set_state, state_to_storage(SubscriptionSet::State::Complete))
+        .Or()
+        .equal(m_sub_set_state, state_to_storage(SubscriptionSet::State::AwaitingMark))
+        .max(m_sub_set_version_num, &key);
 
     // If there is no active subscription yet, return the zeroth subscription.
-    if (res.is_empty()) {
-        return sub_sets->get_object_with_primary_key(0);
-    }
-    return res.get_object(0);
+    return key ? sub_sets->get_object(key) : sub_sets->get_object_with_primary_key(0);
 }
 
 SubscriptionStore::VersionInfo SubscriptionStore::get_version_info() const
@@ -724,24 +746,20 @@ SubscriptionStore::VersionInfo SubscriptionStore::get_version_info() const
     // There should always be at least one SubscriptionSet - the zeroth subscription set for schema instructions.
     REALM_ASSERT(!sub_sets->is_empty());
 
+    auto get = [](Mixed m) {
+        return m.is_type(type_Int) ? m.get_int() : SubscriptionSet::EmptyVersion;
+    };
+
     VersionInfo ret;
     ret.latest = sub_sets->max(sub_sets->get_primary_key_column())->get_int();
-    DescriptorOrdering descriptor_ordering;
-    descriptor_ordering.append_sort(SortDescriptor{{{sub_sets->get_primary_key_column()}}, {false}});
-    descriptor_ordering.append_limit(LimitDescriptor{1});
-
-    auto res = sub_sets->where()
-                   .equal(m_sub_set_state, state_to_storage(SubscriptionSet::State::Complete))
-                   .Or()
-                   .equal(m_sub_set_state, state_to_storage(SubscriptionSet::State::AwaitingMark))
-                   .find_all(descriptor_ordering);
-    ret.active = res.is_empty() ? SubscriptionSet::EmptyVersion : res.get_object(0).get_primary_key().get_int();
-
-    res = sub_sets->where()
-              .equal(m_sub_set_state, state_to_storage(SubscriptionSet::State::AwaitingMark))
-              .find_all(descriptor_ordering);
-    ret.pending_mark = res.is_empty() ? SubscriptionSet::EmptyVersion : res.get_object(0).get_primary_key().get_int();
-
+    ret.active = get(*sub_sets->where()
+                          .equal(m_sub_set_state, state_to_storage(SubscriptionSet::State::Complete))
+                          .Or()
+                          .equal(m_sub_set_state, state_to_storage(SubscriptionSet::State::AwaitingMark))
+                          .max(m_sub_set_version_num));
+    ret.pending_mark = get(*sub_sets->where()
+                                .equal(m_sub_set_state, state_to_storage(SubscriptionSet::State::AwaitingMark))
+                                .max(m_sub_set_version_num));
     return ret;
 }
 
@@ -753,22 +771,21 @@ SubscriptionStore::get_next_pending_version(int64_t last_query_version) const
     // There should always be at least one SubscriptionSet - the zeroth subscription set for schema instructions.
     REALM_ASSERT(!sub_sets->is_empty());
 
-    DescriptorOrdering descriptor_ordering;
-    descriptor_ordering.append_sort(SortDescriptor{{{sub_sets->get_primary_key_column()}}, {true}});
-    auto res = sub_sets->where()
-                   .greater(sub_sets->get_primary_key_column(), last_query_version)
-                   .group()
-                   .equal(m_sub_set_state, state_to_storage(SubscriptionSet::State::Pending))
-                   .Or()
-                   .equal(m_sub_set_state, state_to_storage(SubscriptionSet::State::Bootstrapping))
-                   .end_group()
-                   .find_all(descriptor_ordering);
+    ObjKey key;
+    sub_sets->where()
+        .greater(sub_sets->get_primary_key_column(), last_query_version)
+        .group()
+        .equal(m_sub_set_state, state_to_storage(SubscriptionSet::State::Pending))
+        .Or()
+        .equal(m_sub_set_state, state_to_storage(SubscriptionSet::State::Bootstrapping))
+        .end_group()
+        .min(m_sub_set_version_num, &key);
 
-    if (res.is_empty()) {
+    if (!key) {
         return util::none;
     }
 
-    auto obj = res.get_object(0);
+    auto obj = sub_sets->get_object(key);
     auto query_version = obj.get_primary_key().get_int();
     auto snapshot_version = obj.get<int64_t>(m_sub_set_snapshot_version);
     return PendingSubscription{query_version, static_cast<DB::version_type>(snapshot_version)};
@@ -807,7 +824,6 @@ void SubscriptionStore::reset(Transaction& wt)
 
     util::CheckedUniqueLock lk(m_pending_notifications_mutex);
     auto to_finish = std::move(m_pending_notifications);
-    m_min_outstanding_version = 0;
     lk.unlock();
 
     for (auto& req : to_finish) {
@@ -815,57 +831,124 @@ void SubscriptionStore::reset(Transaction& wt)
     }
 }
 
-void SubscriptionStore::update_state(int64_t version, State new_state, std::optional<std::string_view> error_str)
+void SubscriptionStore::begin_bootstrap(const Transaction& tr, int64_t query_version)
 {
-    REALM_ASSERT(error_str.has_value() == (new_state == State::Error));
-    REALM_ASSERT(new_state != State::Pending);
-    REALM_ASSERT(new_state != State::Superseded);
+    auto sub_sets = tr.get_table(m_sub_set_table);
+    REALM_ASSERT(!sub_sets->is_empty());
+    Obj obj = sub_sets->get_object_with_primary_key(query_version);
+    if (!obj) {
+        throw RuntimeError(ErrorCodes::SyncProtocolInvariantFailed,
+                           util::format("Received bootstrap for nonexistent query version %1", query_version));
+    }
 
+    switch (auto old_state = state_from_storage(obj.get<int64_t>(m_sub_set_state))) {
+        case State::Complete:
+        case State::AwaitingMark:
+            // Once bootstrapping has completed it remains complete even if the
+            // server decides to send us more bootstrap messages
+            return;
+
+        case State::Pending:
+            obj.set(m_sub_set_state, state_to_storage(State::Bootstrapping));
+            break;
+
+        case State::Error: {
+            auto error = obj.get<String>(m_sub_set_error_str);
+            throw RuntimeError(ErrorCodes::SyncProtocolInvariantFailed,
+                               util::format("Received bootstrap for query version %1 after receiving the error '%2'",
+                                            query_version, error));
+        }
+
+        default:
+            // Any other state is an internal bug of some sort
+            REALM_ASSERT_EX(false, old_state);
+            static_cast<void>(old_state);
+    }
+}
+
+void SubscriptionStore::do_complete_bootstrap(const Transaction& tr, int64_t query_version, State new_state)
+{
+    auto sub_sets = tr.get_table(m_sub_set_table);
+    REALM_ASSERT(!sub_sets->is_empty());
+    Obj obj = sub_sets->get_object_with_primary_key(query_version);
+    // The sub set object being deleted while we're in the middle of applying
+    // a bootstrap would be an internal bug
+    REALM_ASSERT(obj);
+
+    switch (auto old_state = state_from_storage(obj.get<int64_t>(m_sub_set_state))) {
+        case State::Complete:
+        case State::AwaitingMark:
+            // We were applying a bootstrap for a subscription which had already
+            // completed applying a bootstrap, which means something like a
+            // permission change occurred server-side which triggered a rebootstrap.
+            return;
+
+        case State::Bootstrapping:
+            obj.set(m_sub_set_state, state_to_storage(new_state));
+            break;
+
+        default:
+            // Any other state is an internal bug of some sort
+            REALM_ASSERT_EX(false, old_state);
+            static_cast<void>(old_state);
+    }
+
+    // Supersede all older subscription sets
+    if (new_state == State::AwaitingMark) {
+        sub_sets->where().less(m_sub_set_version_num, query_version).remove();
+    }
+}
+
+void SubscriptionStore::complete_bootstrap(const Transaction& tr, int64_t query_version)
+{
+    do_complete_bootstrap(tr, query_version, State::AwaitingMark);
+}
+
+void SubscriptionStore::cancel_bootstrap(const Transaction& tr, int64_t query_version)
+{
+    do_complete_bootstrap(tr, query_version, State::Pending);
+}
+
+void SubscriptionStore::set_error(int64_t query_version, std::string_view error_str)
+{
     auto tr = m_db->start_write();
     auto sub_sets = tr->get_table(m_sub_set_table);
-    auto obj = sub_sets->get_object_with_primary_key(version);
+    auto obj = sub_sets->get_object_with_primary_key(query_version);
     if (!obj) {
         // This can happen either due to a bug in the sync client or due to the
         // server sending us an error message for an invalid query version. We
         // assume it is the latter here.
         throw RuntimeError(ErrorCodes::SyncProtocolInvariantFailed,
-                           util::format("Invalid state update for nonexistent query version %1", version));
+                           util::format("Invalid state update for nonexistent query version %1", query_version));
     }
 
     auto old_state = state_from_storage(obj.get<int64_t>(m_sub_set_state));
-    switch (new_state) {
-        case State::Error:
-            if (old_state == State::Complete) {
-                throw RuntimeError(ErrorCodes::SyncProtocolInvariantFailed,
-                                   util::format("Received error '%1' for already-completed query version %2. This "
-                                                "may be due to a queryable field being removed in the server-side "
-                                                "configuration making the previous subscription set no longer valid.",
-                                                *error_str, version));
-            }
-            break;
-
-        case State::Bootstrapping:
-        case State::AwaitingMark:
-            REALM_ASSERT(old_state != State::Complete);
-            REALM_ASSERT(old_state != State::Error);
-            break;
-
-        case State::Complete:
-            supercede_prior_to(tr, version);
-            break;
-
-        case State::Uncommitted:
-        case State::Superseded:
-        case State::Pending:
-            REALM_TERMINATE("Illegal new state for subscription set");
+    if (old_state == State::Complete) {
+        throw RuntimeError(ErrorCodes::SyncProtocolInvariantFailed,
+                           util::format("Received error '%1' for already-completed query version %2. This "
+                                        "may be due to a queryable field being removed in the server-side "
+                                        "configuration making the previous subscription set no longer valid.",
+                                        error_str, query_version));
     }
 
-    obj.set(m_sub_set_state, state_to_storage(new_state));
-    obj.set(m_sub_set_error_str, error_str ? StringData(*error_str) : StringData());
-
+    obj.set(m_sub_set_state, state_to_storage(State::Error));
+    obj.set(m_sub_set_error_str, error_str);
     tr->commit();
+}
 
-    process_notifications(new_state, version, error_str.value_or(std::string_view{}));
+void SubscriptionStore::download_complete()
+{
+    auto tr = m_db->start_read();
+    auto obj = get_active(*tr);
+    if (state_from_storage(obj.get<int64_t>(m_sub_set_state)) != State::AwaitingMark)
+        return;
+
+    // Although subscription sets can be created from any thread or process,
+    // they're only *modified* on the sync client thread, so we don't have to
+    // recheck that things have changed after the promote to write
+    tr->promote_to_write();
+    obj.set(m_sub_set_state, state_to_storage(State::Complete));
+    tr->commit();
 }
 
 SubscriptionSet SubscriptionStore::get_by_version(int64_t version_id)
@@ -875,9 +958,8 @@ SubscriptionSet SubscriptionStore::get_by_version(int64_t version_id)
     if (auto obj = sub_sets->get_object_with_primary_key(version_id)) {
         return SubscriptionSet(weak_from_this(), *tr, obj);
     }
-
-    util::CheckedLockGuard lk(m_pending_notifications_mutex);
-    if (version_id < m_min_outstanding_version) {
+    REALM_ASSERT(!sub_sets->is_empty());
+    if (version_id < sub_sets->min(m_sub_set_version_num)->get_int()) {
         return SubscriptionSet(weak_from_this(), version_id, SubscriptionSet::SupersededTag{});
     }
     throw KeyNotFound(util::format("Subscription set with version %1 not found", version_id));
@@ -910,14 +992,6 @@ SubscriptionStore::TableSet SubscriptionStore::get_tables_for_latest(const Trans
     }
 
     return ret;
-}
-
-void SubscriptionStore::supercede_prior_to(TransactionRef tr, int64_t version_id) const
-{
-    auto sub_sets = tr->get_table(m_sub_set_table);
-    Query remove_query(sub_sets);
-    remove_query.less(sub_sets->get_primary_key_column(), version_id);
-    remove_query.remove();
 }
 
 MutableSubscriptionSet SubscriptionStore::make_mutable_copy(const SubscriptionSet& set)

--- a/test/object-store/sync/flx_sync.cpp
+++ b/test/object-store/sync/flx_sync.cpp
@@ -2793,6 +2793,13 @@ TEST_CASE("flx: bootstrap batching prevents orphan documents", "[sync][flx][boot
         REQUIRE(latest_subs.at(0).object_class_name == "TopLevel");
     };
 
+    auto peek_pending_state = [](const DBRef& db) {
+        auto logger = util::Logger::get_default_logger();
+        sync::PendingBootstrapStore bootstrap_store(db, *logger, nullptr);
+        REQUIRE(bootstrap_store.has_pending());
+        return bootstrap_store.peek_pending(*db->start_read(), 1024 * 1024 * 16);
+    };
+
     auto mutate_realm = [&] {
         harness.load_initial_data([&](SharedRealm realm) {
             auto table = realm->read_group().get_table("class_TopLevel");
@@ -2847,10 +2854,7 @@ TEST_CASE("flx: bootstrap batching prevents orphan documents", "[sync][flx][boot
             DBOptions options;
             options.encryption_key = test_util::crypt_key();
             auto realm = DB::create(sync::make_client_replication(), interrupted_realm_config.path, options);
-            auto logger = util::Logger::get_default_logger();
-            sync::PendingBootstrapStore bootstrap_store(realm, *logger);
-            REQUIRE(bootstrap_store.has_pending());
-            auto pending_batch = bootstrap_store.peek_pending(1024 * 1024 * 16);
+            auto pending_batch = peek_pending_state(realm);
             REQUIRE(pending_batch.query_version == 1);
             REQUIRE(pending_batch.progress);
 
@@ -2940,10 +2944,7 @@ TEST_CASE("flx: bootstrap batching prevents orphan documents", "[sync][flx][boot
             DBOptions options;
             options.encryption_key = test_util::crypt_key();
             auto realm = DB::create(sync::make_client_replication(), interrupted_realm_config.path, options);
-            util::StderrLogger logger;
-            sync::PendingBootstrapStore bootstrap_store(realm, logger);
-            REQUIRE(bootstrap_store.has_pending());
-            auto pending_batch = bootstrap_store.peek_pending(1024 * 1024 * 16);
+            auto pending_batch = peek_pending_state(realm);
             REQUIRE(pending_batch.query_version == 1);
             REQUIRE(pending_batch.progress);
 
@@ -3009,10 +3010,7 @@ TEST_CASE("flx: bootstrap batching prevents orphan documents", "[sync][flx][boot
             DBOptions options;
             options.encryption_key = test_util::crypt_key();
             auto realm = DB::create(sync::make_client_replication(), interrupted_realm_config.path, options);
-            auto logger = util::Logger::get_default_logger();
-            sync::PendingBootstrapStore bootstrap_store(realm, *logger);
-            REQUIRE(bootstrap_store.has_pending());
-            auto pending_batch = bootstrap_store.peek_pending(1024 * 1024 * 16);
+            auto pending_batch = peek_pending_state(realm);
             REQUIRE(pending_batch.query_version == 1);
             REQUIRE(!pending_batch.progress);
             REQUIRE(pending_batch.remaining_changesets == 0);
@@ -3086,10 +3084,7 @@ TEST_CASE("flx: bootstrap batching prevents orphan documents", "[sync][flx][boot
             DBOptions options;
             options.encryption_key = test_util::crypt_key();
             auto realm = DB::create(sync::make_client_replication(), interrupted_realm_config.path, options);
-            auto logger = util::Logger::get_default_logger();
-            sync::PendingBootstrapStore bootstrap_store(realm, *logger);
-            REQUIRE(bootstrap_store.has_pending());
-            auto pending_batch = bootstrap_store.peek_pending(1024 * 1024 * 16);
+            auto pending_batch = peek_pending_state(realm);
             REQUIRE(pending_batch.query_version == 1);
             REQUIRE(static_cast<bool>(pending_batch.progress));
             REQUIRE(pending_batch.remaining_changesets == 0);

--- a/test/object-store/util/sync/sync_test_utils.cpp
+++ b/test/object-store/util/sync/sync_test_utils.cpp
@@ -436,7 +436,7 @@ struct FakeLocalClientReset : public TestClientReset {
                                            {ErrorCodes::SyncClientResetRequired, "Bad client file ident"}};
 
             using _impl::client_reset::perform_client_reset_diff;
-            perform_client_reset_diff(*local_db, reset_config, *logger, nullptr, [](int64_t) {});
+            perform_client_reset_diff(*local_db, reset_config, *logger, nullptr);
 
             remote_realm->close();
             if (m_on_post_reset) {

--- a/test/test_client_reset.cpp
+++ b/test/test_client_reset.cpp
@@ -916,8 +916,8 @@ void expect_reset(unit_test::TestContext& test_context, DBRef& target, DBRef& fr
 
     sync::ClientReset cr_config{mode, fresh, error, action};
 
-    bool did_reset = _impl::client_reset::perform_client_reset(*test_context.logger, *target, std::move(cr_config),
-                                                               sub_store, [](int64_t) {});
+    bool did_reset =
+        _impl::client_reset::perform_client_reset(*test_context.logger, *target, std::move(cr_config), sub_store);
     CHECK(did_reset);
 
     // Should have closed and deleted the fresh realm
@@ -1121,8 +1121,8 @@ TEST(ClientReset_UninitializedFile)
 
     // Should not perform a client reset because the target file has never been
     // written to
-    bool did_reset = _impl::client_reset::perform_client_reset(*test_context.logger, *db_empty, std::move(cr_config),
-                                                               nullptr, [](int64_t) {});
+    bool did_reset =
+        _impl::client_reset::perform_client_reset(*test_context.logger, *db_empty, std::move(cr_config), nullptr);
     CHECK_NOT(did_reset);
     auto rd_tr = db_empty->start_frozen();
     CHECK_NOT(PendingResetStore::has_pending_reset(rd_tr));
@@ -1293,9 +1293,9 @@ TEST(ClientReset_Recover_RecoveryDisabled)
                                 {ErrorCodes::SyncClientResetRequired, "Bad client file identifier (IDENT)"},
                                 sync::ProtocolErrorInfo::Action::ClientResetNoRecovery};
 
-    CHECK_THROW((_impl::client_reset::perform_client_reset(*test_context.logger, *dbs.first, std::move(cr_config),
-                                                           nullptr, [](int64_t) {})),
-                sync::ClientResetFailed);
+    CHECK_THROW(
+        _impl::client_reset::perform_client_reset(*test_context.logger, *dbs.first, std::move(cr_config), nullptr),
+        sync::ClientResetFailed);
     auto rd_tr = dbs.first->start_frozen();
     CHECK_NOT(PendingResetStore::has_pending_reset(rd_tr));
 }
@@ -1542,15 +1542,15 @@ TEST(ClientReset_Recover_UploadableBytes)
     uint_fast64_t unused, pre_reset_uploadable_bytes;
     DownloadableProgress unused_progress;
     version_type unused_version;
-    history.get_upload_download_state(*db, unused, unused_progress, unused, pre_reset_uploadable_bytes, unused,
-                                      unused_version);
+    history.get_upload_download_state(*db->start_read(), db->get_alloc(), unused, unused_progress, unused,
+                                      pre_reset_uploadable_bytes, unused, unused_version);
     CHECK_GREATER(pre_reset_uploadable_bytes, 0);
 
     expect_reset(test_context, db, db_fresh, ClientResyncMode::Recover, nullptr);
 
     uint_fast64_t post_reset_uploadable_bytes;
-    history.get_upload_download_state(*db, unused, unused_progress, unused, post_reset_uploadable_bytes, unused,
-                                      unused_version);
+    history.get_upload_download_state(*db->start_read(), db->get_alloc(), unused, unused_progress, unused,
+                                      post_reset_uploadable_bytes, unused, unused_version);
     CHECK_GREATER(post_reset_uploadable_bytes, 0);
     CHECK_GREATER(pre_reset_uploadable_bytes, post_reset_uploadable_bytes);
 }

--- a/test/test_sync_pending_bootstraps.cpp
+++ b/test/test_sync_pending_bootstraps.cpp
@@ -1,6 +1,7 @@
 #include "realm/db.hpp"
 #include "realm/sync/noinst/client_history_impl.hpp"
 #include "realm/sync/noinst/pending_bootstrap_store.hpp"
+#include "realm/sync/subscriptions.hpp"
 
 #include "test.hpp"
 #include "util/test_path.hpp"
@@ -14,9 +15,13 @@ TEST(Sync_PendingBootstrapStoreBatching)
     progress.download = {5, 5};
     progress.latest_server_version = {5, 123456789};
     progress.upload = {5, 5};
+
     {
         auto db = DB::create(make_client_replication(), db_path);
-        sync::PendingBootstrapStore store(db, *test_context.logger);
+        auto sub_store = sync::SubscriptionStore::create(db);
+        sync::PendingBootstrapStore store(db, *test_context.logger, sub_store);
+        int64_t query_version = sub_store->get_latest().make_mutable_copy().commit().version();
+        CHECK_EQUAL(sub_store->get_by_version(query_version).state(), SubscriptionSet::State::Pending);
 
         CHECK(!store.has_pending());
         std::vector<RemoteChangeset> changesets;
@@ -32,11 +37,10 @@ TEST(Sync_PendingBootstrapStoreBatching)
         changesets.emplace_back(3, 8, BinaryData(changeset_data.back()), 3, 1);
         changesets.back().original_changeset_size = 1024;
 
-        bool created_new_batch = false;
-        store.add_batch(1, util::none, 0, changesets, &created_new_batch);
+        store.add_batch(query_version, util::none, 0, changesets);
 
-        CHECK(created_new_batch);
         CHECK(store.has_pending());
+        CHECK_EQUAL(sub_store->get_by_version(query_version).state(), SubscriptionSet::State::Bootstrapping);
 
         changesets.clear();
         changeset_data.clear();
@@ -47,13 +51,14 @@ TEST(Sync_PendingBootstrapStoreBatching)
         changesets.emplace_back(5, 10, BinaryData(changeset_data.back()), 5, 3);
         changesets.back().original_changeset_size = 1024;
 
-        store.add_batch(1, progress, 1, changesets, &created_new_batch);
-        CHECK(!created_new_batch);
+        store.add_batch(query_version, progress, 1, changesets);
+        CHECK_EQUAL(sub_store->get_by_version(query_version).state(), SubscriptionSet::State::Bootstrapping);
     }
 
     {
         auto db = DB::create(make_client_replication(), db_path);
-        sync::PendingBootstrapStore store(db, *test_context.logger);
+        auto sub_store = sync::SubscriptionStore::create(db);
+        sync::PendingBootstrapStore store(db, *test_context.logger, sub_store);
         CHECK(store.has_pending());
 
         auto stats = store.pending_stats();
@@ -61,7 +66,7 @@ TEST(Sync_PendingBootstrapStoreBatching)
         CHECK_EQUAL(stats.pending_changesets, 5);
         CHECK_EQUAL(stats.query_version, 1);
 
-        auto pending_batch = store.peek_pending((1024 * 3) - 1);
+        auto pending_batch = store.peek_pending(*db->start_read(), (1024 * 3) - 1);
         CHECK_EQUAL(pending_batch.changesets.size(), 3);
         CHECK_EQUAL(pending_batch.remaining_changesets, 2);
         CHECK_EQUAL(pending_batch.query_version, 1);
@@ -87,11 +92,11 @@ TEST(Sync_PendingBootstrapStoreBatching)
         validate_changeset(2, 3, 8, 'c', 3, 1);
 
         auto tr = db->start_write();
-        store.pop_front_pending(tr, pending_batch.changesets.size());
+        store.pop_front_pending(*tr, pending_batch.changesets.size());
         tr->commit();
         CHECK(store.has_pending());
 
-        pending_batch = store.peek_pending(1024 * 2);
+        pending_batch = store.peek_pending(*db->start_read(), 1024 * 2);
         CHECK_EQUAL(pending_batch.changesets.size(), 2);
         CHECK_EQUAL(pending_batch.remaining_changesets, 0);
         CHECK_EQUAL(pending_batch.query_version, 1);
@@ -100,9 +105,10 @@ TEST(Sync_PendingBootstrapStoreBatching)
         validate_changeset(1, 5, 10, 'e', 5, 3);
 
         tr = db->start_write();
-        store.pop_front_pending(tr, pending_batch.changesets.size());
+        store.pop_front_pending(*tr, pending_batch.changesets.size());
         tr->commit();
         CHECK(!store.has_pending());
+        CHECK_EQUAL(sub_store->get_latest().state(), SubscriptionSet::State::AwaitingMark);
     }
 }
 
@@ -114,7 +120,8 @@ TEST(Sync_PendingBootstrapStoreClear)
     progress.latest_server_version = {5, 123456789};
     progress.upload = {5, 5};
     auto db = DB::create(make_client_replication(), db_path);
-    sync::PendingBootstrapStore store(db, *test_context.logger);
+    auto sub_store = sync::SubscriptionStore::create(db);
+    sync::PendingBootstrapStore store(db, *test_context.logger, sub_store);
 
     CHECK(!store.has_pending());
     std::vector<RemoteChangeset> changesets;
@@ -127,25 +134,23 @@ TEST(Sync_PendingBootstrapStoreClear)
     changesets.emplace_back(2, 7, BinaryData(changeset_data.back()), 2, 1);
     changesets.back().original_changeset_size = 1024;
 
-    bool created_new_batch = false;
-    store.add_batch(2, progress, 1, changesets, &created_new_batch);
-    CHECK(created_new_batch);
+    int64_t query_version = sub_store->get_latest().make_mutable_copy().commit().version();
+    store.add_batch(query_version, progress, 1, changesets);
     CHECK(store.has_pending());
+    CHECK_EQUAL(SubscriptionSet::State::Bootstrapping, sub_store->get_latest().state());
 
-    auto pending_batch = store.peek_pending(1025);
+    auto pending_batch = store.peek_pending(*db->start_read(), 1025);
     CHECK_EQUAL(pending_batch.remaining_changesets, 0);
-    CHECK_EQUAL(pending_batch.query_version, 2);
+    CHECK_EQUAL(pending_batch.query_version, query_version);
     CHECK(pending_batch.progress);
     CHECK_EQUAL(pending_batch.changesets.size(), 2);
 
-    store.clear();
+    auto tr = db->start_write();
+    store.clear(*tr, query_version);
+    tr->commit();
 
+    CHECK_EQUAL(SubscriptionSet::State::Pending, sub_store->get_latest().state());
     CHECK_NOT(store.has_pending());
-    pending_batch = store.peek_pending(1024);
-    CHECK_EQUAL(pending_batch.changesets.size(), 0);
-    CHECK_EQUAL(pending_batch.query_version, 0);
-    CHECK_EQUAL(pending_batch.remaining_changesets, 0);
-    CHECK_NOT(pending_batch.progress);
 }
 
 } // namespace realm::sync

--- a/test/util/unit_test.hpp
+++ b/test/util/unit_test.hpp
@@ -163,6 +163,20 @@
         }                                                                                                            \
     }())
 
+#define CHECK_THROW_ERROR(expr, ec, message)                                                                         \
+    ([&] {                                                                                                           \
+        try {                                                                                                        \
+            (expr);                                                                                                  \
+            test_context.throw_any_failed(__FILE__, __LINE__, #expr);                                                \
+        }                                                                                                            \
+        catch (const Exception& e) {                                                                                 \
+            CHECK_EQUAL(e.code(), ErrorCodes::ec);                                                                   \
+            CHECK_STRING_CONTAINS(e.what(), message);                                                                \
+            return true;                                                                                             \
+        }                                                                                                            \
+        return false;                                                                                                \
+    }())
+
 #define CHECK_NOTHROW(expr)                                                                                          \
     ([&] {                                                                                                           \
         try {                                                                                                        \


### PR DESCRIPTION
As with the other multi-process notifications, the core idea here is to eliminate the in-memory state and produce notifications based entirely on the current state of the Realm file.

SubscriptionStore::update_state() has been replaced with separate functions for the specific legal state transitions, which also take a write transaction as a parameter. These functions are called by PendingBootstrapStore inside the same write transaction as the bootstrap updates which changed the subscription state. This is both a minor performance optimization (due to fewer writes) and eliminates a brief window between the two writes where the Realm file was in an inconsistent state.

There's a minor functional change here: previously old subscription sets were superseded when the new one reached the Completed state, and now they are superseded on AwaitingMark. This aligns it with when the new subscription set becomes the one which is returned by get_active().

Fixes #7861.