### PR TITLE
RCORE-2209 Treat completing a client reset as receiving a MARK message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 * Fixed bug which would prevent eventual consistency during conflict resolution. Affected clients would experience data divergence and potentially consistency errors as a result. ([PR #7955](https://github.com/realm/realm-core/pull/7955), since v14.8.0)
 * Fixed issues loading the native Realm libraries on Linux ARMv7 systems when they linked against our bundled OpenSSL resulting in errors like `unexpected reloc type 0x03`. ([#7947](https://github.com/realm/realm-core/issues/7947), since v14.1.0)
 * `Realm::convert()` would sometimes incorrectly throw an exception claiming that there were unuploaded local changes when the source Realm is a synchronized Realm ([#7966](https://github.com/realm/realm-core/issues/7966), since v10.7.0).
+* Automatic client reset handling now reports download completion as soon as all changes from the newly downloaded file have been applied to the main Realm file rather than at an inconsistent time afterwards ([PR #7921](https://github.com/realm/realm-core/pull/7921)).
+* Cycle detection for automatic client reset handling would sometimes consider two client resets in a row to be a cycle even when the first reset did not recover any changes and so could not have triggered the second. ([PR #7921](https://github.com/realm/realm-core/pull/7921)).
 
 ### Breaking changes
 * None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 * Fixed issues loading the native Realm libraries on Linux ARMv7 systems when they linked against our bundled OpenSSL resulting in errors like `unexpected reloc type 0x03`. ([#7947](https://github.com/realm/realm-core/issues/7947), since v14.1.0)
 * `Realm::convert()` would sometimes incorrectly throw an exception claiming that there were unuploaded local changes when the source Realm is a synchronized Realm ([#7966](https://github.com/realm/realm-core/issues/7966), since v10.7.0).
 * Automatic client reset handling now reports download completion as soon as all changes from the newly downloaded file have been applied to the main Realm file rather than at an inconsistent time afterwards ([PR #7921](https://github.com/realm/realm-core/pull/7921)).
-* Cycle detection for automatic client reset handling would sometimes consider two client resets in a row to be a cycle even when the first reset did not recover any changes and so could not have triggered the second. ([PR #7921](https://github.com/realm/realm-core/pull/7921)).
+* Cycle detection for automatic client reset handling is now more precise. Previously errors which occurred after all recovered changesets were uploaded would sometimes be incorrectly considered a cycle and skip automatic handling. ([PR #7921](https://github.com/realm/realm-core/pull/7921)).
 
 ### Breaking changes
 * None.

--- a/src/realm/object-store/shared_realm.cpp
+++ b/src/realm/object-store/shared_realm.cpp
@@ -1213,6 +1213,11 @@ void Realm::convert(const Config& config, bool merge_into_existing)
     }
 }
 
+bool Realm::has_pending_unuploaded_changes() const noexcept
+{
+    return !m_transaction->get_history()->no_pending_local_changes(m_transaction->get_version());
+}
+
 OwnedBinaryData Realm::write_copy()
 {
     verify_thread();

--- a/src/realm/object-store/shared_realm.hpp
+++ b/src/realm/object-store/shared_realm.hpp
@@ -321,6 +321,8 @@ public:
     // Returns `true` if the Realm is frozen, `false` otherwise.
     bool is_frozen() const;
 
+    bool has_pending_unuploaded_changes() const noexcept;
+
     // Returns true if the Realm is either in a read or frozen transaction
     bool is_in_read_transaction() const
     {

--- a/src/realm/sync/network/default_socket.cpp
+++ b/src/realm/sync/network/default_socket.cpp
@@ -32,8 +32,6 @@ public:
         initiate_resolve();
     }
 
-    virtual ~DefaultWebSocketImpl() = default;
-
     void async_write_binary(util::Span<const char> data, SyncSocketProvider::FunctionHandler&& handler) override
     {
         m_websocket.async_write_binary(data.data(), data.size(),

--- a/src/realm/sync/network/network.cpp
+++ b/src/realm/sync/network/network.cpp
@@ -1414,10 +1414,7 @@ public:
         bool resolver_thread_started = m_resolver_thread.joinable();
         if (resolver_thread_started)
             return;
-        auto func = [this]() noexcept {
-            resolver_thread();
-        };
-        m_resolver_thread = std::thread{std::move(func)};
+        m_resolver_thread = std::thread{&Impl::resolver_thread, this};
     }
 
     void add_wait_oper(LendersWaitOperPtr op)

--- a/src/realm/sync/noinst/client_history_impl.cpp
+++ b/src/realm/sync/noinst/client_history_impl.cpp
@@ -91,7 +91,7 @@ void ClientHistory::set_history_adjustments(
         for (size_t i = 0, size = m_arrays->remote_versions.size(); i < size; ++i) {
             m_arrays->remote_versions.set(i, server_version.version);
             version_type version = m_sync_history_base_version + i;
-            logger.debug("Updating %1: client_version(%2) changeset_size(%3) server_version(%4)", i, version + 1,
+            logger.debug("Updating %1: client_version(%2) changeset_size(%3) server_version(%4)", i, version,
                          m_arrays->changesets.get(i).size(), server_version.version);
         }
     }
@@ -956,9 +956,7 @@ void ClientHistory::update_sync_progress(const SyncProgress& progress, Downloada
         // server. The situation we want to avoid is that a recovery itself causes another reset
         // which creates a reset cycle. However, at this point, upload progress has been made
         // and we can remove the cycle detection flag if there is one.
-        if (PendingResetStore::clear_pending_reset(*m_group)) {
-            logger.info(util::LogCategory::reset, "Clearing pending reset tracker after upload completion.");
-        }
+        PendingResetStore::remove_if_complete(*m_group, progress.upload.client_version, logger);
     }
 
     m_progress_download = progress.download;

--- a/src/realm/sync/noinst/client_history_impl.hpp
+++ b/src/realm/sync/noinst/client_history_impl.hpp
@@ -175,7 +175,8 @@ public:
     /// \param downloadable_bytes If specified, and if the implementation cares
     /// about byte-level progress, this function updates the persistent record
     /// of the estimate of the number of remaining bytes to be downloaded.
-    void set_sync_progress(const SyncProgress& progress, DownloadableProgress downloadable_bytes, VersionInfo&);
+    void set_sync_progress(const SyncProgress& progress, DownloadableProgress downloadable_bytes, VersionInfo&,
+                           util::Logger& logger);
 
     /// \brief Scan through the history for changesets to be uploaded.
     ///
@@ -421,7 +422,7 @@ private:
     void prepare_for_write();
     Replication::version_type add_changeset(BinaryData changeset, BinaryData sync_changeset);
     void add_sync_history_entry(const HistoryEntry&);
-    void update_sync_progress(const SyncProgress&, DownloadableProgress downloadable_bytes);
+    void update_sync_progress(const SyncProgress&, DownloadableProgress downloadable_bytes, util::Logger& logger);
     void trim_ct_history();
     void trim_sync_history();
     void do_trim_sync_history(std::size_t n);

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -978,8 +978,6 @@ void Connection::initiate_write_message(const OutputBuffer& out, Session* sess)
     if (m_websocket_error_received)
         return;
 
-    m_sending_session = sess;
-    m_sending = true;
     m_websocket->async_write_binary(out.as_span(), [this, sentinel = m_websocket_sentinel](Status status) {
         if (sentinel->destroyed) {
             return;
@@ -993,6 +991,8 @@ void Connection::initiate_write_message(const OutputBuffer& out, Session* sess)
         }
         handle_write_message(); // Throws
     });                         // Throws
+    m_sending_session = sess;
+    m_sending = true;
 }
 
 

--- a/src/realm/sync/noinst/client_impl_base.hpp
+++ b/src/realm/sync/noinst/client_impl_base.hpp
@@ -934,7 +934,6 @@ private:
     void process_pending_flx_bootstrap();
 
     bool client_reset_if_needed();
-    void handle_pending_client_reset_acknowledgement();
 
     void gather_pending_compensating_writes(util::Span<Changeset> changesets, std::vector<ProtocolErrorInfo>* out);
 

--- a/src/realm/sync/noinst/client_reset.cpp
+++ b/src/realm/sync/noinst/client_reset.cpp
@@ -552,6 +552,12 @@ bool perform_client_reset_diff(DB& db_local, sync::ClientReset& reset_config, ut
                     "Immediately removing client reset tracker as there are no recovered changesets to upload.");
         sync::PendingResetStore::clear_pending_reset(*wt_local);
     }
+    else {
+        logger.debug(util::LogCategory::reset,
+                     "Marking %1 as the version which must be uploaded to complete client reset recovery.",
+                     recovered.back().version);
+        sync::PendingResetStore::set_recovered_version(*wt_local, recovered.back().version);
+    }
 
     wt_local->commit_and_continue_as_read();
 

--- a/src/realm/sync/noinst/client_reset.cpp
+++ b/src/realm/sync/noinst/client_reset.cpp
@@ -545,6 +545,14 @@ bool perform_client_reset_diff(DB& db_local, sync::ClientReset& reset_config, ut
         }
     }
 
+    // If there was nothing to recover or recovery was disabled then immediately
+    // mark the client reset as successfully complete
+    if (recovered.empty()) {
+        logger.info(util::LogCategory::reset,
+                    "Immediately removing client reset tracker as there are no recovered changesets to upload.");
+        sync::PendingResetStore::clear_pending_reset(*wt_local);
+    }
+
     wt_local->commit_and_continue_as_read();
 
     VersionID new_version_local = wt_local->get_version_of_current_transaction();

--- a/src/realm/sync/noinst/migration_store.cpp
+++ b/src/realm/sync/noinst/migration_store.cpp
@@ -53,9 +53,9 @@ bool MigrationStore::load_data(bool read_only)
 
     auto tr = m_db->start_read();
     // Start with a reader so it doesn't try to write until we are ready
-    SyncMetadataSchemaVersionsReader schema_versions_reader(tr);
+    SyncMetadataSchemaVersionsReader schema_versions_reader(*tr);
     if (auto schema_version =
-            schema_versions_reader.get_version_for(tr, internal_schema_groups::c_flx_migration_store)) {
+            schema_versions_reader.get_version_for(*tr, internal_schema_groups::c_flx_migration_store)) {
         if (*schema_version != c_schema_version) {
             throw RuntimeError(ErrorCodes::UnsupportedFileFormatVersion,
                                "Invalid schema version for flexible sync migration store metadata");

--- a/src/realm/sync/noinst/pending_bootstrap_store.cpp
+++ b/src/realm/sync/noinst/pending_bootstrap_store.cpp
@@ -102,9 +102,9 @@ PendingBootstrapStore::PendingBootstrapStore(DBRef db, util::Logger& logger,
 
     auto tr = m_db->start_read();
     // Start with a reader so it doesn't try to write until we are ready
-    SyncMetadataSchemaVersionsReader schema_versions_reader(tr);
+    SyncMetadataSchemaVersionsReader schema_versions_reader(*tr);
     if (auto schema_version =
-            schema_versions_reader.get_version_for(tr, internal_schema_groups::c_pending_bootstraps)) {
+            schema_versions_reader.get_version_for(*tr, internal_schema_groups::c_pending_bootstraps)) {
         if (*schema_version != c_schema_version) {
             throw RuntimeError(ErrorCodes::SchemaVersionMismatch,
                                "Invalid schema version for FLX sync pending bootstrap table group");

--- a/src/realm/sync/noinst/pending_reset_store.cpp
+++ b/src/realm/sync/noinst/pending_reset_store.cpp
@@ -63,11 +63,13 @@ constexpr static std::string_view s_reset_action_col_name("action");
 constexpr static std::string_view s_reset_error_code_col_name("error_code");
 constexpr static std::string_view s_reset_error_msg_col_name("error_msg");
 
-void PendingResetStore::clear_pending_reset(Group& group)
+bool PendingResetStore::clear_pending_reset(Group& group)
 {
     if (auto table = group.get_table(s_meta_reset_table_name); table && !table->is_empty()) {
         table->clear();
+        return true;
     }
+    return false;
 }
 
 std::optional<PendingReset> PendingResetStore::has_pending_reset(const Group& group)

--- a/src/realm/sync/noinst/pending_reset_store.hpp
+++ b/src/realm/sync/noinst/pending_reset_store.hpp
@@ -52,7 +52,8 @@ public:
     static void track_reset(Group& group, ClientResyncMode mode, PendingReset::Action action, Status error);
     // Clear the pending reset tracking information, if it exists
     // Requires a writable transaction and changes must be committed manually
-    static void clear_pending_reset(Group& group);
+    // Returns true if there was anything to remove
+    static bool clear_pending_reset(Group& group);
     static std::optional<PendingReset> has_pending_reset(const Group& group);
 
     static int64_t from_reset_action(PendingReset::Action action);

--- a/src/realm/sync/noinst/sync_metadata_schema.hpp
+++ b/src/realm/sync/noinst/sync_metadata_schema.hpp
@@ -129,11 +129,11 @@ Status try_load_sync_metadata_schema(const Group& g, std::vector<SyncMetadataTab
 
 class SyncMetadataSchemaVersionsReader {
 public:
-    explicit SyncMetadataSchemaVersionsReader(const TransactionRef& ref);
+    explicit SyncMetadataSchemaVersionsReader(const Group& g);
 
-    std::optional<int64_t> get_version_for(const TransactionRef& tr, std::string_view schema_group_name);
+    std::optional<int64_t> get_version_for(const Group& g, std::string_view schema_group_name);
 
-    std::optional<int64_t> get_legacy_version(const TransactionRef& tr);
+    std::optional<int64_t> get_legacy_version(const Group& g);
 
 protected:
     TableKey m_table;

--- a/src/realm/sync/subscriptions.cpp
+++ b/src/realm/sync/subscriptions.cpp
@@ -663,10 +663,10 @@ SubscriptionStore::SubscriptionStore(Private, DBRef db)
 
     auto tr = m_db->start_read();
     // Start with a reader so it doesn't try to write until we are ready
-    SyncMetadataSchemaVersionsReader schema_versions_reader(tr);
+    SyncMetadataSchemaVersionsReader schema_versions_reader(*tr);
 
     if (auto schema_version =
-            schema_versions_reader.get_version_for(tr, internal_schema_groups::c_flx_subscription_store)) {
+            schema_versions_reader.get_version_for(*tr, internal_schema_groups::c_flx_subscription_store)) {
         if (*schema_version != c_flx_schema_version) {
             throw RuntimeError(ErrorCodes::UnsupportedFileFormatVersion,
                                "Invalid schema version for flexible sync metadata");

--- a/test/object-store/benchmarks/client_reset.cpp
+++ b/test/object-store/benchmarks/client_reset.cpp
@@ -80,7 +80,7 @@ struct BenchmarkLocalClientReset : public reset_utils::TestClientReset {
         progress.upload.client_version = current_version;
         progress.upload.last_integrated_server_version = current_version;
         sync::VersionInfo info_out;
-        history_local->set_sync_progress(progress, 0, info_out);
+        history_local->set_sync_progress(progress, 0, info_out, *util::Logger::get_default_logger());
 
         constexpr int64_t shared_pk = -42;
         {

--- a/test/object-store/util/sync/baas_admin_api.hpp
+++ b/test/object-store/util/sync/baas_admin_api.hpp
@@ -293,6 +293,22 @@ inline app::AppConfig get_config(Factory factory, const AppSession& app_session)
              "A device version", "A framework name", "A framework version", "A bundle id"}};
 }
 
+class DisableDevelopmentMode {
+public:
+    DisableDevelopmentMode(const AppSession& session)
+        : m_session(session)
+    {
+        session.admin_api.set_development_mode_to(session.server_app_id, false);
+    }
+    ~DisableDevelopmentMode()
+    {
+        m_session.admin_api.set_development_mode_to(m_session.server_app_id, true);
+    }
+
+private:
+    const AppSession& m_session;
+};
+
 } // namespace realm
 
 #endif // REALM_ENABLE_AUTH_TESTS

--- a/test/object-store/util/sync/sync_test_utils.hpp
+++ b/test/object-store/util/sync/sync_test_utils.hpp
@@ -328,7 +328,8 @@ struct TestClientReset {
     TestClientReset* on_post_reset(Callback&& post_reset);
     void set_pk_of_object_driving_reset(const ObjectId& pk);
     ObjectId get_pk_of_object_driving_reset() const;
-    void disable_wait_for_reset_completion();
+    TestClientReset* disable_wait_for_reset_completion();
+    TestClientReset* expect_reset_error(std::optional<SyncError>&);
 
     virtual TestClientReset* set_development_mode(bool enable = true);
     virtual void run() = 0;
@@ -343,8 +344,9 @@ protected:
     Callback m_make_remote_changes;
     Callback m_on_post_local;
     Callback m_on_post_reset;
-    bool m_did_run = false;
     ObjectId m_pk_driving_reset = ObjectId::gen();
+    std::optional<SyncError>* m_error = nullptr;
+    bool m_did_run = false;
     bool m_wait_for_reset_completion = true;
 };
 

--- a/test/test_client_reset.cpp
+++ b/test/test_client_reset.cpp
@@ -937,35 +937,6 @@ void expect_reset(unit_test::TestContext& test_context, DBRef& target, DBRef& fr
     }
 }
 
-TEST(ClientReset_ConvertResyncMode)
-{
-    CHECK(PendingResetStore::to_resync_mode(0) == ClientResyncMode::DiscardLocal);
-    CHECK(PendingResetStore::to_resync_mode(1) == ClientResyncMode::Recover);
-    CHECK_THROW(PendingResetStore::to_resync_mode(2), sync::ClientResetFailed);
-
-    CHECK(PendingResetStore::from_resync_mode(ClientResyncMode::DiscardLocal) == 0);
-    CHECK(PendingResetStore::from_resync_mode(ClientResyncMode::RecoverOrDiscard) == 1);
-    CHECK(PendingResetStore::from_resync_mode(ClientResyncMode::Recover) == 1);
-    CHECK_THROW(PendingResetStore::from_resync_mode(ClientResyncMode::Manual), sync::ClientResetFailed);
-}
-
-TEST(ClientReset_ConvertResetAction)
-{
-    CHECK(PendingResetStore::to_reset_action(0) == sync::ProtocolErrorInfo::Action::NoAction);
-    CHECK(PendingResetStore::to_reset_action(1) == sync::ProtocolErrorInfo::Action::ClientReset);
-    CHECK(PendingResetStore::to_reset_action(2) == sync::ProtocolErrorInfo::Action::ClientResetNoRecovery);
-    CHECK(PendingResetStore::to_reset_action(3) == sync::ProtocolErrorInfo::Action::MigrateToFLX);
-    CHECK(PendingResetStore::to_reset_action(4) == sync::ProtocolErrorInfo::Action::RevertToPBS);
-    CHECK(PendingResetStore::to_reset_action(5) == sync::ProtocolErrorInfo::Action::NoAction);
-
-    CHECK(PendingResetStore::from_reset_action(sync::ProtocolErrorInfo::Action::ClientReset) == 1);
-    CHECK(PendingResetStore::from_reset_action(sync::ProtocolErrorInfo::Action::ClientResetNoRecovery) == 2);
-    CHECK(PendingResetStore::from_reset_action(sync::ProtocolErrorInfo::Action::MigrateToFLX) == 3);
-    CHECK(PendingResetStore::from_reset_action(sync::ProtocolErrorInfo::Action::RevertToPBS) == 4);
-    CHECK_THROW(PendingResetStore::from_reset_action(sync::ProtocolErrorInfo::Action::MigrateSchema),
-                sync::ClientResetFailed);
-}
-
 TEST_TYPES(
     ClientReset_TrackReset,
     std::integral_constant<sync::ProtocolErrorInfo::Action, sync::ProtocolErrorInfo::Action::ClientReset>,


### PR DESCRIPTION
Client resets which did not recovery any changes (either because changes were discarded, there was nothing to recover, or the recovered changesets became empty after merging) don't need to wait for a server round-trip to mark the reset as complete, as that round-trip merely consisted of sending a MARK to the server and waiting for a response. This partially reverts #6196 and fixes that bug by immediately removing the client reset tracker as part of the diff commit if there was nothing recovered.

Performing a client reset involves waiting for download completion and bringing the Realm file into the state it would have been in if it had completed downloading, so it should fire download completion handlers. Previously we did everything we would do on download completion *except* for this. Since we performed a wait for download completion after applying a client reset diff the handlers would eventually get called, but the exact timing depended on server behavior which is changing in QBSv2 (and the wait for download completion is removed by the above change).