### PR TITLE
RCORE-2235 Upload progress notifications should not be reported after client reset if no local changes to upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 * Fixed bug which would prevent eventual consistency during conflict resolution. Affected clients would experience data divergence and potentially consistency errors as a result. ([PR #7955](https://github.com/realm/realm-core/pull/7955), since v14.8.0)
 
 ### Breaking changes
-* None.
+* Progress notifications that would previously report transferrable and transferred values of 0 are no longer being reported. ([PR #7971](https://github.com/realm/realm-core/pull/7971))
 
 ### Compatibility
 * Fileformat: Generates files with format v24. Reads and automatically upgrade from fileformat v10. If you want to upgrade from an earlier file format version you will have to use RealmCore v13.x.y or earlier.

--- a/src/realm/object-store/sync/sync_session.cpp
+++ b/src/realm/object-store/sync/sync_session.cpp
@@ -1585,9 +1585,15 @@ void SyncProgressNotifier::set_local_version(uint64_t snapshot_version)
 util::UniqueFunction<void()>
 SyncProgressNotifier::NotifierPackage::create_invocation(Progress const& current_progress, bool& is_expired)
 {
-    uint64_t transfered = is_download ? current_progress.downloaded : current_progress.uploaded;
+    uint64_t transferred = is_download ? current_progress.downloaded : current_progress.uploaded;
     uint64_t transferable = is_download ? current_progress.downloadable : current_progress.uploadable;
     double estimate = is_download ? current_progress.download_estimate : current_progress.upload_estimate;
+
+    // If this is an "empty" progress, then there is no need to notify the progress
+    // callback. Wait until there is something "real" to report.
+    if (transferable == 0 && transferred == 0) {
+        return [] {};
+    }
 
     if (!is_streaming) {
         // If the sync client has not yet processed all of the local
@@ -1617,16 +1623,16 @@ SyncProgressNotifier::NotifierPackage::create_invocation(Progress const& current
         // the total number of uploadable bytes available rather than the number of
         // bytes this NotifierPackage was waiting to upload.
         if (!is_download) {
-            estimate = transferable > 0 ? std::min(transfered / double(transferable), 1.0) : 0.0;
+            estimate = std::min(transferred / double(transferable), 1.0);
         }
     }
 
     // A notifier is expired if at least as many bytes have been transferred
     // as were originally considered transferrable.
     is_expired =
-        !is_streaming && (transfered >= transferable && (!is_download || !pending_query_version || estimate >= 1.0));
+        !is_streaming && (transferred >= transferable && (!is_download || !pending_query_version || estimate >= 1.0));
     return [=, notifier = notifier] {
-        notifier(transfered, transferable, estimate);
+        notifier(transferred, transferable, estimate);
     };
 }
 


### PR DESCRIPTION
## What, How & Why?
If an empty progress [uploadable: 0, uploaded: 0] or [downloadable: 0, downloaded: 0] is received by the `SyncProgressNotifier::update()` function then a progress notification will not be generated for that direction.

This also addresses the issue where an upload progress notification is reported after a client reset with recovery that did not generate any pending local changes or a discard local client reset.

Fixes #7970 

## ☑️ ToDos
* [x] 📝 Changelog update
* [X] 🚦 Tests (or not relevant)
* ~~[ ] C-API, if public C++ API changed~~
* ~~[ ] `bindgen/spec.yml`, if public C++ API changed~~
