### PR TITLE
RCORE-2219 Add test to verify upload progress notifications during client reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 -----------
 
 ### Internals
-* None.
+* Added test to verify upload progress notification reporting during a client reset. [PR #7958](https://github.com/realm/realm-core/pull/7958)
 
 ----------------------------------------------
 

--- a/test/object-store/sync/session/progress_notifications.cpp
+++ b/test/object-store/sync/session/progress_notifications.cpp
@@ -1615,6 +1615,7 @@ TEMPLATE_TEST_CASE("sync progress: upload progress during client reset", "[sync]
                 return "both local and remote changes";
         }
         FAIL(util::format("Missing case for unhandled TestMode value: ", static_cast<int>(tm)));
+        REALM_UNREACHABLE();
     };
 
     auto logger = util::Logger::get_default_logger();


### PR DESCRIPTION
## What, How & Why?
Added test to verify the streaming and non-streaming upload progress notifications when registered prior to a client reset. The upload notifications should not be reported until after the client reset diff is performed and should include reporting on the local changes that need to be uploaded after the client reset.

This test verifies the progress notifications for both PBS and FLX sync sessions for each of the following cases:
* No local or remote changes
* Local changes only
* Remote changes only
* Both local and remote changes

Fixes #7932 

## ☑️ ToDos
* [x] 📝 Changelog update
* [X] 🚦 Tests (or not relevant)
* ~~[ ] C-API, if public C++ API changed~~
* ~~[ ] `bindgen/spec.yml`, if public C++ API changed~~
