### PR TITLE
RCORE-2201 Add an implementation for the realm_app_config_get_sync_client_config() function in the Core CAPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * On Windows devices Device Sync will additionally look up SSL certificates in the Windows Trusted Root Certification Authorities certificate store when establishing a connection. (PR [#7882](https://github.com/realm/realm-core/pull/7882))
 * Updated the return type of `LogCategory::get_category_names()` from `std::vector<const char*>` to `std::vector<std::string_view>`. ([PR #7879](https://github.com/realm/realm-core/pull/7879))
 * Added `realm_get_persisted_schema_version` for reading the version of the schema currently stored locally. (PR [#7873](https://github.com/realm/realm-core/pull/7873))
-* Added `realm_app_config_set_sync_client_config()` function to the C_API to set the sync_client_config value in `realm_app_config_t`. Also added setter functions for the individual sync_client_config parameters stored in the `realm_app_config_t`.([PR #7891](https://github.com/realm/realm-core/pull/7891))
+* Added `realm_app_config_get_sync_client_config()` function to the C_API to get the sync_client_config value in `realm_app_config_t` if REALM_APP_SERVICES is enabled. If REALM_APP_SERVICES is not available, `realm_sync_client_config_new()` is available to create a new `sync_client_config_t` to use when initializing the sync manager. ([PR #7891](https://github.com/realm/realm-core/pull/7891))
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * On Windows devices Device Sync will additionally look up SSL certificates in the Windows Trusted Root Certification Authorities certificate store when establishing a connection. (PR [#7882](https://github.com/realm/realm-core/pull/7882))
 * Updated the return type of `LogCategory::get_category_names()` from `std::vector<const char*>` to `std::vector<std::string_view>`. ([PR #7879](https://github.com/realm/realm-core/pull/7879))
 * Added `realm_get_persisted_schema_version` for reading the version of the schema currently stored locally. (PR [#7873](https://github.com/realm/realm-core/pull/7873))
+* Added `realm_app_config_set_sync_client_config()` function to the C_API to set the sync_client_config value in `realm_app_config_t`. ([PR #7891](https://github.com/realm/realm-core/pull/7891))
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * On Windows devices Device Sync will additionally look up SSL certificates in the Windows Trusted Root Certification Authorities certificate store when establishing a connection. (PR [#7882](https://github.com/realm/realm-core/pull/7882))
 * Updated the return type of `LogCategory::get_category_names()` from `std::vector<const char*>` to `std::vector<std::string_view>`. ([PR #7879](https://github.com/realm/realm-core/pull/7879))
 * Added `realm_get_persisted_schema_version` for reading the version of the schema currently stored locally. (PR [#7873](https://github.com/realm/realm-core/pull/7873))
-* Added `realm_app_config_set_sync_client_config()` function to the C_API to set the sync_client_config value in `realm_app_config_t`. ([PR #7891](https://github.com/realm/realm-core/pull/7891))
+* Added `realm_app_config_set_sync_client_config()` function to the C_API to set the sync_client_config value in `realm_app_config_t`. Also added setter functions for the individual sync_client_config parameters stored in the `realm_app_config_t`.([PR #7891](https://github.com/realm/realm-core/pull/7891))
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)

--- a/src/realm.h
+++ b/src/realm.h
@@ -3776,13 +3776,18 @@ RLM_API void realm_sync_client_config_set_default_binding_thread_observer(
     realm_userdata_t user_data, realm_free_userdata_func_t free_userdata);
 
 #if REALM_APP_SERVICES
+// NOTE: realm_app_config_set_sync_client_config() can be used to set the entire
+//       sync_client_config structure in the realm_app_config_t or the individual
+//       realm_app_config_set_sc_* functions can be used to set the individual
+//       components of the sync_client_config, one at a time.
+
 // This function does not take ownership of the realm_sync_client_config_t pointer,
 // so this will need to be released manually after calling this function.
 RLM_API void realm_app_config_set_sync_client_config(realm_app_config_t*,
                                                      realm_sync_client_config_t*) RLM_API_NOEXCEPT;
 
 // Functions to set/modify the realm_sync_client_config_t structure that is
-// part of the realm_app_config_t structure
+// included in the realm_app_config_t structure
 RLM_API void realm_app_config_set_sc_reconnect_mode(realm_app_config_t*,
                                                     realm_sync_client_reconnect_mode_e) RLM_API_NOEXCEPT;
 RLM_API void realm_app_config_set_sc_multiplex_sessions(realm_app_config_t*, bool) RLM_API_NOEXCEPT;

--- a/src/realm.h
+++ b/src/realm.h
@@ -3023,7 +3023,10 @@ RLM_API void realm_app_config_set_metadata_mode(realm_app_config_t*,
 RLM_API void realm_app_config_set_metadata_encryption_key(realm_app_config_t*, const uint8_t[64]) RLM_API_NOEXCEPT;
 RLM_API void realm_app_config_set_security_access_group(realm_app_config_t*, const char*) RLM_API_NOEXCEPT;
 
-RLM_API realm_sync_client_config_t* realm_app_config_get_sync_client_config(realm_app_config_t*) RLM_API_NOEXCEPT;
+// This function does not take ownership of the realm_sync_client_config_t pointer,
+// so this will need to be released manually after calling this function.
+RLM_API void realm_app_config_set_sync_client_config(realm_app_config_t* app_config,
+                                                     realm_sync_client_config_t* sc_config) RLM_API_NOEXCEPT;
 
 /**
  * Get an existing @a realm_app_credentials_t and return it's json representation

--- a/src/realm.h
+++ b/src/realm.h
@@ -3745,9 +3745,17 @@ typedef void (*realm_async_open_task_completion_func_t)(realm_userdata_t userdat
 typedef void (*realm_async_open_task_init_subscription_func_t)(realm_thread_safe_reference_t* realm,
                                                                realm_userdata_t userdata);
 #if REALM_APP_SERVICES
-// If using App Services, the sync client config is part of
+// If using App Services, the realm_sync_client_config_t instance is part of the
+// realm_app_config_t structure and this function returns a pointer to that
+// member property. The realm_sync_client_config_t reference returned by this
+// function should not be freed using realm_release.
 RLM_API realm_sync_client_config_t* realm_app_config_get_sync_client_config(realm_app_config_t*) RLM_API_NOEXCEPT;
 #else
+// If not using App Services, the realm_app_config_t structure is not defined, and
+// the real_sync_client_config_t structure returned by this function is meant to be
+// used with realm_sync_manager_create() to create a separate Sync Manager instance.
+// The realm_sync_client_config_t instance returned by this function will need to be
+// manually freed using realm_release.
 RLM_API realm_sync_client_config_t* realm_sync_client_config_new(void) RLM_API_NOEXCEPT;
 #endif // REALM_APP_SERVICES
 

--- a/src/realm.h
+++ b/src/realm.h
@@ -3023,11 +3023,6 @@ RLM_API void realm_app_config_set_metadata_mode(realm_app_config_t*,
 RLM_API void realm_app_config_set_metadata_encryption_key(realm_app_config_t*, const uint8_t[64]) RLM_API_NOEXCEPT;
 RLM_API void realm_app_config_set_security_access_group(realm_app_config_t*, const char*) RLM_API_NOEXCEPT;
 
-// This function does not take ownership of the realm_sync_client_config_t pointer,
-// so this will need to be released manually after calling this function.
-RLM_API void realm_app_config_set_sync_client_config(realm_app_config_t* app_config,
-                                                     realm_sync_client_config_t* sc_config) RLM_API_NOEXCEPT;
-
 /**
  * Get an existing @a realm_app_credentials_t and return it's json representation
  * Note: the caller must delete the pointer to the string via realm_release
@@ -3779,6 +3774,35 @@ RLM_API void realm_sync_client_config_set_default_binding_thread_observer(
     realm_sync_client_config_t* config, realm_on_object_store_thread_callback_t on_thread_create,
     realm_on_object_store_thread_callback_t on_thread_destroy, realm_on_object_store_error_callback_t on_error,
     realm_userdata_t user_data, realm_free_userdata_func_t free_userdata);
+
+#if REALM_APP_SERVICES
+// This function does not take ownership of the realm_sync_client_config_t pointer,
+// so this will need to be released manually after calling this function.
+RLM_API void realm_app_config_set_sync_client_config(realm_app_config_t*,
+                                                     realm_sync_client_config_t*) RLM_API_NOEXCEPT;
+
+// Functions to set/modify the realm_sync_client_config_t structure that is
+// part of the realm_app_config_t structure
+RLM_API void realm_app_config_set_sc_reconnect_mode(realm_app_config_t*,
+                                                    realm_sync_client_reconnect_mode_e) RLM_API_NOEXCEPT;
+RLM_API void realm_app_config_set_sc_multiplex_sessions(realm_app_config_t*, bool) RLM_API_NOEXCEPT;
+RLM_API void realm_app_config_set_sc_user_agent_binding_info(realm_app_config_t*, const char*) RLM_API_NOEXCEPT;
+RLM_API void realm_app_config_set_sc_user_agent_application_info(realm_app_config_t*, const char*) RLM_API_NOEXCEPT;
+RLM_API void realm_app_config_set_sc_connect_timeout(realm_app_config_t*, uint64_t) RLM_API_NOEXCEPT;
+RLM_API void realm_app_config_set_sc_connection_linger_time(realm_app_config_t*, uint64_t) RLM_API_NOEXCEPT;
+RLM_API void realm_app_config_set_sc_ping_keepalive_period(realm_app_config_t*, uint64_t) RLM_API_NOEXCEPT;
+RLM_API void realm_app_config_set_sc_pong_keepalive_timeout(realm_app_config_t*, uint64_t) RLM_API_NOEXCEPT;
+RLM_API void realm_app_config_set_sc_fast_reconnect_limit(realm_app_config_t*, uint64_t) RLM_API_NOEXCEPT;
+RLM_API void realm_app_config_set_sc_resumption_delay_interval(realm_app_config_t*, uint64_t) RLM_API_NOEXCEPT;
+RLM_API void realm_app_config_set_sc_max_resumption_delay_interval(realm_app_config_t*, uint64_t) RLM_API_NOEXCEPT;
+RLM_API void realm_app_config_set_sc_resumption_delay_backoff_multiplier(realm_app_config_t*, int) RLM_API_NOEXCEPT;
+RLM_API void realm_app_config_set_sc_sync_socket(realm_app_config_t*, realm_sync_socket_t*) RLM_API_NOEXCEPT;
+RLM_API void realm_app_config_set_sc_default_binding_thread_observer(
+    realm_app_config_t*, realm_on_object_store_thread_callback_t on_thread_create,
+    realm_on_object_store_thread_callback_t on_thread_destroy, realm_on_object_store_error_callback_t on_error,
+    realm_userdata_t user_data, realm_free_userdata_func_t free_userdata);
+
+#endif // REALM_APP_SERVICES
 
 RLM_API realm_sync_config_t* realm_sync_config_new(const realm_user_t*, const char* partition_value) RLM_API_NOEXCEPT;
 RLM_API realm_sync_config_t* realm_flx_sync_config_new(const realm_user_t*) RLM_API_NOEXCEPT;

--- a/src/realm.h
+++ b/src/realm.h
@@ -3744,8 +3744,13 @@ typedef void (*realm_async_open_task_completion_func_t)(realm_userdata_t userdat
 // callback runs.
 typedef void (*realm_async_open_task_init_subscription_func_t)(realm_thread_safe_reference_t* realm,
                                                                realm_userdata_t userdata);
-
+#if REALM_APP_SERVICES
+// If using App Services, the sync client config is part of
+RLM_API realm_sync_client_config_t* realm_app_config_get_sync_client_config(realm_app_config_t*) RLM_API_NOEXCEPT;
+#else
 RLM_API realm_sync_client_config_t* realm_sync_client_config_new(void) RLM_API_NOEXCEPT;
+#endif // REALM_APP_SERVICES
+
 RLM_API void realm_sync_client_config_set_reconnect_mode(realm_sync_client_config_t*,
                                                          realm_sync_client_reconnect_mode_e) RLM_API_NOEXCEPT;
 RLM_API void realm_sync_client_config_set_multiplex_sessions(realm_sync_client_config_t*, bool) RLM_API_NOEXCEPT;
@@ -3774,40 +3779,6 @@ RLM_API void realm_sync_client_config_set_default_binding_thread_observer(
     realm_sync_client_config_t* config, realm_on_object_store_thread_callback_t on_thread_create,
     realm_on_object_store_thread_callback_t on_thread_destroy, realm_on_object_store_error_callback_t on_error,
     realm_userdata_t user_data, realm_free_userdata_func_t free_userdata);
-
-#if REALM_APP_SERVICES
-// NOTE: realm_app_config_set_sync_client_config() can be used to set the entire
-//       sync_client_config structure in the realm_app_config_t or the individual
-//       realm_app_config_set_sc_* functions can be used to set the individual
-//       components of the sync_client_config, one at a time.
-
-// This function does not take ownership of the realm_sync_client_config_t pointer,
-// so this will need to be released manually after calling this function.
-RLM_API void realm_app_config_set_sync_client_config(realm_app_config_t*,
-                                                     realm_sync_client_config_t*) RLM_API_NOEXCEPT;
-
-// Functions to set/modify the realm_sync_client_config_t structure that is
-// included in the realm_app_config_t structure
-RLM_API void realm_app_config_set_sc_reconnect_mode(realm_app_config_t*,
-                                                    realm_sync_client_reconnect_mode_e) RLM_API_NOEXCEPT;
-RLM_API void realm_app_config_set_sc_multiplex_sessions(realm_app_config_t*, bool) RLM_API_NOEXCEPT;
-RLM_API void realm_app_config_set_sc_user_agent_binding_info(realm_app_config_t*, const char*) RLM_API_NOEXCEPT;
-RLM_API void realm_app_config_set_sc_user_agent_application_info(realm_app_config_t*, const char*) RLM_API_NOEXCEPT;
-RLM_API void realm_app_config_set_sc_connect_timeout(realm_app_config_t*, uint64_t) RLM_API_NOEXCEPT;
-RLM_API void realm_app_config_set_sc_connection_linger_time(realm_app_config_t*, uint64_t) RLM_API_NOEXCEPT;
-RLM_API void realm_app_config_set_sc_ping_keepalive_period(realm_app_config_t*, uint64_t) RLM_API_NOEXCEPT;
-RLM_API void realm_app_config_set_sc_pong_keepalive_timeout(realm_app_config_t*, uint64_t) RLM_API_NOEXCEPT;
-RLM_API void realm_app_config_set_sc_fast_reconnect_limit(realm_app_config_t*, uint64_t) RLM_API_NOEXCEPT;
-RLM_API void realm_app_config_set_sc_resumption_delay_interval(realm_app_config_t*, uint64_t) RLM_API_NOEXCEPT;
-RLM_API void realm_app_config_set_sc_max_resumption_delay_interval(realm_app_config_t*, uint64_t) RLM_API_NOEXCEPT;
-RLM_API void realm_app_config_set_sc_resumption_delay_backoff_multiplier(realm_app_config_t*, int) RLM_API_NOEXCEPT;
-RLM_API void realm_app_config_set_sc_sync_socket(realm_app_config_t*, realm_sync_socket_t*) RLM_API_NOEXCEPT;
-RLM_API void realm_app_config_set_sc_default_binding_thread_observer(
-    realm_app_config_t*, realm_on_object_store_thread_callback_t on_thread_create,
-    realm_on_object_store_thread_callback_t on_thread_destroy, realm_on_object_store_error_callback_t on_error,
-    realm_userdata_t user_data, realm_free_userdata_func_t free_userdata);
-
-#endif // REALM_APP_SERVICES
 
 RLM_API realm_sync_config_t* realm_sync_config_new(const realm_user_t*, const char* partition_value) RLM_API_NOEXCEPT;
 RLM_API realm_sync_config_t* realm_flx_sync_config_new(const realm_user_t*) RLM_API_NOEXCEPT;

--- a/src/realm/object-store/c_api/app.cpp
+++ b/src/realm/object-store/c_api/app.cpp
@@ -281,7 +281,7 @@ RLM_API const char* realm_app_credentials_serialize_as_json(realm_app_credential
 
 RLM_API realm_sync_client_config_t* realm_app_config_get_sync_client_config(realm_app_config_t* app_config) noexcept
 {
-    return reinterpret_cast<realm_sync_client_config_t*>(&app_config->sync_client_config);
+    return static_cast<realm_sync_client_config_t*>(&app_config->sync_client_config);
 }
 
 RLM_API realm_app_t* realm_app_create(const realm_app_config_t* app_config)

--- a/src/realm/object-store/c_api/app.cpp
+++ b/src/realm/object-store/c_api/app.cpp
@@ -279,87 +279,9 @@ RLM_API const char* realm_app_credentials_serialize_as_json(realm_app_credential
     });
 }
 
-RLM_API void realm_app_config_set_sync_client_config(realm_app_config_t* app_config,
-                                                     realm_sync_client_config_t* sc_config) noexcept
+RLM_API realm_sync_client_config_t* realm_app_config_get_sync_client_config(realm_app_config_t* app_config) noexcept
 {
-    app_config->sync_client_config = *sc_config;
-}
-
-RLM_API void realm_app_config_set_sc_reconnect_mode(realm_app_config_t* app_config,
-                                                    realm_sync_client_reconnect_mode_e mode) noexcept
-{
-    app_config->sync_client_config.reconnect_mode = ReconnectMode(mode);
-}
-
-RLM_API void realm_app_config_set_sc_multiplex_sessions(realm_app_config_t* app_config, bool multiplex) noexcept
-{
-    app_config->sync_client_config.multiplex_sessions = multiplex;
-}
-
-RLM_API void realm_app_config_set_sc_user_agent_binding_info(realm_app_config_t* app_config,
-                                                             const char* info) noexcept
-{
-    app_config->sync_client_config.user_agent_binding_info = info;
-}
-
-RLM_API void realm_app_config_set_sc_user_agent_application_info(realm_app_config_t* app_config,
-                                                                 const char* info) noexcept
-{
-    app_config->sync_client_config.user_agent_application_info = info;
-}
-
-RLM_API void realm_app_config_set_sc_connect_timeout(realm_app_config_t* app_config, uint64_t timeout) noexcept
-{
-    app_config->sync_client_config.timeouts.connect_timeout = timeout;
-}
-
-RLM_API void realm_app_config_set_sc_connection_linger_time(realm_app_config_t* app_config, uint64_t time) noexcept
-{
-    app_config->sync_client_config.timeouts.connection_linger_time = time;
-}
-
-RLM_API void realm_app_config_set_sc_ping_keepalive_period(realm_app_config_t* app_config, uint64_t period) noexcept
-{
-    app_config->sync_client_config.timeouts.ping_keepalive_period = period;
-}
-
-RLM_API void realm_app_config_set_sc_pong_keepalive_timeout(realm_app_config_t* app_config, uint64_t timeout) noexcept
-{
-    app_config->sync_client_config.timeouts.pong_keepalive_timeout = timeout;
-}
-
-RLM_API void realm_app_config_set_sc_fast_reconnect_limit(realm_app_config_t* app_config, uint64_t limit) noexcept
-{
-    app_config->sync_client_config.timeouts.fast_reconnect_limit = limit;
-}
-
-RLM_API void realm_app_config_set_sc_resumption_delay_interval(realm_app_config_t* app_config,
-                                                               uint64_t interval) noexcept
-{
-    app_config->sync_client_config.timeouts.reconnect_backoff_info.resumption_delay_interval =
-        std::chrono::milliseconds{interval};
-}
-
-RLM_API void realm_app_config_set_sc_max_resumption_delay_interval(realm_app_config_t* app_config,
-                                                                   uint64_t interval) noexcept
-{
-    app_config->sync_client_config.timeouts.reconnect_backoff_info.max_resumption_delay_interval =
-        std::chrono::milliseconds{interval};
-}
-
-RLM_API void realm_app_config_set_sc_resumption_delay_backoff_multiplier(realm_app_config_t* app_config,
-                                                                         int multiplier) noexcept
-{
-    app_config->sync_client_config.timeouts.reconnect_backoff_info.resumption_delay_backoff_multiplier = multiplier;
-}
-
-RLM_API void realm_app_config_set_sc_default_binding_thread_observer(
-    realm_app_config_t* app_config, realm_on_object_store_thread_callback_t on_thread_create,
-    realm_on_object_store_thread_callback_t on_thread_destroy, realm_on_object_store_error_callback_t on_error,
-    realm_userdata_t user_data, realm_free_userdata_func_t free_userdata)
-{
-    app_config->sync_client_config.default_socket_provider_thread_observer = std::make_shared<CBindingThreadObserver>(
-        on_thread_create, on_thread_destroy, on_error, user_data, free_userdata);
+    return reinterpret_cast<realm_sync_client_config_t*>(&app_config->sync_client_config);
 }
 
 RLM_API realm_app_t* realm_app_create(const realm_app_config_t* app_config)

--- a/src/realm/object-store/c_api/app.cpp
+++ b/src/realm/object-store/c_api/app.cpp
@@ -285,6 +285,83 @@ RLM_API void realm_app_config_set_sync_client_config(realm_app_config_t* app_con
     app_config->sync_client_config = *sc_config;
 }
 
+RLM_API void realm_app_config_set_sc_reconnect_mode(realm_app_config_t* app_config,
+                                                    realm_sync_client_reconnect_mode_e mode) noexcept
+{
+    app_config->sync_client_config.reconnect_mode = ReconnectMode(mode);
+}
+
+RLM_API void realm_app_config_set_sc_multiplex_sessions(realm_app_config_t* app_config, bool multiplex) noexcept
+{
+    app_config->sync_client_config.multiplex_sessions = multiplex;
+}
+
+RLM_API void realm_app_config_set_sc_user_agent_binding_info(realm_app_config_t* app_config,
+                                                             const char* info) noexcept
+{
+    app_config->sync_client_config.user_agent_binding_info = info;
+}
+
+RLM_API void realm_app_config_set_sc_user_agent_application_info(realm_app_config_t* app_config,
+                                                                 const char* info) noexcept
+{
+    app_config->sync_client_config.user_agent_application_info = info;
+}
+
+RLM_API void realm_app_config_set_sc_connect_timeout(realm_app_config_t* app_config, uint64_t timeout) noexcept
+{
+    app_config->sync_client_config.timeouts.connect_timeout = timeout;
+}
+
+RLM_API void realm_app_config_set_sc_connection_linger_time(realm_app_config_t* app_config, uint64_t time) noexcept
+{
+    app_config->sync_client_config.timeouts.connection_linger_time = time;
+}
+
+RLM_API void realm_app_config_set_sc_ping_keepalive_period(realm_app_config_t* app_config, uint64_t period) noexcept
+{
+    app_config->sync_client_config.timeouts.ping_keepalive_period = period;
+}
+
+RLM_API void realm_app_config_set_sc_pong_keepalive_timeout(realm_app_config_t* app_config, uint64_t timeout) noexcept
+{
+    app_config->sync_client_config.timeouts.pong_keepalive_timeout = timeout;
+}
+
+RLM_API void realm_app_config_set_sc_fast_reconnect_limit(realm_app_config_t* app_config, uint64_t limit) noexcept
+{
+    app_config->sync_client_config.timeouts.fast_reconnect_limit = limit;
+}
+
+RLM_API void realm_app_config_set_sc_resumption_delay_interval(realm_app_config_t* app_config,
+                                                               uint64_t interval) noexcept
+{
+    app_config->sync_client_config.timeouts.reconnect_backoff_info.resumption_delay_interval =
+        std::chrono::milliseconds{interval};
+}
+
+RLM_API void realm_app_config_set_sc_max_resumption_delay_interval(realm_app_config_t* app_config,
+                                                                   uint64_t interval) noexcept
+{
+    app_config->sync_client_config.timeouts.reconnect_backoff_info.max_resumption_delay_interval =
+        std::chrono::milliseconds{interval};
+}
+
+RLM_API void realm_app_config_set_sc_resumption_delay_backoff_multiplier(realm_app_config_t* app_config,
+                                                                         int multiplier) noexcept
+{
+    app_config->sync_client_config.timeouts.reconnect_backoff_info.resumption_delay_backoff_multiplier = multiplier;
+}
+
+RLM_API void realm_app_config_set_sc_default_binding_thread_observer(
+    realm_app_config_t* app_config, realm_on_object_store_thread_callback_t on_thread_create,
+    realm_on_object_store_thread_callback_t on_thread_destroy, realm_on_object_store_error_callback_t on_error,
+    realm_userdata_t user_data, realm_free_userdata_func_t free_userdata)
+{
+    app_config->sync_client_config.default_socket_provider_thread_observer = std::make_shared<CBindingThreadObserver>(
+        on_thread_create, on_thread_destroy, on_error, user_data, free_userdata);
+}
+
 RLM_API realm_app_t* realm_app_create(const realm_app_config_t* app_config)
 {
     return wrap_err([&] {

--- a/src/realm/object-store/c_api/app.cpp
+++ b/src/realm/object-store/c_api/app.cpp
@@ -279,6 +279,12 @@ RLM_API const char* realm_app_credentials_serialize_as_json(realm_app_credential
     });
 }
 
+RLM_API void realm_app_config_set_sync_client_config(realm_app_config_t* app_config,
+                                                     realm_sync_client_config_t* sc_config) noexcept
+{
+    app_config->sync_client_config = *sc_config;
+}
+
 RLM_API realm_app_t* realm_app_create(const realm_app_config_t* app_config)
 {
     return wrap_err([&] {

--- a/src/realm/object-store/c_api/socket_provider.cpp
+++ b/src/realm/object-store/c_api/socket_provider.cpp
@@ -322,4 +322,10 @@ RLM_API void realm_sync_client_config_set_sync_socket(realm_sync_client_config_t
     config->socket_provider = *sync_socket;
 }
 
+RLM_API void realm_app_config_set_sc_sync_socket(realm_app_config_t* app_config,
+                                                 realm_sync_socket_t* sync_socket) noexcept
+{
+    app_config->sync_client_config.socket_provider = *sync_socket;
+}
+
 } // namespace realm::c_api

--- a/src/realm/object-store/c_api/socket_provider.cpp
+++ b/src/realm/object-store/c_api/socket_provider.cpp
@@ -322,12 +322,4 @@ RLM_API void realm_sync_client_config_set_sync_socket(realm_sync_client_config_t
     config->socket_provider = *sync_socket;
 }
 
-#if REALM_APP_SERVICES
-RLM_API void realm_app_config_set_sc_sync_socket(realm_app_config_t* app_config,
-                                                 realm_sync_socket_t* sync_socket) noexcept
-{
-    app_config->sync_client_config.socket_provider = *sync_socket;
-}
-#endif // REALM_APP_SERVICES
-
 } // namespace realm::c_api

--- a/src/realm/object-store/c_api/socket_provider.cpp
+++ b/src/realm/object-store/c_api/socket_provider.cpp
@@ -322,10 +322,12 @@ RLM_API void realm_sync_client_config_set_sync_socket(realm_sync_client_config_t
     config->socket_provider = *sync_socket;
 }
 
+#if REALM_APP_SERVICES
 RLM_API void realm_app_config_set_sc_sync_socket(realm_app_config_t* app_config,
                                                  realm_sync_socket_t* sync_socket) noexcept
 {
     app_config->sync_client_config.socket_provider = *sync_socket;
 }
+#endif // REALM_APP_SERVICES
 
 } // namespace realm::c_api

--- a/src/realm/object-store/c_api/sync.cpp
+++ b/src/realm/object-store/c_api/sync.cpp
@@ -128,10 +128,12 @@ static Query add_ordering_to_realm_query(Query realm_query, const DescriptorOrde
     return realm_query;
 }
 
+#if !REALM_APP_SERVICES
 RLM_API realm_sync_client_config_t* realm_sync_client_config_new(void) noexcept
 {
     return new realm_sync_client_config_t;
 }
+#endif // !REALM_APP_SERVICES
 
 RLM_API void realm_sync_client_config_set_reconnect_mode(realm_sync_client_config_t* config,
                                                          realm_sync_client_reconnect_mode_e mode) noexcept

--- a/src/realm/object-store/c_api/types.hpp
+++ b/src/realm/object-store/c_api/types.hpp
@@ -617,9 +617,19 @@ struct realm_http_transport : realm::c_api::WrapC, std::shared_ptr<realm::app::G
     }
 };
 
+#if REALM_APP_SERVICES
+// This class doesn't support realm_release since it isn't meant to be deleted
+// Do not add any extra functions or member variables to this class to keep
+// it compatible with the realm::SyncClientConfig class
+struct realm_sync_client_config final : realm::SyncClientConfig {
+    using SyncClientConfig::SyncClientConfig;
+};
+#else
+// This class must be freed using realm_release()
 struct realm_sync_client_config : realm::c_api::WrapC, realm::SyncClientConfig {
     using SyncClientConfig::SyncClientConfig;
 };
+#endif // REALM_APP_SERVICES
 
 struct realm_sync_config : realm::c_api::WrapC, realm::SyncConfig {
     using SyncConfig::SyncConfig;

--- a/src/realm/object-store/c_api/types.hpp
+++ b/src/realm/object-store/c_api/types.hpp
@@ -618,9 +618,11 @@ struct realm_http_transport : realm::c_api::WrapC, std::shared_ptr<realm::app::G
 };
 
 #if REALM_APP_SERVICES
-// This class doesn't support realm_release since it isn't meant to be deleted
-// Do not add any extra functions or member variables to this class to keep
-// it compatible with the realm::SyncClientConfig class
+// This class doesn't support realm_release() since it is only meant to be used
+// as a CAPI-compatible reference to the SyncClientConfig member variable that
+// is part of AppConfig.
+// To avoid data misalignment or other conflicts with the original SyncClientConfig,
+// do not add any additional functions or member variables to this class.
 struct realm_sync_client_config final : realm::SyncClientConfig {
     using SyncClientConfig::SyncClientConfig;
 };

--- a/test/object-store/c_api/c_api.cpp
+++ b/test/object-store/c_api/c_api.cpp
@@ -570,7 +570,8 @@ TEST_CASE("C API (non-database)", "[c_api]") {
         };
         verify_sync_client_config(test_sync_client_config.get());
 
-        // Make a dummy app config and make sure the values are updated after set
+#if REALM_APP_SERVICES
+        // Make a dummy app config and make sure the sync_client_config is updated
         const uint64_t request_timeout = 2500;
         auto transport = std::make_shared<UnitTestTransport>(request_timeout);
         auto http_transport = realm_http_transport(transport);
@@ -578,6 +579,7 @@ TEST_CASE("C API (non-database)", "[c_api]") {
         realm_app_config_set_sync_client_config(app_config.get(), test_sync_client_config.get());
         // Make sure app_config's sync_client_config has the values set above
         verify_sync_client_config(&app_config->sync_client_config);
+#endif
     }
 
 #if !REALM_APP_SERVICES

--- a/test/object-store/c_api/c_api.cpp
+++ b/test/object-store/c_api/c_api.cpp
@@ -545,28 +545,39 @@ TEST_CASE("C API (non-database)", "[c_api]") {
         realm_sync_client_config_set_multiplex_sessions(test_sync_client_config.get(), true);
         CHECK(test_sync_client_config->multiplex_sessions);
         realm_sync_client_config_set_multiplex_sessions(test_sync_client_config.get(), false);
-        CHECK_FALSE(test_sync_client_config->multiplex_sessions);
         realm_sync_client_config_set_user_agent_binding_info(test_sync_client_config.get(), "some user agent stg");
-        CHECK(test_sync_client_config->user_agent_binding_info == "some user agent stg");
         realm_sync_client_config_set_user_agent_application_info(test_sync_client_config.get(), "some application");
-        CHECK(test_sync_client_config->user_agent_application_info == "some application");
         realm_sync_client_config_set_connect_timeout(test_sync_client_config.get(), 666);
-        CHECK(test_sync_client_config->timeouts.connect_timeout == 666);
         realm_sync_client_config_set_connection_linger_time(test_sync_client_config.get(), 999);
-        CHECK(test_sync_client_config->timeouts.connection_linger_time == 999);
         realm_sync_client_config_set_ping_keepalive_period(test_sync_client_config.get(), 555);
-        CHECK(test_sync_client_config->timeouts.ping_keepalive_period == 555);
         realm_sync_client_config_set_pong_keepalive_timeout(test_sync_client_config.get(), 100000);
-        CHECK(test_sync_client_config->timeouts.pong_keepalive_timeout == 100000);
         realm_sync_client_config_set_fast_reconnect_limit(test_sync_client_config.get(), 1099);
-        CHECK(test_sync_client_config->timeouts.fast_reconnect_limit == 1099);
         realm_sync_client_config_set_resumption_delay_interval(test_sync_client_config.get(), 1024);
-        CHECK(test_sync_client_config->timeouts.reconnect_backoff_info.resumption_delay_interval.count() == 1024);
         realm_sync_client_config_set_max_resumption_delay_interval(test_sync_client_config.get(), 600024);
-        CHECK(test_sync_client_config->timeouts.reconnect_backoff_info.max_resumption_delay_interval.count() ==
-              600024);
         realm_sync_client_config_set_resumption_delay_backoff_multiplier(test_sync_client_config.get(), 1010);
-        CHECK(test_sync_client_config->timeouts.reconnect_backoff_info.resumption_delay_backoff_multiplier == 1010);
+        auto verify_sync_client_config = [](SyncClientConfig* config) {
+            CHECK_FALSE(config->multiplex_sessions);
+            CHECK(config->user_agent_binding_info == "some user agent stg");
+            CHECK(config->user_agent_application_info == "some application");
+            CHECK(config->timeouts.connect_timeout == 666);
+            CHECK(config->timeouts.connection_linger_time == 999);
+            CHECK(config->timeouts.ping_keepalive_period == 555);
+            CHECK(config->timeouts.pong_keepalive_timeout == 100000);
+            CHECK(config->timeouts.fast_reconnect_limit == 1099);
+            CHECK(config->timeouts.reconnect_backoff_info.resumption_delay_interval.count() == 1024);
+            CHECK(config->timeouts.reconnect_backoff_info.max_resumption_delay_interval.count() == 600024);
+            CHECK(config->timeouts.reconnect_backoff_info.resumption_delay_backoff_multiplier == 1010);
+        };
+        verify_sync_client_config(test_sync_client_config.get());
+
+        // Make a dummy app config and make sure the values are updated after set
+        const uint64_t request_timeout = 2500;
+        auto transport = std::make_shared<UnitTestTransport>(request_timeout);
+        auto http_transport = realm_http_transport(transport);
+        auto app_config = cptr(realm_app_config_new("app_id_123", &http_transport));
+        realm_app_config_set_sync_client_config(app_config.get(), test_sync_client_config.get());
+        // Make sure app_config's sync_client_config has the values set above
+        verify_sync_client_config(&app_config->sync_client_config);
     }
 
 #if !REALM_APP_SERVICES
@@ -823,6 +834,12 @@ TEST_CASE("C API (non-database)", "[c_api]") {
         realm_app_config_set_base_file_path(app_config.get(), temp_dir.c_str());
         realm_app_config_set_metadata_mode(app_config.get(), RLM_SYNC_CLIENT_METADATA_MODE_DISABLED);
         realm_app_config_set_security_access_group(app_config.get(), "");
+
+        auto sync_client_config = cptr(realm_sync_client_config_new());
+        realm_sync_client_config_set_connect_timeout(sync_client_config.get(), 9876543); // some bogus value
+        realm_app_config_set_sync_client_config(app_config.get(), sync_client_config.get());
+        // Make sure app_config's sync_client_config has the value we set
+        CHECK(app_config->sync_client_config.timeouts.connect_timeout == 9876543);
 
         auto test_app = cptr(realm_app_create(app_config.get()));
         realm_user_t* sync_user;

--- a/test/object-store/c_api/c_api.cpp
+++ b/test/object-store/c_api/c_api.cpp
@@ -837,11 +837,36 @@ TEST_CASE("C API (non-database)", "[c_api]") {
         realm_app_config_set_metadata_mode(app_config.get(), RLM_SYNC_CLIENT_METADATA_MODE_DISABLED);
         realm_app_config_set_security_access_group(app_config.get(), "");
 
-        auto sync_client_config = cptr(realm_sync_client_config_new());
-        realm_sync_client_config_set_connect_timeout(sync_client_config.get(), 9876543); // some bogus value
-        realm_app_config_set_sync_client_config(app_config.get(), sync_client_config.get());
-        // Make sure app_config's sync_client_config has the value we set
-        CHECK(app_config->sync_client_config.timeouts.connect_timeout == 9876543);
+        realm_app_config_set_sc_reconnect_mode(app_config.get(), RLM_SYNC_CLIENT_RECONNECT_MODE_TESTING);
+        CHECK(app_config->sync_client_config.reconnect_mode ==
+              static_cast<ReconnectMode>(RLM_SYNC_CLIENT_RECONNECT_MODE_TESTING));
+        realm_app_config_set_sc_multiplex_sessions(app_config.get(), true);
+        CHECK(app_config->sync_client_config.multiplex_sessions);
+        realm_app_config_set_sc_multiplex_sessions(app_config.get(), false);
+        CHECK_FALSE(app_config->sync_client_config.multiplex_sessions);
+        realm_app_config_set_sc_user_agent_binding_info(app_config.get(), "some user agent stg");
+        CHECK(app_config->sync_client_config.user_agent_binding_info == "some user agent stg");
+        realm_app_config_set_sc_user_agent_application_info(app_config.get(), "some application");
+        CHECK(app_config->sync_client_config.user_agent_application_info == "some application");
+        realm_app_config_set_sc_connect_timeout(app_config.get(), 666);
+        CHECK(app_config->sync_client_config.timeouts.connect_timeout == 666);
+        realm_app_config_set_sc_connection_linger_time(app_config.get(), 999);
+        CHECK(app_config->sync_client_config.timeouts.connection_linger_time == 999);
+        realm_app_config_set_sc_ping_keepalive_period(app_config.get(), 555);
+        CHECK(app_config->sync_client_config.timeouts.ping_keepalive_period == 555);
+        realm_app_config_set_sc_pong_keepalive_timeout(app_config.get(), 100000);
+        CHECK(app_config->sync_client_config.timeouts.pong_keepalive_timeout == 100000);
+        realm_app_config_set_sc_fast_reconnect_limit(app_config.get(), 1099);
+        CHECK(app_config->sync_client_config.timeouts.fast_reconnect_limit == 1099);
+        realm_app_config_set_sc_resumption_delay_interval(app_config.get(), 1024);
+        CHECK(app_config->sync_client_config.timeouts.reconnect_backoff_info.resumption_delay_interval.count() ==
+              1024);
+        realm_app_config_set_sc_max_resumption_delay_interval(app_config.get(), 600024);
+        CHECK(app_config->sync_client_config.timeouts.reconnect_backoff_info.max_resumption_delay_interval.count() ==
+              600024);
+        realm_app_config_set_sc_resumption_delay_backoff_multiplier(app_config.get(), 1010);
+        CHECK(app_config->sync_client_config.timeouts.reconnect_backoff_info.resumption_delay_backoff_multiplier ==
+              1010);
 
         auto test_app = cptr(realm_app_create(app_config.get()));
         realm_user_t* sync_user;


### PR DESCRIPTION
## What, How & Why?
As part of the changes to separate the App from the Sync Client, a `realm_app_config_get_sync_client_config()` function was added to the C_API to retrieve a pointer to the sync client config stored in the AppConfig. Unfortunately, this function was never implemented and was only a function declaration.
There are two implementations for getting a `realm_sync_client_config_t`, depending on the value of the `REALM_APP_SERVICES` build flag:
* If it is set, `realm_app_config_get_sync_client_config()` is available to get a pointer to the `sync_client_config` member property of the `realm_app_config_t` structure. The value returned by this function is a reference and should not be freed using `realm_release()`.
* If it is not set, `realm_sync_client_config_new()` is available to create a new `realm_sync_client_config_t` instance this is intended to be used with `realm_sync_manager_create()`, which is also only available if `REALM_APP_SERVICES` is not set. The value returned by this function is a new object and must be manually freed using `realm_release()`

The `realm_sync_client_config_t` returned by either `realm_app_config_get_sync_client_config()` or `realm_sync_client_config_new()` is compatible with the `realm_sync_client_config_set_...()` functions for setting the individual parameters of this structure.

The tests for `realm_sync_client_config_t` and `realm_app_config_t` were updated to verify these functions for retrieving an instance/reference and setting the SyncClientConfig values.

Fixes #7890 

## ☑️ ToDos
* [x] 📝 Changelog update
* [X] 🚦 Tests (or not relevant)
* [X] C-API, if public C++ API changed
* ~~[ ] `bindgen/spec.yml`, if public C++ API changed~~
