### PR TITLE
Add get local schema version to the C-API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Enhancements
 * <New feature description> (PR [#????](https://github.com/realm/realm-core/pull/????))
-* None.
+* Added `realm_get_persisted_schema_version` for reading the version of the schema currently stored locally. (PR [#7873](https://github.com/realm/realm-core/pull/7873))
 
 ### Fixed
 * When a public name is defined on a property, calling `realm::Results::sort()` or `realm::Results::distinct()` with the internal name could throw an error like `Cannot sort on key path 'NAME': property 'PersonObject.NAME' does not exist`. ([realm/realm-js#6779](https://github.com/realm/realm-js/issues/6779), since v12.12.0)

--- a/src/realm.h
+++ b/src/realm.h
@@ -1243,8 +1243,6 @@ RLM_API uint64_t realm_get_schema_version(const realm_t* realm);
 
 /**
  * Get the schema version for this realm at the path.
- *
- * This function cannot fail.
  */
 RLM_API uint64_t realm_get_persisted_schema_version(const realm_config_t* config);
 

--- a/src/realm.h
+++ b/src/realm.h
@@ -1242,6 +1242,13 @@ RLM_API realm_schema_t* realm_get_schema(const realm_t*);
 RLM_API uint64_t realm_get_schema_version(const realm_t* realm);
 
 /**
+ * Get the schema version for this realm at the path.
+ *
+ * This function cannot fail.
+ */
+RLM_API uint64_t realm_get_persisted_schema_version(const realm_config_t* config);
+
+/**
  * Update the schema of an open realm.
  *
  * This is equivalent to calling `realm_update_schema_advanced(realm, schema, 0,

--- a/src/realm/object-store/c_api/schema.cpp
+++ b/src/realm/object-store/c_api/schema.cpp
@@ -68,13 +68,11 @@ RLM_API uint64_t realm_get_persisted_schema_version(const realm_config_t* config
         conf.force_sync_history = true;
     }
 
-    return wrap_err([&]() {
-        auto realm = new shared_realm{Realm::get_shared_realm(conf)};
-        uint64_t version = ObjectStore::get_schema_version(realm->get()->read_group());
-        delete realm;
+    auto realm = new shared_realm{Realm::get_shared_realm(conf)};
+    uint64_t version = ObjectStore::get_schema_version(realm->get()->read_group());
+    delete realm;
 
-        return version;
-    });
+    return version;
 }
 
 RLM_API bool realm_schema_validate(const realm_schema_t* schema, uint64_t validation_mode)

--- a/src/realm/object-store/c_api/schema.cpp
+++ b/src/realm/object-store/c_api/schema.cpp
@@ -57,11 +57,16 @@ RLM_API uint64_t realm_get_schema_version(const realm_t* realm)
 
 RLM_API uint64_t realm_get_persisted_schema_version(const realm_config_t* config)
 {
+
     auto conf = RealmConfig();
-    conf.schema_mode = SchemaMode::Immutable;
     conf.schema_version = ObjectStore::NotVersioned;
     conf.path = config->path;
     conf.encryption_key = config->encryption_key;
+
+    if (config->sync_config) {
+        conf.sync_config = nullptr;
+        conf.force_sync_history = true;
+    }
 
     return wrap_err([&]() {
         auto realm = new shared_realm{Realm::get_shared_realm(conf)};

--- a/src/realm/object-store/c_api/schema.cpp
+++ b/src/realm/object-store/c_api/schema.cpp
@@ -55,6 +55,23 @@ RLM_API uint64_t realm_get_schema_version(const realm_t* realm)
     return rlm->schema_version();
 }
 
+RLM_API uint64_t realm_get_persisted_schema_version(const realm_config_t* config)
+{
+    auto conf = RealmConfig();
+    conf.schema_mode = SchemaMode::Immutable;
+    conf.schema_version = ObjectStore::NotVersioned;
+    conf.path = config->path;
+    conf.encryption_key = config->encryption_key;
+
+    return wrap_err([&]() {
+        auto realm = new shared_realm{Realm::get_shared_realm(conf)};
+        uint64_t version = ObjectStore::get_schema_version(realm->get()->read_group());
+        delete realm;
+
+        return version;
+    });
+}
+
 RLM_API bool realm_schema_validate(const realm_schema_t* schema, uint64_t validation_mode)
 {
     return wrap_err([&]() {

--- a/src/realm/object-store/c_api/schema.cpp
+++ b/src/realm/object-store/c_api/schema.cpp
@@ -57,7 +57,6 @@ RLM_API uint64_t realm_get_schema_version(const realm_t* realm)
 
 RLM_API uint64_t realm_get_persisted_schema_version(const realm_config_t* config)
 {
-
     auto conf = RealmConfig();
     conf.schema_version = ObjectStore::NotVersioned;
     conf.path = config->path;
@@ -68,10 +67,8 @@ RLM_API uint64_t realm_get_persisted_schema_version(const realm_config_t* config
         conf.force_sync_history = true;
     }
 
-    auto realm = new shared_realm{Realm::get_shared_realm(conf)};
+    auto realm = Realm::get_shared_realm(conf);
     uint64_t version = ObjectStore::get_schema_version(realm->get()->read_group());
-    delete realm;
-
     return version;
 }
 

--- a/test/object-store/c_api/c_api.cpp
+++ b/test/object-store/c_api/c_api.cpp
@@ -1287,6 +1287,9 @@ TEST_CASE("C API - schema", "[c_api]") {
         realm_config_set_schema_version(config.get(), 0);
         realm_config_set_schema(config.get(), schema.get());
 
+        // no local schema version yet
+        REQUIRE(realm_get_persisted_schema_version(config.get()) == (uint64_t)-1);
+
         SECTION("error on open") {
             {
                 std::ofstream o(test_file_2.path.c_str());
@@ -1304,6 +1307,7 @@ TEST_CASE("C API - schema", "[c_api]") {
             realm_config_set_data_initialization_function(config.get(), initialize_data, &userdata, nullptr);
             auto realm = cptr_checked(realm_open(config.get()));
             CHECK(userdata.num_initializations == 1);
+            REQUIRE(realm_get_persisted_schema_version(config.get()) == 0);
         }
 
         SECTION("data initialization callback error") {
@@ -1323,6 +1327,7 @@ TEST_CASE("C API - schema", "[c_api]") {
             realm_config_set_migration_function(config.get(), migrate_schema, &userdata, nullptr);
             auto realm = cptr_checked(realm_open(config.get()));
             CHECK(userdata.num_migrations == 0);
+            REQUIRE(realm_get_persisted_schema_version(config.get()) == 0);
             realm.reset();
 
             auto config2 = cptr(realm_config_new());
@@ -1334,6 +1339,7 @@ TEST_CASE("C API - schema", "[c_api]") {
             realm_config_set_migration_function(config2.get(), migrate_schema, &userdata, nullptr);
             auto realm2 = cptr_checked(realm_open(config2.get()));
             CHECK(userdata.num_migrations == 1);
+            REQUIRE(realm_get_persisted_schema_version(config2.get()) == 999);
         }
 
         SECTION("migrate schema and delete old table") {
@@ -5869,6 +5875,7 @@ TEST_CASE("C API - async_open", "[sync][pbs][c_api]") {
         realm_config_set_path(config, test_config.path.c_str());
         realm_config_set_sync_config(config, sync_config);
         realm_config_set_schema_version(config, 1);
+
         realm_async_open_task_t* task = realm_open_synchronized(config);
         REQUIRE(task);
         Userdata userdata;
@@ -5882,6 +5889,8 @@ TEST_CASE("C API - async_open", "[sync][pbs][c_api]") {
 
         realm_t* realm = realm_from_thread_safe_reference(userdata.realm_ref, nullptr);
         realm_release(userdata.realm_ref);
+
+        REQUIRE(realm_get_persisted_schema_version(config) == 0);
 
         bool found;
         realm_class_info_t class_info;

--- a/test/object-store/c_api/c_api.cpp
+++ b/test/object-store/c_api/c_api.cpp
@@ -5890,8 +5890,6 @@ TEST_CASE("C API - async_open", "[sync][pbs][c_api]") {
         realm_t* realm = realm_from_thread_safe_reference(userdata.realm_ref, nullptr);
         realm_release(userdata.realm_ref);
 
-        REQUIRE(realm_get_persisted_schema_version(config) == 0);
-
         bool found;
         realm_class_info_t class_info;
         realm_find_class(realm, "object", &found, &class_info);


### PR DESCRIPTION
## What, How & Why?
Kotlin uses some heuristic for which is required to know the local schema version, before opening a synchronized realm via `open_async`.  

There is no clear API for reading the local schema version without opening the realm, and most importantly, avoiding opening a synchronized realm (in order to guarantee that no sync code is run). 

Opening realm in immutable mode seems a viable and simple approach for achieving that, although it will result in a double opening, if a migration is needed (since it requires opening a synchronized realm in async mode). 

Another possible approach is to add a new cnf param that the SDK needs to specify and throw an exception inside `RealmCoordinator::do_get_realm` if the new param is set. 


## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed
* [ ] `bindgen/spec.yml`, if public C++ API changed
