### PR TITLE
RCORE-2233 Reduce locking for StringInterner lookup and compare methods

### DIFF
--- a/src/realm/string_interner.hpp
+++ b/src/realm/string_interner.hpp
@@ -74,7 +74,7 @@ private:
     // when ever we meet a string too large to be placed inline.
     Array m_current_long_string_node;
     void rebuild_internal();
-    CompressedStringView& get_compressed(StringID id);
+    CompressedStringView& get_compressed(StringID id, bool lock_if_mutating = false);
     // return true if the leaf was reloaded
     bool load_leaf_if_needed(DataLeaf& leaf);
     // return 'true' if the new ref was different and forced a reload

--- a/src/realm/string_interner.hpp
+++ b/src/realm/string_interner.hpp
@@ -37,8 +37,19 @@ namespace realm {
 class StringCompressor;
 
 struct CachedString {
-    uint8_t m_weight = 0;
+    std::atomic<uint8_t> m_weight = 0;
     std::unique_ptr<std::string> m_decompressed;
+    CachedString() {}
+    CachedString(CachedString&& other)
+    {
+        m_decompressed = std::move(other.m_decompressed);
+        m_weight.store(other.m_weight.load(std::memory_order_relaxed), std::memory_order_relaxed);
+    }
+    CachedString(uint8_t init_weight, std::unique_ptr<std::string>&& ptr)
+    {
+        m_decompressed = std::move(ptr);
+        m_weight.store(init_weight, std::memory_order_relaxed);
+    }
 };
 
 class StringInterner {


### PR DESCRIPTION
## What, How & Why?

Reduce locking in the string interner:

* when using it for comparing strings or for mapping strings to StringIDs.
* when mapping StringIDs to strings.

Also entirely remove locking from methods where it isn't needed (less important since they are much less frequently used than the methods mentioned above).
