### PR TITLE
RCORE-2204: Use accepting_clients key to check for initial sync completion in flx tests

### DIFF
--- a/test/object-store/sync/flx_role_change.cpp
+++ b/test/object-store/sync/flx_role_change.cpp
@@ -472,7 +472,7 @@ TEST_CASE("flx: role change bootstraps", "[sync][flx][baas][role change][bootstr
         general_role.document_filters.read = {{"role", "employee"}};
         general_role.document_filters.write = {{"role", "employee"}};
 
-        test_rules["roles"][0] = {transform_service_role(general_role)};
+        test_rules["roles"][0] = transform_service_role(general_role);
         harness->do_with_new_realm([&](SharedRealm new_realm) {
             set_up_realm(new_realm, num_total);
 
@@ -527,7 +527,7 @@ TEST_CASE("flx: role change bootstraps", "[sync][flx][baas][role change][bootstr
             user1_role_2.document_filters.read = {{"role", {{"$in", {"employee", "manager"}}}}};
             user1_role_2.document_filters.write = {{"role", {{"$in", {"employee", "manager"}}}}};
             // Update the first rule for user 1 and verify the data after the rule is applied
-            test_rules["roles"][0] = {transform_service_role(user1_role_2)};
+            test_rules["roles"][0] = transform_service_role(user1_role_2);
             // Realm 1 should receive a role change bootstrap which updates the data to employee
             // and manager records. It doesn't matter what type of bootstrap occurs
             update_perms_and_verify(*harness, realm_1, test_rules,

--- a/test/object-store/util/sync/baas_admin_api.hpp
+++ b/test/object-store/util/sync/baas_admin_api.hpp
@@ -133,7 +133,7 @@ public:
     std::vector<SchemaVersionInfo> get_schema_versions(const std::string& app_id) const;
     bool is_sync_enabled(const std::string& app_id) const;
     bool is_sync_terminated(const std::string& app_id) const;
-    bool is_initial_sync_complete(const std::string& app_id) const;
+    bool is_initial_sync_complete(const std::string& app_id, bool is_flx_sync) const;
 
     struct MigrationStatus {
         std::string statusMessage;

--- a/test/object-store/util/sync/sync_test_utils.cpp
+++ b/test/object-store/util/sync/sync_test_utils.cpp
@@ -569,7 +569,7 @@ struct BaasClientReset : public TestClientReset {
         // state.
         timed_sleeping_wait_for(
             [&] {
-                return app_session.admin_api.is_initial_sync_complete(app_session.server_app_id);
+                return app_session.admin_api.is_initial_sync_complete(app_session.server_app_id, false);
             },
             std::chrono::seconds(30), std::chrono::seconds(1));
 


### PR DESCRIPTION
## What, How & Why?
The initial sync progress endpoint has an additional key, `accepting_clients`, which in FLX is only set to true after the first initial sync completes. This is a more reliable way to check for initial sync completion than relying on individual namespaces. This PR updates the test helper to check that value instead for FLX apps.

Additionally fixing a bug in the role change tests' API calls that is manifesting in the latest baas, but not the pinned baasaas version for some reason.

## ☑️ ToDos
* [ ] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [x] C-API, if public C++ API changed
* [x] `bindgen/spec.yml`, if public C++ API changed
