### PR TITLE
RCORE-1990 Get exact parity with Jenkins for UWP builders in evg

### DIFF
--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -2060,6 +2060,22 @@ buildvariants:
     cmake_bindir: "/cygdrive/c/Program Files/CMake/bin/"
     cmake_generator: "Visual Studio 16 2019"
     cmake_generator_platform: "Win32"
+    cmake_build_type: "Release"
+    extra_flags: -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0
+    max_jobs: $(($(grep -c proc /proc/cpuinfo) / 2))
+    fetch_missing_dependencies: On
+    python3: "/cygdrive/c/python/python37/python.exe"
+    no_tests: On
+  tasks:
+  - name: compile_only
+
+- name: windows-x64-uwp
+  display_name: "Windows X64 (UWP)"
+  run_on: windows-vsCurrent-large
+  expansions:
+    cmake_bindir: "/cygdrive/c/Program Files/CMake/bin/"
+    cmake_generator: "Visual Studio 16 2019"
+    extra_flags: "-A x64"
     cmake_build_type: "Debug"
     extra_flags: -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0
     max_jobs: $(($(grep -c proc /proc/cpuinfo) / 2))


### PR DESCRIPTION
## What, How & Why?
In Jenkins we actually had two UWP builders:
- Windows 64-bit UWP debug app build with Sync and encryption enabled
- Windows 32-bit UWP release app build with Sync and encryption enabled

This makes the evergreen config match that.

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed
* [ ] `bindgen/spec.yml`, if public C++ API changed
