### PR TITLE
RCORE-2187 Fix a test failure when the default log level is too low

### DIFF
--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -3305,6 +3305,7 @@ TEST_CASE("app: sync logs contain baas coid", "[sync][app][baas]") {
     };
 
     auto in_mem_logger = std::make_shared<InMemoryLogger>();
+    in_mem_logger->set_level_threshold(InMemoryLogger::Level::all);
     TestAppSession app_session(get_runtime_app_session(), nullptr, DeleteApp{false}, ReconnectMode::normal, nullptr,
                                in_mem_logger);
 


### PR DESCRIPTION
This test was relying on the default log level being high enough that the expected messages would actually be logged.