### PR TITLE
Optimize size of Node and Array

### DIFF
--- a/src/realm/array.hpp
+++ b/src/realm/array.hpp
@@ -532,10 +532,10 @@ protected:
     Getter m_getter = nullptr; // cached to avoid indirection
     const VTable* m_vtable = nullptr;
 
-    uint_least8_t m_width = 0; // Size of an element (meaning depend on type of array).
     int64_t m_lbound;          // min number that can be stored with current m_width
     int64_t m_ubound;          // max number that can be stored with current m_width
 
+    uint8_t m_width = 0;         // Size of an element (meaning depend on type of array).
     bool m_is_inner_bptree_node; // This array is an inner node of B+-tree.
     bool m_has_refs;             // Elements whose first bit is zero are refs to subarrays.
     bool m_context_flag;         // Meaning depends on context.

--- a/src/realm/node.hpp
+++ b/src/realm/node.hpp
@@ -243,11 +243,7 @@ public:
     void set_parent(ArrayParent* parent, size_t ndx_in_parent) noexcept
     {
         m_parent = parent;
-        m_ndx_in_parent = ndx_in_parent;
-    }
-    void set_ndx_in_parent(size_t ndx) noexcept
-    {
-        m_ndx_in_parent = ndx;
+        m_ndx_in_parent = unsigned(ndx_in_parent);
     }
 
     void clear_missing_parent_update()
@@ -339,7 +335,7 @@ protected:
 private:
     friend class NodeTree;
     ArrayParent* m_parent = nullptr;
-    size_t m_ndx_in_parent = 0; // Ignored if m_parent is null.
+    unsigned m_ndx_in_parent = 0; // Ignored if m_parent is null.
     bool m_missing_parent_update = false;
 
     void do_copy_on_write(size_t minimum_size = 0);

--- a/src/realm/search_index.hpp
+++ b/src/realm/search_index.hpp
@@ -116,7 +116,6 @@ public:
     bool is_attached() const noexcept;
     void set_parent(ArrayParent* parent, size_t ndx_in_parent) noexcept;
     size_t get_ndx_in_parent() const noexcept;
-    void set_ndx_in_parent(size_t ndx_in_parent) noexcept;
     void update_from_parent() noexcept;
     void refresh_accessor_tree(const ClusterColumn& target_column);
     ref_type get_ref() const noexcept;
@@ -172,11 +171,6 @@ inline void SearchIndex::set_parent(ArrayParent* parent, size_t ndx_in_parent) n
 inline size_t SearchIndex::get_ndx_in_parent() const noexcept
 {
     return m_root_array->get_ndx_in_parent();
-}
-
-inline void SearchIndex::set_ndx_in_parent(size_t ndx_in_parent) noexcept
-{
-    m_root_array->set_ndx_in_parent(ndx_in_parent);
 }
 
 inline void SearchIndex::update_from_parent() noexcept

--- a/src/realm/spec.hpp
+++ b/src/realm/spec.hpp
@@ -81,7 +81,6 @@ public:
     void destroy() noexcept;
 
     size_t get_ndx_in_parent() const noexcept;
-    void set_ndx_in_parent(size_t) noexcept;
 
     void verify() const;
 
@@ -175,11 +174,6 @@ inline void Spec::destroy() noexcept
 inline size_t Spec::get_ndx_in_parent() const noexcept
 {
     return m_top.get_ndx_in_parent();
-}
-
-inline void Spec::set_ndx_in_parent(size_t ndx) noexcept
-{
-    m_top.set_ndx_in_parent(ndx);
 }
 
 inline ref_type Spec::get_ref() const noexcept

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -838,8 +838,6 @@ private:
 
     util::Logger* get_logger() const noexcept;
 
-    void set_ndx_in_parent(size_t ndx_in_parent) noexcept;
-
     /// Refresh the part of the accessor tree that is rooted at this
     /// table.
     void refresh_accessor_tree();
@@ -1338,12 +1336,6 @@ inline bool Table::operator!=(const Table& t) const
 inline bool Table::is_link_type(ColumnType col_type) noexcept
 {
     return col_type == col_type_Link;
-}
-
-inline void Table::set_ndx_in_parent(size_t ndx_in_parent) noexcept
-{
-    REALM_ASSERT(m_top.is_attached());
-    m_top.set_ndx_in_parent(ndx_in_parent);
 }
 
 inline size_t Table::colkey2spec_ndx(ColKey key) const


### PR DESCRIPTION
The size of Node and Array decresed from 64 and 128 to 56 and 112. Some redundant code removed in Spec class.

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- Link to relevant issue this fixes -->

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed
* [ ] `bindgen/spec.yml`, if public C++ API changed
