### PR TITLE
Update return type of `LogCategory::get_category_names()` from `std::vector<const char*>` to `std::vector<std::string_view>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 # NEXT RELEASE
 
 ### Enhancements
-* <New feature description> (PR [#????](https://github.com/realm/realm-core/pull/????))
-* None.
+* Updated the return type of `LogCategory::get_category_names()` from `std::vector<const char*>` to `std::vector<std::string_view>`. ([PR #7879](https://github.com/realm/realm-core/pull/7879))
 
 ### Fixed
 * When a public name is defined on a property, calling `realm::Results::sort()` or `realm::Results::distinct()` with the internal name could throw an error like `Cannot sort on key path 'NAME': property 'PersonObject.NAME' does not exist`. ([realm/realm-js#6779](https://github.com/realm/realm-js/issues/6779), since v12.12.0)
@@ -23,14 +22,14 @@
 # 14.10.3 Release notes
 
 ### Enhancements
-* "Next launch" metadata file actions are now performed in a multi-process safe manner ([#7576](https://github.com/realm/realm-core/pull/7576)).
+* "Next launch" metadata file actions are now performed in a multi-process safe manner. ([PR #7576](https://github.com/realm/realm-core/pull/7576))
 
 ### Fixed
 * Fixed a change of mode from Strong to All when removing links from an embedded object that links to a tombstone. This affects sync apps that use embedded objects which have a `Lst<Mixed>` that contains a link to another top level object which has been deleted by another sync client (creating a tombstone locally). In this particular case, the switch would cause any remaining link removals to recursively delete the destination object if there were no other links to it. ([#7828](https://github.com/realm/realm-core/issues/7828), since 14.0.0-beta.0)
 * Fixed removing backlinks from the wrong objects if the link came from a nested list, nested dictionary, top-level dictionary, or list of mixed, and the source table had more than 256 objects. This could manifest as `array_backlink.cpp:112: Assertion failed: int64_t(value >> 1) == key.value` when removing an object. ([#7594](https://github.com/realm/realm-core/issues/7594), since v11 for dictionaries)
 * Fixed the collapse/rejoin of clusters which contained nested collections with links. This could manifest as `array.cpp:319: Array::move() Assertion failed: begin <= end [2, 1]` when removing an object. ([#7839](https://github.com/realm/realm-core/issues/7839), since the introduction of nested collections in v14.0.0-beta.0)
 * wait_for_upload_completion() was inconsistent in how it handled commits which did not produce any changesets to upload. Previously it would sometimes complete immediately if all commits waiting to be uploaded were empty, and at other times it would wait for a server roundtrip. It will now always complete immediately. ([PR #7796](https://github.com/realm/realm-core/pull/7796)).
-* `realm_sync_session_handle_error_for_testing` parameter `is_fatal` was flipped changing the expected behavior. (#[7750](https://github.com/realm/realm-core/issues/7750)).
+* `realm_sync_session_handle_error_for_testing` parameter `is_fatal` was flipped changing the expected behavior. ([#7750](https://github.com/realm/realm-core/issues/7750))
 
 ### Breaking changes
 * None.

--- a/src/realm/object-store/c_api/logging.cpp
+++ b/src/realm/object-store/c_api/logging.cpp
@@ -91,7 +91,7 @@ RLM_API size_t realm_get_category_names(size_t num_values, const char** out_valu
         if (number_to_copy > num_values)
             number_to_copy = num_values;
         for (size_t n = 0; n < number_to_copy; n++) {
-            out_values[n] = vec[n];
+            out_values[n] = vec[n].data();
         }
     }
     return number_to_copy;

--- a/src/realm/util/logger.cpp
+++ b/src/realm/util/logger.cpp
@@ -30,7 +30,7 @@ std::shared_ptr<util::Logger> s_default_logger;
 } // anonymous namespace
 
 size_t LogCategory::s_next_index = 0;
-static std::map<std::string_view, LogCategory*> log_catagory_map;
+static std::map<std::string_view, LogCategory*> log_category_map;
 
 LogCategory LogCategory::realm("Realm", nullptr);
 LogCategory LogCategory::storage("Storage", &realm);
@@ -58,19 +58,19 @@ LogCategory::LogCategory(std::string_view name, LogCategory* parent)
         parent->m_children.push_back(this);
     }
     m_name += name;
-    log_catagory_map.emplace(m_name, this);
+    log_category_map.emplace(m_name, this);
 }
 
 LogCategory& LogCategory::get_category(std::string_view name)
 {
-    return *log_catagory_map.at(name); // Throws
+    return *log_category_map.at(name); // Throws
 }
 
 std::vector<const std::string_view> LogCategory::get_category_names()
 {
     std::vector<const std::string_view> ret;
-    ret.reserve(log_catagory_map.size());
-    for (auto& it : log_catagory_map) {
+    ret.reserve(log_category_map.size());
+    for (auto& it : log_category_map) {
         ret.push_back(it.second->get_name());
     }
     return ret;

--- a/src/realm/util/logger.cpp
+++ b/src/realm/util/logger.cpp
@@ -66,9 +66,9 @@ LogCategory& LogCategory::get_category(std::string_view name)
     return *log_category_map.at(name); // Throws
 }
 
-std::vector<const std::string_view> LogCategory::get_category_names()
+std::vector<std::string_view> LogCategory::get_category_names()
 {
-    std::vector<const std::string_view> ret;
+    std::vector<std::string_view> ret;
     ret.reserve(log_category_map.size());
     for (auto& it : log_category_map) {
         ret.push_back(it.second->get_name());

--- a/src/realm/util/logger.cpp
+++ b/src/realm/util/logger.cpp
@@ -66,11 +66,12 @@ LogCategory& LogCategory::get_category(std::string_view name)
     return *log_catagory_map.at(name); // Throws
 }
 
-std::vector<const char*> LogCategory::get_category_names()
+std::vector<const std::string_view> LogCategory::get_category_names()
 {
-    std::vector<const char*> ret;
+    std::vector<const std::string_view> ret;
+    ret.reserve(log_catagory_map.size());
     for (auto& it : log_catagory_map) {
-        ret.push_back(it.second->get_name().c_str());
+        ret.push_back(it.second->get_name());
     }
     return ret;
 }

--- a/src/realm/util/logger.hpp
+++ b/src/realm/util/logger.hpp
@@ -99,7 +99,7 @@ public:
     // Find category from fully qualified name. Will throw if
     // name does not match a category
     static LogCategory& get_category(std::string_view name);
-    static std::vector<const char*> get_category_names();
+    static std::vector<const std::string_view> get_category_names();
 
 private:
     friend class Logger;

--- a/src/realm/util/logger.hpp
+++ b/src/realm/util/logger.hpp
@@ -99,7 +99,7 @@ public:
     // Find category from fully qualified name. Will throw if
     // name does not match a category
     static LogCategory& get_category(std::string_view name);
-    static std::vector<const std::string_view> get_category_names();
+    static std::vector<std::string_view> get_category_names();
 
 private:
     friend class Logger;


### PR DESCRIPTION
## What, How & Why?

Updates the return type of `LogCategory::get_category_names()` from `std::vector<const char*>` to `std::vector<std::string_view>` in order to alleviate marshaling of strings in DotNet.

This also aligns better with `LogCategory::get_category(std::string_view name)` (already taking a `std::string_view`).

We don't believe this will be a breaking change.

**SDK reviewers, please confirm if this is non-breaking/breaking for you.**

## ☑️ ToDos
* [x] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed
  * Remains unchanged. 
* [ ] `bindgen/spec.yml`, if public C++ API changed
  * This API was never exposed.
