### PR TITLE
Fix data races in the connection state changes tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 -----------
 
 ### Internals
-* None.
+* Fix a thread sanitizer failure in the "unregister connection change listener during callback" test ([PR #7871](https://github.com/realm/realm-core/pull/7871)).
 
 ----------------------------------------------
 


### PR DESCRIPTION
This produced a tsan error for me when running locally. The assignment to token1 on the main thread and the read of it on the sync worker thread didn't have any intervening synchronization and in theory the callback could read it before it's actually written. Fixing this requires adding some locking.

Conversely, listener2 doesn't actually need to be atomic since the second callback should only ever be invokved synchronously inside log_out(), and if it's called on some other thread that's a bug.

It doesn't matter here, but `listener1_call_cnt = listener1_call_cnt + 1` is a nonatomic increment that will drop updates if it happens on multiple threads at once, while `++` will not.