### PR TITLE
RCORE-2213 Add CI builder that runs tests with log level set to all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Sync client may report duplicate compensating write errors ([#7708](https://github.com/realm/realm-core/issues/7708), since v14.8.0).
+* String serialization of timestamps with a sufficiently large timestamp value could overflow an int causing undefined behavior, causing potentially bad values for the month/day/year values in stringified dates. ([PR #7934](https://github.com/realm/realm-core/pull/7934)).
 
 ### Breaking changes
 * None.

--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -297,23 +297,24 @@ functions:
           fi
 
           # NOTE: These two values will be ANDed together for matching tests
-          TEST_FLAGS=
+          TEST_FLAGS="--no-tests=error ${test_flags|} "
           if [[ -n "${test_label}" ]]; then
-              TEST_FLAGS="-L ${test_label} "
+              TEST_FLAGS+="-L ${test_label} "
           fi
           if [[ -n "${test_filter}" ]]; then
               TEST_FLAGS+="-R ${test_filter} "
           fi
 
           if [[ -n "${verbose_test_output}" ]]; then
-              TEST_FLAGS="$TEST_FLAGS -VV"
               export UNITTEST_THREADS=1
               export UNITTEST_LOG_LEVEL="${test_logging_level|debug}"
+              TEST_FLAGS+="-VV "
+              if [[ "$UNITTEST_LOG_LEVEL" = "all" ]]; then
+                TEST_FLAGS+="-O $(./evergreen/abspath.sh test_${task_id}.log) -Q "
+              fi
           else
-              TEST_FLAGS="$TEST_FLAGS -V"
+              TEST_FLAGS+="-V "
           fi
-
-          TEST_FLAGS="--no-tests=error $TEST_FLAGS ${test_flags|}"
 
           if [[ -n "${disable_tests_against_baas|}" ]]; then
               unset BAASAAS_API_KEY
@@ -323,9 +324,18 @@ functions:
 
           if [[ -n "${c_compiler}" && "$(basename ${c_compiler})" = "clang" && -f "$(dirname ${c_compiler})/llvm-symbolizer" ]]; then
               LLVM_SYMBOLIZER="$(dirname ${c_compiler})/llvm-symbolizer"
+              # we don't want to put all of the llvm bin-dir onto the path, so make a new directory, as-needed,
+              # and put a symlink to llvm-symbolizer in it. This is for ubsan, which doesn't have an
+              # environment variable to specify the path to the llvm-symbolizer.
+              if [[ ! ./llvm_symbolizer_bindir/llvm-symbolizer -ef "$LLVM_SYMBOLIZER" ]]; then
+                mkdir llvm_symbolizer_bindir
+                ln -s "$(./evergreen/abspath.sh $LLVM_SYMBOLIZER)" llvm_symbolizer_bindir/llvm-symbolizer
+              fi
+              export PATH="$(./evergreen/abspath.sh llvm_symbolizer_bindir)":$PATH
               export ASAN_SYMBOLIZER_PATH="$(./evergreen/abspath.sh $LLVM_SYMBOLIZER)"
               export TSAN_OPTIONS="external_symbolizer_path=$(./evergreen/abspath.sh $LLVM_SYMBOLIZER)"
           fi
+
           if [[ -n "${enable_llvm_coverage}" ]]; then
               if [[ -z "${test_executable_name}" ]]; then
                 echo "Missing executable name"
@@ -367,16 +377,12 @@ functions:
           fi
 
           cd build
-          if ! "$CTEST" -C ${cmake_build_type|Debug} $TEST_FLAGS; then
-            BAAS_PID=$(pgrep baas_server)
-            if [[ -n "$BAAS_PID" ]]; then
-              echo "Dumping baas to log file"
-              kill -3 $BAAS_PID
-              sleep 15
-            fi
-            exit 1
-          fi
+          "$CTEST" -C ${cmake_build_type|Debug} $TEST_FLAGS
 
+          if [[ -f ../test_${task_id}.log ]]; then
+            # If the test succeeded, then we don't need to save any trace level logs.
+            rm ../test_${task_id}.log
+          fi
   "upload test results":
   - command: attach.results
     params:
@@ -468,6 +474,17 @@ functions:
       permissions: public-read
       content_type: text/plain
       display_name: baas proxy logs
+      optional: true
+  - command: s3.put
+    params:
+      aws_key: '${artifacts_aws_access_key}'
+      aws_secret: '${artifacts_aws_secret_key}'
+      local_file: 'realm-core/test_${task_id}.log'
+      remote_file: 'realm-core-stable/${branch_name}/${task_id}/${execution}/test.log'
+      bucket: mciuploads
+      permissions: public-read
+      content_type: text/plain
+      display_name: trace level test logs
       optional: true
 
   "upload fuzzer results":
@@ -1962,6 +1979,21 @@ buildvariants:
   tasks:
   - name: compile_test_coverage
   - name: finalize_coverage_data
+
+- name: ubuntu-trace-logging
+  display_name: "Ubuntu (Trace Logging Enabled)"
+  run_on: ubuntu2204-arm64-large
+  allowed_requesters: [ "patch", "ad_hoc" ]
+  expansions:
+    fetch_missing_dependencies: On
+    cmake_build_type: Debug 
+    c_compiler: "/opt/clang+llvm/bin/clang"
+    cxx_compiler: "/opt/clang+llvm/bin/clang++"
+    test_logging_level: all
+    enable_ubsan: On
+    verbose_test_output: true
+  tasks:
+  - name: compile_test
 
 - name: ubuntu-no-app-services
   display_name: "Ubuntu (AppServices Disabled)"

--- a/src/realm/sync/noinst/protocol_codec.cpp
+++ b/src/realm/sync/noinst/protocol_codec.cpp
@@ -215,13 +215,16 @@ void ServerProtocol::insert_single_changeset_download_message(OutputBuffer& out,
     entry.changeset.write_to(out);
 
     if (logger.would_log(util::Logger::Level::trace)) {
+        util::AppendBuffer<char> changeset_buffer;
+        entry.changeset.copy_to(changeset_buffer);
+
         logger.trace(util::LogCategory::changeset,
                      "DOWNLOAD: insert single changeset (server_version=%1, "
                      "client_version=%2, timestamp=%3, client_file_ident=%4, "
                      "original_changeset_size=%5, changeset_size=%6, changeset='%7').",
                      changeset_info.server_version, changeset_info.client_version, entry.origin_timestamp,
                      entry.origin_file_ident, changeset_info.original_size, entry.changeset.size(),
-                     _impl::clamped_hex_dump(entry.changeset.get_first_chunk())); // Throws
+                     _impl::clamped_hex_dump(BinaryData(changeset_buffer.data(), changeset_buffer.size()))); // Throws
     }
 }
 

--- a/src/realm/util/serializer.cpp
+++ b/src/realm/util/serializer.cpp
@@ -43,18 +43,18 @@ static constexpr long date_to_julian(int y, int m, int d)
 
 static void julian_to_date(int jd, int* y, int* m, int* d)
 {
-    int L = jd + 68569;
-    int n = (4 * L) / 146097;
-    int i, j;
+    uint64_t L = jd + 68569;
+    uint64_t n = (4 * L) / 146097;
+    uint64_t i, j;
 
     L = L - (146097 * n + 3) / 4;
     i = (4000 * (L + 1)) / 1461001;
     L = L - (1461 * i) / 4 + 31;
     j = (80 * L) / 2447;
-    *d = L - (2447 * j) / 80;
+    *d = static_cast<int>(L - (2447 * j) / 80);
     L = j / 11;
-    *m = j + 2 - (12 * L);
-    *y = 100 * (n - 49) + i + L;
+    *m = static_cast<int>(j + 2 - (12 * L));
+    *y = static_cast<int>(100 * (n - 49) + i + L);
 }
 
 // Confirmed to work for all val < 16389

--- a/test/test_alloc.cpp
+++ b/test/test_alloc.cpp
@@ -242,7 +242,7 @@ TEST(Alloc_BadBuffer)
     GROUP_TEST_PATH(path);
 
     // Produce an invalid buffer
-    char buffer[32];
+    alignas(8) char buffer[32];
     for (size_t i = 0; i < sizeof buffer; ++i)
         buffer[i] = char((i + 192) % 128);
 


### PR DESCRIPTION
## What, How & Why?
This adds a builder that runs as part of the nightly build that runs our test suites with logging set to `all`. Because the log output can be 100s of MB per run, we only capture the logs if the tests fail, and we upload them directly to s3 rather than capturing them inline in the evergreen logs.

This also fixes some UBSAN failures and one bug that only manifested when trace level logging was enabled.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed
* [ ] `bindgen/spec.yml`, if public C++ API changed
