### PR TITLE
RJS-2858: Allow both internal and public name in realm::Results::{sort, distinct}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,7 @@
 * None.
 
 ### Fixed
-* <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* When a public name is defined on a property, calling `realm::Results::sort()` or `realm::Results::distinct()` with the internal name could throw an error like `Cannot sort on key path 'NAME': property 'PersonObject.NAME' does not exist`. ([realm/realm-js#6779](https://github.com/realm/realm-js/issues/6779), since v12.12.0)
 
 ### Breaking changes
 * None.

--- a/src/realm/object-store/results.cpp
+++ b/src/realm/object-store/results.cpp
@@ -871,6 +871,9 @@ static std::vector<ExtendedColumnKey> parse_keypath(StringData keypath, Schema c
         begin = sep + (sep != end);
 
         auto prop = object_schema->property_for_public_name(key);
+        if (!prop) {
+            prop = object_schema->property_for_name(key);
+        }
         check(prop, "property '%1.%2' does not exist", object_schema->name, key);
         if (is_dictionary(prop->type)) {
             check(index.length(), "missing dictionary key");

--- a/test/object-store/results.cpp
+++ b/test/object-store/results.cpp
@@ -4984,7 +4984,7 @@ TEST_CASE("results: public name declared", "[results]") {
     realm->commit_transaction();
     Results r(realm, table);
 
-    SECTION("sorted") {
+    SECTION("sorted by public_name") {
         auto sorted = r.sort({{"public_value", true}});
         REQUIRE(sorted.limit(0).size() == 0);
         REQUIRE_ORDER(sorted.limit(1), 2);
@@ -4993,7 +4993,16 @@ TEST_CASE("results: public name declared", "[results]") {
         REQUIRE_ORDER(sorted.limit(100), 2, 6, 3, 7, 0, 4, 1, 5);
     }
 
-    SECTION("distinct") {
+    SECTION("sorted by name") {
+        auto sorted = r.sort({{"value", true}});
+        REQUIRE(sorted.limit(0).size() == 0);
+        REQUIRE_ORDER(sorted.limit(1), 2);
+        REQUIRE_ORDER(sorted.limit(2), 2, 6);
+        REQUIRE_ORDER(sorted.limit(8), 2, 6, 3, 7, 0, 4, 1, 5);
+        REQUIRE_ORDER(sorted.limit(100), 2, 6, 3, 7, 0, 4, 1, 5);
+    }
+
+    SECTION("distinct by public_name") {
         auto sorted = r.distinct({"public_value"});
         REQUIRE(sorted.limit(0).size() == 0);
         REQUIRE_ORDER(sorted.limit(1), 0);
@@ -5001,6 +5010,20 @@ TEST_CASE("results: public name declared", "[results]") {
         REQUIRE_ORDER(sorted.limit(8), 0, 1, 2, 3);
 
         sorted = r.sort({{"public_value", true}}).distinct({"public_value"});
+        REQUIRE(sorted.limit(0).size() == 0);
+        REQUIRE_ORDER(sorted.limit(1), 2);
+        REQUIRE_ORDER(sorted.limit(2), 2, 3);
+        REQUIRE_ORDER(sorted.limit(8), 2, 3, 0, 1);
+    }
+
+    SECTION("distinct by name") {
+        auto sorted = r.distinct({"value"});
+        REQUIRE(sorted.limit(0).size() == 0);
+        REQUIRE_ORDER(sorted.limit(1), 0);
+        REQUIRE_ORDER(sorted.limit(2), 0, 1);
+        REQUIRE_ORDER(sorted.limit(8), 0, 1, 2, 3);
+
+        sorted = r.sort({{"value", true}}).distinct({"value"});
         REQUIRE(sorted.limit(0).size() == 0);
         REQUIRE_ORDER(sorted.limit(1), 2);
         REQUIRE_ORDER(sorted.limit(2), 2, 3);


### PR DESCRIPTION
## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- Link to relevant issue this fixes -->

From the RJS ticket:

> When mapTo is used to have an alias for a property name, Realm.Results.sorted() doesn't recognize the alias leading to errors like Cannot sort on key path 'NAME': property 'PersonObject.NAME' does not exist.

This closes https://github.com/realm/realm-js/issues/6779

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* ~[ ] C-API, if public C++ API changed~
* ~[ ] `bindgen/spec.yml`, if public C++ API changed~
