### PR TITLE
RCORE-2227 Updated non-streaming upload progress to report 1.0 if nothing to upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 * None.
 
 ### Breaking changes
-* None.
+* Non-streaming upload progress notifications will report an estimate of 1.0 instead of 0.0 if there is nothing to upload. [PR #7957](https://github.com/realm/realm-core/pull/7957)
 
 ### Compatibility
 * Fileformat: Generates files with format v24. Reads and automatically upgrade from fileformat v10. If you want to upgrade from an earlier file format version you will have to use RealmCore v13.x.y or earlier.

--- a/test/object-store/sync/session/progress_notifications.cpp
+++ b/test/object-store/sync/session/progress_notifications.cpp
@@ -162,7 +162,8 @@ TEST_CASE("progress notification", "[sync][session][progress]") {
 
     SECTION("callback is invoked immediately when a progress update has already occurred") {
         progress.set_local_version(1);
-        progress.update(0, 0, 0, 0, 1, 0.0, 0.0, 0);
+        // progress is reported as 1.0 for transferrable/transferred values of 0
+        progress.update(0, 0, 0, 0, 1, 1.0, 1.0, 0);
 
         bool callback_was_called = false;
         SECTION("for upload notifications, with no data transfer ongoing") {
@@ -174,7 +175,7 @@ TEST_CASE("progress notification", "[sync][session][progress]") {
                 },
                 NotifierType::upload, false, 0);
             REQUIRE(callback_was_called);
-            REQUIRE(estimate == 0.0);
+            REQUIRE(estimate == 1.0);
         }
 
         SECTION("for download notifications, with no data transfer ongoing") {
@@ -185,7 +186,7 @@ TEST_CASE("progress notification", "[sync][session][progress]") {
                     estimate = ep;
                 },
                 NotifierType::download, false, 0);
-            REQUIRE(estimate == 0.0);
+            REQUIRE(estimate == 1.0);
             REQUIRE(callback_was_called);
         }
 
@@ -206,7 +207,8 @@ TEST_CASE("progress notification", "[sync][session][progress]") {
     }
 
     SECTION("callback is invoked after each update for streaming notifiers") {
-        progress.update(0, 0, 0, 0, 1, 0.0, 0.0, 0);
+        // progress is reported as 1.0 for transferrable/transferred values of 0
+        progress.update(0, 0, 0, 0, 1, 1.0, 1.0, 0);
 
         bool callback_was_called = false;
         uint64_t transferred = 0;


### PR DESCRIPTION
## What, How & Why?
Currently, the non-streaming upload progress callback notifications would report an estimate of 0.0 and the notification callback was being expired if the uploadable and uploaded values were reported as zero. Since the notification estimate is being expired, it make better sense to report the estimate of 1.0, since that suggests that the notification request is complete.

These changes update the notification callback invocation routine to report an estimate of 1.0 if the uploaded and uploadable values are 0. The original tests that checked for 0.0 were updated.

In addition, some of the tests were `SyncProgressNotifier::update()` with an estimates of 0.0 when the uploadable/uploaded or  downloadable/downloaded values were zero. These calls were updated to provide an estimate of 1.0, since that mimics the actual behavior of the sync client progress reporting.

Fixes #7952

## ☑️ ToDos
* [x] 📝 Changelog update
* [X] 🚦 Tests (or not relevant)
* ~~[ ] C-API, if public C++ API changed~~
* ~~[ ] `bindgen/spec.yml`, if public C++ API changed~~
