### PR TITLE
RCORE-2192 RCORE-2193 Fix FLX download progress reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* FLX download progress was only updated when bootstraps completed, making it always be 0 before the first completion and then forever 1. ([PR #7869](https://github.com/realm/realm-core/issues/7869), since v14.10.2)
 
 ### Breaking changes
 * None.

--- a/src/realm/object-store/sync/async_open_task.hpp
+++ b/src/realm/object-store/sync/async_open_task.hpp
@@ -21,6 +21,7 @@
 
 #include <realm/util/checked_mutex.hpp>
 #include <realm/util/functional.hpp>
+#include <realm/util/future.hpp>
 
 #include <memory>
 #include <vector>
@@ -47,12 +48,20 @@ public:
                            std::shared_ptr<realm::SyncSession> session, bool db_open_for_the_first_time);
     AsyncOpenTask(const AsyncOpenTask&) = delete;
     AsyncOpenTask& operator=(const AsyncOpenTask&) = delete;
+
     // Starts downloading the Realm. The callback will be triggered either when the download completes
     // or an error is encountered.
     //
     // If multiple AsyncOpenTasks all attempt to download the same Realm and one of them is canceled,
     // the other tasks will receive a "Cancelled" exception.
     void start(AsyncOpenCallback callback) REQUIRES(!m_mutex);
+
+    // Starts downloading the Realm. The future will be fulfilled either when the download completes
+    // or an error is encountered.
+    //
+    // If multiple AsyncOpenTasks all attempt to download the same Realm and one of them is canceled,
+    // the other tasks will receive a cancelled Status
+    util::Future<ThreadSafeReference> start() REQUIRES(!m_mutex);
 
     // Cancels the download and stops the session. No further functions should be called on this class.
     void cancel() REQUIRES(!m_mutex);

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -1710,8 +1710,8 @@ void SessionWrapper::report_progress(ReportedProgress& p, DownloadableProgress d
     bool download_completed = p.downloaded == 0;
     p.download_estimate = 1.00;
     if (m_flx_pending_bootstrap_store) {
+        p.download_estimate = downloadable.as_estimate();
         if (m_flx_pending_bootstrap_store->has_pending()) {
-            p.download_estimate = downloadable.as_estimate();
             p.downloaded += m_flx_pending_bootstrap_store->pending_stats().pending_changeset_bytes;
         }
         download_completed = p.download_estimate >= 1.0;

--- a/src/realm/sync/noinst/client_history_impl.cpp
+++ b/src/realm/sync/noinst/client_history_impl.cpp
@@ -953,6 +953,18 @@ void ClientHistory::update_sync_progress(const SyncProgress& progress, Downloada
     trim_sync_history(); // Throws
 }
 
+void ClientHistory::set_download_progress(Transaction& tr, DownloadableProgress p)
+{
+    using gf = _impl::GroupFriend;
+    ref_type ref = gf::get_history_ref(tr);
+    REALM_ASSERT(ref);
+    Array root(gf::get_alloc(tr));
+    root.init_from_ref(ref);
+    gf::set_history_parent(tr, root);
+    REALM_ASSERT(root.size() > s_progress_uploadable_bytes_iip);
+    root.set(s_progress_downloadable_bytes_iip,
+             RefOrTagged::make_tagged(p.as_bytes())); // Throws
+}
 
 void ClientHistory::trim_ct_history()
 {

--- a/src/realm/sync/noinst/client_history_impl.hpp
+++ b/src/realm/sync/noinst/client_history_impl.hpp
@@ -258,6 +258,15 @@ public:
                                           std::uint_fast64_t&, std::uint_fast64_t&, version_type&);
     static void get_upload_download_state(DB*, std::uint_fast64_t&, std::uint_fast64_t&);
 
+    /// Record the current download progress.
+    ///
+    /// This is used when storing FLX bootstraps to make the progress available
+    /// to other processes which are observing the file. It must be called
+    /// inside of a write transaction. The data stored here is only meaningful
+    /// until the next call of integrate_server_changesets(), which will
+    /// overwrite it.
+    static void set_download_progress(Transaction& tr, DownloadableProgress);
+
     // Overriding member functions in realm::TransformHistory
     version_type find_history_entry(version_type, version_type, HistoryEntry&) const noexcept override;
     ChunkedBinaryData get_reciprocal_transform(version_type, bool&) const override;

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -2467,7 +2467,8 @@ Status Session::receive_download_message(const DownloadMessage& message)
     }
     REALM_ASSERT_EX(hook_action == SyncClientHookAction::NoAction, hook_action);
 
-    if (process_flx_bootstrap_message(progress, batch_state, query_version, message.changesets)) {
+    if (process_flx_bootstrap_message(progress, batch_state, query_version, message.downloadable,
+                                      message.changesets)) {
         clear_resumption_delay_state();
         return Status::OK();
     }

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -2467,8 +2467,7 @@ Status Session::receive_download_message(const DownloadMessage& message)
     }
     REALM_ASSERT_EX(hook_action == SyncClientHookAction::NoAction, hook_action);
 
-    if (process_flx_bootstrap_message(progress, batch_state, query_version, message.downloadable,
-                                      message.changesets)) {
+    if (process_flx_bootstrap_message(message)) {
         clear_resumption_delay_state();
         return Status::OK();
     }

--- a/src/realm/sync/noinst/client_impl_base.hpp
+++ b/src/realm/sync/noinst/client_impl_base.hpp
@@ -920,9 +920,7 @@ private:
     // Processes an FLX download message, if it's a bootstrap message. If it's not a bootstrap
     // message then this is a noop and will return false. Otherwise this will return true
     // and no further processing of the download message should take place.
-    bool process_flx_bootstrap_message(const SyncProgress& progress, DownloadBatchState batch_state,
-                                       int64_t query_version, DownloadableProgress download_progress,
-                                       const ReceivedChangesets& received_changesets);
+    bool process_flx_bootstrap_message(const DownloadMessage& message);
 
     // Processes any pending FLX bootstraps, if one exists. Otherwise this is a noop.
     void process_pending_flx_bootstrap();

--- a/src/realm/sync/noinst/client_impl_base.hpp
+++ b/src/realm/sync/noinst/client_impl_base.hpp
@@ -921,7 +921,8 @@ private:
     // message then this is a noop and will return false. Otherwise this will return true
     // and no further processing of the download message should take place.
     bool process_flx_bootstrap_message(const SyncProgress& progress, DownloadBatchState batch_state,
-                                       int64_t query_version, const ReceivedChangesets& received_changesets);
+                                       int64_t query_version, DownloadableProgress download_progress,
+                                       const ReceivedChangesets& received_changesets);
 
     // Processes any pending FLX bootstraps, if one exists. Otherwise this is a noop.
     void process_pending_flx_bootstrap();

--- a/src/realm/sync/noinst/pending_bootstrap_store.cpp
+++ b/src/realm/sync/noinst/pending_bootstrap_store.cpp
@@ -25,6 +25,7 @@
 #include "realm/list.hpp"
 #include "realm/query.hpp"
 #include "realm/sync/changeset_parser.hpp"
+#include "realm/sync/noinst/client_history_impl.hpp"
 #include "realm/sync/noinst/protocol_codec.hpp"
 #include "realm/sync/noinst/sync_metadata_schema.hpp"
 #include "realm/sync/protocol.hpp"
@@ -127,6 +128,7 @@ PendingBootstrapStore::PendingBootstrapStore(DBRef db, util::Logger& logger)
 }
 
 void PendingBootstrapStore::add_batch(int64_t query_version, util::Optional<SyncProgress> progress,
+                                      DownloadableProgress download_progress,
                                       const _impl::ClientProtocol::ReceivedChangesets& changesets,
                                       bool* created_new_batch_out)
 {
@@ -175,6 +177,8 @@ void PendingBootstrapStore::add_batch(int64_t query_version, util::Optional<Sync
         BinaryData compressed_data(compressed_changesets[idx].data(), compressed_changesets[idx].size());
         cur_changeset.set(m_changeset_data, compressed_data);
     }
+
+    ClientHistory::set_download_progress(*tr, download_progress);
 
     tr->commit();
 

--- a/src/realm/sync/noinst/pending_bootstrap_store.hpp
+++ b/src/realm/sync/noinst/pending_bootstrap_store.hpp
@@ -79,7 +79,8 @@ public:
 
     // Adds a set of changesets to the store.
     void add_batch(int64_t query_version, util::Optional<SyncProgress> progress,
-                   const std::vector<RemoteChangeset>& changesets, bool* created_new_batch);
+                   DownloadableProgress download_progress, const std::vector<RemoteChangeset>& changesets,
+                   bool* created_new_batch);
 
     void clear();
     void clear(Transaction& wt);

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -4471,22 +4471,7 @@ TEST_CASE("app: full-text compatible with sync", "[sync][app][baas]") {
         INFO("realm opened with async open");
         auto async_open_task = Realm::get_synchronized_realm(config);
 
-        auto [realm_promise, realm_future] = util::make_promise_future<ThreadSafeReference>();
-        async_open_task->start(
-            [promise = std::move(realm_promise)](ThreadSafeReference ref, std::exception_ptr ouch) mutable {
-                if (ouch) {
-                    try {
-                        std::rethrow_exception(ouch);
-                    }
-                    catch (...) {
-                        promise.set_error(exception_to_status());
-                    }
-                }
-                else {
-                    promise.emplace_value(std::move(ref));
-                }
-            });
-
+        auto realm_future = async_open_task->start();
         realm = Realm::get_shared_realm(std::move(realm_future.get()));
     }
 

--- a/test/object-store/sync/flx_sync.cpp
+++ b/test/object-store/sync/flx_sync.cpp
@@ -4690,20 +4690,8 @@ TEST_CASE("flx sync: Client reset during async open", "[sync][flx][client reset]
     };
 
     auto realm_task = Realm::get_synchronized_realm(realm_config);
-    auto realm_pf = util::make_promise_future<SharedRealm>();
-    realm_task->start([&](ThreadSafeReference ref, std::exception_ptr ex) {
-        auto& promise = realm_pf.promise;
-        try {
-            if (ex) {
-                std::rethrow_exception(ex);
-            }
-            promise.emplace_value(Realm::get_shared_realm(std::move(ref), util::Scheduler::make_dummy()));
-        }
-        catch (...) {
-            promise.set_error(exception_to_status());
-        }
-    });
-    auto realm = realm_pf.future.get();
+    auto realm_future = realm_task->start();
+    auto realm = Realm::get_shared_realm(std::move(realm_future).get(), util::Scheduler::make_dummy());
     before_callback_called.future.get();
     after_callback_called.future.get();
     REQUIRE(subscription_invoked.load());

--- a/test/object-store/sync/session/progress_notifications.cpp
+++ b/test/object-store/sync/session/progress_notifications.cpp
@@ -880,7 +880,7 @@ TEST_CASE("progress notification", "[sync][session][progress]") {
     SECTION("flx streaming notifiers") {
         // clang-format off
         TestValues test_values = GENERATE(
-            // resgisters at the begining and should see all entries.
+            // registers at the begining and should see all entries.
             TestValues{{
                 TestInputValue{TestInputValue::IsRegistration{}},
                 TestInputValue{0, 0, 0, 0},
@@ -903,6 +903,7 @@ TEST_CASE("progress notification", "[sync][session][progress]") {
                 ProgressEntry{900, 1000, 0.6},
                 ProgressEntry{1000, 1000, 1},
             }, 1},
+            // registers in the middle of the initial download
             TestValues{{
                 TestInputValue{1, 0.2, 300, 600},
                 TestInputValue{1, 0.4, 400, 600},
@@ -924,6 +925,28 @@ TEST_CASE("progress notification", "[sync][session][progress]") {
             }, {
                 ProgressEntry{900, 900, 1},
                 ProgressEntry{1000, 1000, 1},
+            }, 1},
+            // new subscription is added after registration which results in more data being downloaded
+            TestValues{{
+                TestInputValue{2, 1, 900, 900},
+                TestInputValue{TestInputValue::IsRegistration{}},
+                TestInputValue{3, 0, 900, 1000},
+                TestInputValue{3, 1, 1000, 1000}
+            }, {
+                ProgressEntry{900, 900, 1},
+                ProgressEntry{900, 1000, 0},
+                ProgressEntry{1000, 1000, 1},
+            }, 1},
+            // new subscription is added after registration which doesn't result in more data being downloaded
+            TestValues{{
+                TestInputValue{2, 1, 900, 900},
+                TestInputValue{TestInputValue::IsRegistration{}},
+                TestInputValue{3, 0, 900, 900},
+                TestInputValue{3, 1, 900, 900}
+            }, {
+                ProgressEntry{900, 900, 1},
+                ProgressEntry{900, 900, 0},
+                ProgressEntry{900, 900, 1},
             }, 1}
         );
         // clang-format on
@@ -987,7 +1010,6 @@ TEST_CASE("progress notification", "[sync][session][progress]") {
             // registers for a notifier for a later query version - should only see notifications
             // for downloads greater than the requested query version
             TestValues{{
-
                 TestInputValue{TestInputValue::IsRegistration{}},
                 TestInputValue{1, 0.8, 700, 700},
                 TestInputValue{1, 1, 700, 700},
@@ -1171,22 +1193,7 @@ TEMPLATE_TEST_CASE("progress notifications fire immediately when fully caught up
         auto async_open_task = Realm::get_synchronized_realm(config);
         auto async_open_progress = util::make_bind<WaitableProgress>(logger, "async open non-streaming progress ");
         async_open_task->register_download_progress_notifier(async_open_progress->make_cb());
-        auto [promise, future] = util::make_promise_future<ThreadSafeReference>();
-        async_open_task->start(
-            [promise = std::move(promise)](ThreadSafeReference ref, std::exception_ptr ouch) mutable {
-                if (ouch) {
-                    try {
-                        std::rethrow_exception(ouch);
-                    }
-                    catch (...) {
-                        promise.set_error(exception_to_status());
-                    }
-                }
-                else {
-                    promise.emplace_value(std::move(ref));
-                }
-            });
-
+        auto future = async_open_task->start();
         auto realm = Realm::get_shared_realm(std::move(future).get());
         auto noop_download_progress = util::make_bind<WaitableProgress>(logger, "non-streaming download ");
         auto noop_token = realm->sync_session()->register_progress_notifier(
@@ -1294,6 +1301,162 @@ TEMPLATE_TEST_CASE("sync progress: upload progress", "[sync][baas][progress]", P
     streaming_entries = streaming_progress->wait_for_full_sync();
     REQUIRE_THAT(streaming_entries, ProgressIncreasesMatcher{ProgressIncreasesMatcher::ByteCountOnly});
     REQUIRE(non_streaming_progress->empty());
+}
+
+namespace {
+struct EstimatesAreValid : Catch::Matchers::MatcherGenericBase {
+    bool match(std::vector<double> const& entries) const
+    {
+        double last = -1;
+        // Estimated progress must be monotonically increasing and end with 1
+        for (double estimate : entries) {
+            if (estimate < 0 || estimate > 1 || estimate <= last)
+                return false;
+            last = estimate;
+        }
+        return last == 1;
+    }
+
+    std::string describe() const override
+    {
+        return "estimated progress must be monotonically increasing";
+    }
+};
+} // namespace
+
+TEST_CASE("sync progress: flx download progress", "[sync][baas][progress]") {
+    static std::optional<FLXSyncTestHarness> harness;
+    if (!harness) {
+        Schema schema{
+            {"object",
+             {{"_id", PropertyType::ObjectId, Property::IsPrimary{true}},
+              {"int", PropertyType::Int | PropertyType::Nullable},
+              {"padding", PropertyType::Data}}},
+        };
+        realm::app::FLXSyncTestHarness::ServerSchema server_schema{std::move(schema), {"int"}};
+        harness.emplace("flx_download_progress", std::move(server_schema));
+        harness->load_initial_data([](const std::shared_ptr<Realm>& realm) {
+            const size_t padding_size = 1024 * 1024;
+            auto buffer = std::make_unique<char[]>(padding_size);
+            auto table = realm->read_group().get_table("class_object");
+            for (int i = 0; i < 5; ++i) {
+                auto obj = table->create_object_with_primary_key(ObjectId::gen());
+                obj.set("int", i);
+                // ensure that each object is large enough that it'll be sent in
+                // a separate DOWNLOAD message
+                obj.set("padding", BinaryData(buffer.get(), padding_size));
+            }
+        });
+    }
+
+    SyncTestFile config = harness->make_test_file();
+
+    SECTION("async open with no subscriptions") {
+        auto task = Realm::get_synchronized_realm(config);
+        std::vector<double> estimates;
+        task->register_download_progress_notifier([&](uint64_t, uint64_t, double estimate) {
+            // Note that no locking is needed here despite this being called on
+            // a background thread as the test provides the required synchronization.
+            // If tsan complains about this, it indicates that the notifier is
+            // being called at a time that it shouldn't be and there's a bug.
+            estimates.push_back(estimate);
+        });
+        task->start().get();
+        // A download happens for the schema, but we now don't report that
+        REQUIRE(estimates.size() == 0);
+    }
+
+    SECTION("async open with initial subscriptions") {
+        config.sync_config->subscription_initializer = [](const std::shared_ptr<Realm>& realm) {
+            subscribe_to_all(*realm);
+        };
+        auto task = Realm::get_synchronized_realm(config);
+        std::vector<double> estimates;
+        task->register_download_progress_notifier([&](uint64_t, uint64_t, double estimate) {
+            // Note that no locking is needed here despite this being called on
+            // a background thread as the test provides the required synchronization.
+            // If tsan complains about this, it indicates that the notifier is
+            // being called at a time that it shouldn't be and there's a bug.
+            estimates.push_back(estimate);
+        });
+        task->start().get();
+
+        // Since we set the soft byte limit to one byte, we should have received
+        // a DOWNLOAD message for each object. We also happen to get an empty
+        // DOWNLOAD at the end, but we don't want to require that.
+        REQUIRE(estimates.size() >= 5);
+        REQUIRE_THAT(estimates, EstimatesAreValid());
+    }
+
+    SECTION("multiple subscription updates which each trigger some downloads") {
+        auto realm = successfully_async_open_realm(config);
+        auto table = realm->read_group().get_table("class_object");
+        auto col = table->get_column_key("int");
+
+        std::vector<double> estimates;
+        realm->sync_session()->register_progress_notifier(
+            [&](uint64_t, uint64_t, double estimate) {
+                // Note that no locking is needed here despite this being called on
+                // a background thread as the test provides the required synchronization.
+                // If tsan complains about this, it indicates that the notifier is
+                // being called at a time that it shouldn't be and there's a bug.
+                estimates.push_back(estimate);
+            },
+            SyncSession::ProgressDirection::download, true);
+
+        for (int i = 4; i > -2; i -= 2) {
+            auto sub_set = realm->get_latest_subscription_set().make_mutable_copy();
+            sub_set.insert_or_assign(table->where().greater(col, i));
+            sub_set.commit().get_state_change_notification(sync::SubscriptionSet::State::Complete).get();
+
+            // We get a variable number of DOWNLOAD messages per update but it should always be at least one
+            REQUIRE(estimates.size() >= 1);
+            REQUIRE_THAT(estimates, EstimatesAreValid());
+
+            estimates.clear();
+        }
+    }
+
+    SECTION("add subscription which doesn't add new objects") {
+        auto realm = successfully_async_open_realm(config);
+        auto table = realm->read_group().get_table("class_object");
+        auto col = table->get_column_key("int");
+
+        std::vector<double> estimates;
+        realm->sync_session()->register_progress_notifier(
+            [&](uint64_t, uint64_t, double estimate) {
+                // Note that no locking is needed here despite this being called on
+                // a background thread as the test provides the required synchronization.
+                // If tsan complains about this, it indicates that the notifier is
+                // being called at a time that it shouldn't be and there's a bug.
+                estimates.push_back(estimate);
+            },
+            SyncSession::ProgressDirection::download, true);
+
+        {
+            auto sub_set = realm->get_latest_subscription_set().make_mutable_copy();
+            sub_set.insert_or_assign(table->where().less(col, 5));
+            sub_set.commit().get_state_change_notification(sync::SubscriptionSet::State::Complete).get();
+        }
+
+        estimates.clear();
+
+        // This subscription change should not actually result in any new objects
+        {
+            auto sub_set = realm->get_latest_subscription_set().make_mutable_copy();
+            sub_set.insert_or_assign(table->where().less(col, 10));
+            sub_set.commit().get_state_change_notification(sync::SubscriptionSet::State::Complete).get();
+        }
+
+        // We expect just a single update with progress_estimate=1, but the
+        // server could legally send us multiple empty DOWNLOADs
+        REQUIRE(estimates.size() >= 1);
+        REQUIRE_THAT(estimates, EstimatesAreValid());
+    }
+
+    SECTION("cleanup") {
+        harness.reset();
+    }
 }
 
 #endif

--- a/test/object-store/sync/session/progress_notifications.cpp
+++ b/test/object-store/sync/session/progress_notifications.cpp
@@ -1381,9 +1381,10 @@ TEST_CASE("sync progress: flx download progress", "[sync][baas][progress]") {
         });
         task->start().get();
 
-        // Since we set the soft byte limit to one byte, we should have received
-        // a DOWNLOAD message for each object. We also happen to get an empty
-        // DOWNLOAD at the end, but we don't want to require that.
+        // Since our objects are larger than the server's soft limit for batching
+        // (1 MB), we expect to receive a separate DOWNLOAD message for each
+        // object. We also happen to get an empty DOWNLOAD at the end, but we
+        // don't want to require that.
         REQUIRE(estimates.size() >= 5);
         REQUIRE_THAT(estimates, EstimatesAreValid());
     }

--- a/test/object-store/util/sync/sync_test_utils.cpp
+++ b/test/object-store/util/sync/sync_test_utils.cpp
@@ -176,7 +176,7 @@ std::string unquote_string(std::string_view possibly_quoted_string)
 
 #if REALM_ENABLE_SYNC
 
-void subscribe_to_all_and_bootstrap(Realm& realm)
+sync::SubscriptionSet subscribe_to_all(Realm& realm)
 {
     auto mut_subs = realm.get_latest_subscription_set().make_mutable_copy();
     auto& group = realm.read_group();
@@ -188,7 +188,12 @@ void subscribe_to_all_and_bootstrap(Realm& realm)
             }
         }
     }
-    auto subs = std::move(mut_subs).commit();
+    return std::move(mut_subs).commit();
+}
+
+void subscribe_to_all_and_bootstrap(Realm& realm)
+{
+    auto subs = subscribe_to_all(realm);
     subs.get_state_change_notification(sync::SubscriptionSet::State::Complete).get();
     wait_for_download(realm);
 }
@@ -290,21 +295,7 @@ void wait_for_advance(Realm& realm)
 StatusWith<std::shared_ptr<Realm>> async_open_realm(const Realm::Config& config)
 {
     auto task = Realm::get_synchronized_realm(config);
-    auto pf = util::make_promise_future<ThreadSafeReference>();
-    task->start([&](ThreadSafeReference&& ref, std::exception_ptr e) {
-        if (e) {
-            try {
-                std::rethrow_exception(e);
-            }
-            catch (...) {
-                pf.promise.set_error(exception_to_status());
-            }
-        }
-        else {
-            pf.promise.emplace_value(std::move(ref));
-        }
-    });
-    auto sw = std::move(pf.future).get_no_throw();
+    auto sw = task->start().get_no_throw();
     if (sw.is_ok())
         return Realm::get_shared_realm(std::move(sw.get_value()));
     return sw.get_status();

--- a/test/object-store/util/sync/sync_test_utils.hpp
+++ b/test/object-store/util/sync/sync_test_utils.hpp
@@ -139,6 +139,7 @@ const std::shared_ptr<app::GenericNetworkTransport> instance_of = std::make_shar
 
 std::ostream& operator<<(std::ostream& os, util::Optional<app::AppError> error);
 
+sync::SubscriptionSet subscribe_to_all(Realm& realm);
 void subscribe_to_all_and_bootstrap(Realm& realm);
 
 #if REALM_APP_SERVICES

--- a/test/test_sync_pending_bootstraps.cpp
+++ b/test/test_sync_pending_bootstraps.cpp
@@ -33,7 +33,7 @@ TEST(Sync_PendingBootstrapStoreBatching)
         changesets.back().original_changeset_size = 1024;
 
         bool created_new_batch = false;
-        store.add_batch(1, util::none, changesets, &created_new_batch);
+        store.add_batch(1, util::none, 0, changesets, &created_new_batch);
 
         CHECK(created_new_batch);
         CHECK(store.has_pending());
@@ -47,7 +47,7 @@ TEST(Sync_PendingBootstrapStoreBatching)
         changesets.emplace_back(5, 10, BinaryData(changeset_data.back()), 5, 3);
         changesets.back().original_changeset_size = 1024;
 
-        store.add_batch(1, progress, changesets, &created_new_batch);
+        store.add_batch(1, progress, 1, changesets, &created_new_batch);
         CHECK(!created_new_batch);
     }
 
@@ -128,7 +128,7 @@ TEST(Sync_PendingBootstrapStoreClear)
     changesets.back().original_changeset_size = 1024;
 
     bool created_new_batch = false;
-    store.add_batch(2, progress, changesets, &created_new_batch);
+    store.add_batch(2, progress, 1, changesets, &created_new_batch);
     CHECK(created_new_batch);
     CHECK(store.has_pending());
 


### PR DESCRIPTION
We need to store the download progress for each batch of a bootstrap and not just at the end for it to be useful in any way. Whoops.

The server will sometimes send us DOWNLOAD messages with a non-one estimate followed by a one estimate where the byte-level information is the same (as the final message is empty). When this happens we need to report the download completion to the user, so add the estimate to the fields checked for changes.

A subscription change which doesn't actually change what set of objects is in view can result in an empty DOWNLOAD message with no changes other than the query version, and we should report that too.

Fixes #7869. Fixes #7867.