### PR TITLE
[C-API] Add relaxed schema configuration option

### DIFF
--- a/src/realm.h
+++ b/src/realm.h
@@ -926,6 +926,11 @@ RLM_API bool realm_config_get_cached(realm_config_t*) RLM_API_NOEXCEPT;
 RLM_API void realm_config_set_automatic_backlink_handling(realm_config_t*, bool) RLM_API_NOEXCEPT;
 
 /**
+ * Allow realm objects in the realm to have additional properties that are not defined in the schema.
+ */
+RLM_API void realm_config_set_flexible_schema(realm_config_t*, bool) RLM_API_NOEXCEPT;
+
+/**
  * Create a custom scheduler object from callback functions.
  *
  * @param notify Function which will be called whenever the scheduler has work

--- a/src/realm/object-store/c_api/config.cpp
+++ b/src/realm/object-store/c_api/config.cpp
@@ -243,3 +243,9 @@ RLM_API void realm_config_set_automatic_backlink_handling(realm_config_t* realm_
 {
     realm_config->automatically_handle_backlinks_in_migrations = enable_automatic_handling;
 }
+
+RLM_API void realm_config_set_flexible_schema(realm_config_t* realm_config,
+                                             bool flexible_schema) noexcept
+{
+    realm_config->flexible_schema = flexible_schema;
+}


### PR DESCRIPTION
## What, How & Why?
Expose new configuration option to C-API

```
RLM_API void realm_config_set_flexible_schema(realm_config_t* realm_config,
                                             bool flexible_schema) noexcept
{
    realm_config->flexible_schema = flexible_schema;
}
```

## ☑️ ToDos
* [ ] ~~📝 Changelog update~~ 
* [ ] ~~🚦 Tests (or not relevant)~~ Considered to be tested as part of the overall feature
* [x] C-API, if public C++ API changed
* [ ] `bindgen/spec.yml`, if public C++ API changed
