### PR TITLE
RCORE-2257 Remove unneeded evergreen tasks/build variants

### DIFF
--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -239,33 +239,6 @@ functions:
           make "-j$NPROC" 2>&1
           popd > /dev/null  # realm-core
 
-  "run benchmark":
-    - command: shell.exec
-      params:
-        working_dir: realm-core
-        shell: bash
-        script: |-
-          set -o errexit
-
-          if [[ -z "${benchmark_name}" ]]; then
-              echo "No benchmark specified."
-              exit 1
-          fi
-
-          export UNITTEST_THREADS=1
-
-          BENCHMARK=$(./evergreen/abspath.sh ./build/test/benchmark-${benchmark_name}/${cmake_build_type|Debug}/realm-benchmark-${benchmark_name})
-          echo "Going to run benchmark $BENCHMARK"
-
-          [[ -d benchmark_results ]] && rm -rf benchmark_results
-          mkdir benchmark_results
-          cd benchmark_results
-
-          $BENCHMARK "$(pwd)/"
-    - command: perf.send
-      params:
-        file: './realm-core/benchmark_results/results.latest.json'
-
   "run tests":
     - command: expansions.update
       params:
@@ -389,92 +362,6 @@ functions:
       file_location: realm-core/${task_name}_results.json
 
   "upload baas artifacts":
-  - command: shell.exec
-    params:
-      working_dir: realm-core
-      shell: bash
-      script: |-
-        set -o errexit
-        set -o pipefail
-        set -o verbose
-
-        if [[ -n "${disable_tests_against_baas|}" ]]; then
-          exit 0
-        fi
-
-        # Copy the baas_server log from the remote baas host if it exists
-        if [[ ! -f baas_host.yml || ! -f .baas_ssh_key ]]; then
-          echo "Skipping - no remote baas host or remote baas host definitions not found"
-          exit 0
-        fi
-
-        BAAS_HOST_NAME=$(tr -d '"[]{}' < baas_host.yml | cut -d , -f 1 | awk -F : '{print $2}')
-        export BAAS_HOST_NAME
-
-        ssh_user="$(printf "ubuntu@%s" "$BAAS_HOST_NAME")"
-        ssh_options="-o ForwardAgent=yes -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -o ConnectTimeout=60 -i .baas_ssh_key"
-
-        # Copy the baas_server.log, mongod.log and (optionally) baas_proxy.log files from the remote baas host
-        REMOTE_PATH=/data/baas-remote
-        REMOTE_BAAS_PATH="$REMOTE_PATH/baas-work-dir"
-        REMOTE_BAAS_DB_PATH="$REMOTE_BAAS_PATH/mongodb-dbpath"
-        REMOTE_PROXY_PATH="$REMOTE_PATH/baas-proxy-dir"
-
-        LOCAL_BAAS_PATH=./baas-work-dir
-        LOCAL_BAAS_DB_PATH="$LOCAL_BAAS_PATH/mongodb-dbpath"
-        LOCAL_PROXY_PATH=./baas-proxy-dir
-
-        mkdir -p "$LOCAL_BAAS_PATH/"
-        mkdir -p "$LOCAL_BAAS_DB_PATH/"
-        mkdir -p "$LOCAL_PROXY_PATH/"
-        scp $ssh_options $ssh_user:"$REMOTE_BAAS_PATH/baas_server.log" "$LOCAL_BAAS_PATH/baas_server.log" || true
-        scp $ssh_options $ssh_user:"$REMOTE_BAAS_DB_PATH/mongod.log" "$LOCAL_BAAS_DB_PATH/mongod.log" || true
-        scp $ssh_options $ssh_user:"$REMOTE_PROXY_PATH/baas_proxy.log" "$LOCAL_PROXY_PATH/baas_proxy.log" || true
-
-  - command: s3.put
-    params:
-      aws_key: '${artifacts_aws_access_key}'
-      aws_secret: '${artifacts_aws_secret_key}'
-      local_file: 'realm-core/baas-work-dir/baas_server.log'
-      remote_file: 'realm-core-stable/${branch_name}/${task_id}/${execution}/baas_server.log'
-      bucket: mciuploads
-      permissions: public-read
-      content_type: text/plain
-      display_name: baas server logs
-      optional: true
-  - command: s3.put
-    params:
-      aws_key: '${artifacts_aws_access_key}'
-      aws_secret: '${artifacts_aws_secret_key}'
-      local_file: 'realm-core/install_baas_output.log'
-      remote_file: 'realm-core-stable/${branch_name}/${task_id}/${execution}/install_baas_output.log'
-      bucket: mciuploads
-      permissions: public-read
-      content_type: text/plain
-      display_name: install baas output
-      optional: true
-  - command: s3.put
-    params:
-      aws_key: '${artifacts_aws_access_key}'
-      aws_secret: '${artifacts_aws_secret_key}'
-      local_file: 'realm-core/baas-work-dir/mongodb-dbpath/mongod.log'
-      remote_file: 'realm-core-stable/${branch_name}/${task_id}/${execution}/mongod.log'
-      bucket: mciuploads
-      permissions: public-read
-      content_type: text/plain
-      display_name: mongod logs
-      optional: true
-  - command: s3.put
-    params:
-      aws_key: '${artifacts_aws_access_key}'
-      aws_secret: '${artifacts_aws_secret_key}'
-      local_file: 'realm-core/baas-proxy-dir/baas_proxy.log'
-      remote_file: 'realm-core-stable/${branch_name}/${task_id}/${execution}/baas_proxy.log'
-      bucket: mciuploads
-      permissions: public-read
-      content_type: text/plain
-      display_name: baas proxy logs
-      optional: true
   - command: s3.put
     params:
       aws_key: '${artifacts_aws_access_key}'
@@ -486,53 +373,6 @@ functions:
       content_type: text/plain
       display_name: trace level test logs
       optional: true
-
-  "upload fuzzer results":
-  - command: shell.exec
-    params:
-      working_dir: realm-core/build/test/realm-fuzzer
-      script: |-
-        if ls crash-*> /dev/null 2>&1; then
-          echo "Found crash file"
-          #Rename the crash file and the realm file.
-          #If there is a crash, this will signal that something needs to be uploaded.
-          mv crash-* realm-fuzzer-crash.txt
-          mv fuzz-realm.realm fuzzer_realm.realm
-        fi
-
-  - command: s3.put
-    params:
-      working_dir: realm-core/build/test/realm-fuzzer
-      aws_key: '${artifacts_aws_access_key}'
-      aws_secret: '${artifacts_aws_secret_key}'
-      local_file: 'realm-core/build/test/realm-fuzzer/realm-fuzzer-crash.txt'
-      remote_file: '${project}/${branch_name}/${task_id}/${execution}/realm-fuzzer-crash.txt'
-      bucket: mciuploads
-      permissions: public-read
-      content_type: text/plain
-      display_name: Crash input file
-      optional: true
-
-  - command: s3.put
-    params:
-      working_dir: realm-core/build/test/realm-fuzzer
-      aws_key: '${artifacts_aws_access_key}'
-      aws_secret: '${artifacts_aws_secret_key}'
-      local_file: 'realm-core/build/test/realm-fuzzer/fuzzer_realm.realm'
-      remote_file: '${project}/${branch_name}/${task_id}/${execution}/fuzzer_realm.realm'
-      bucket: mciuploads
-      permissions: public-read
-      content_type: application/x-binary
-      display_name: Realm File
-      optional: true
-
-  - command: shell.exec
-    params:
-      working_dir: realm-core/build/test/realm-fuzzer
-      script: |-
-        #remove the crash file and the realm produced by the fuzzer run
-        rm realm-fuzzer-crash.txt
-        rm fuzzer_realm.realm
 
   "run hang analyzer":
   - command: shell.exec
@@ -627,149 +467,6 @@ functions:
         fi
 
         python $HANG_ANALYZER_PATH
-
-  "launch remote baas":
-  - command: host.create
-    params:
-      provider: ec2
-      distro: ubuntu2004-medium
-  - command: host.list
-    params:
-      num_hosts: 1
-      path: realm-core/baas_host.yml
-      timeout_seconds: 600
-      wait: true
-  - command: shell.exec
-    params:
-      working_dir: realm-core
-      shell: bash
-      # Do NOT use verbose for this script since it would reveal the values of secrets
-      script: |-
-        set -o errexit
-        set -o pipefail
-
-        if [[ -n "${disable_tests_against_baas|}" ]]; then
-          echo "Should not be using remote baas if the tests are not being used"
-          exit 0
-        fi
-
-        # Save the remote host ssh key and details to files
-        echo "${__project_aws_ssh_key_value}" > .baas_ssh_key
-        chmod 600 .baas_ssh_key
-
-        BAAS_HOST_NAME=$(tr -d '"[]{}' < baas_host.yml | cut -d , -f 1 | awk -F : '{print $2}')
-
-        # Github SSH host key updated 06/26/2023
-        # Use 'github_known_hosts' expansion for GITHUB_KNOWN_HOSTS below once EVG-20410 has been implemented
-        cat >baas_host_vars.sh <<EOF
-        export AWS_ACCESS_KEY_ID="${baas_secrets_aws_access_key}"
-        export AWS_SECRET_ACCESS_KEY="${baas_secrets_aws_secret_key}"
-        export BAAS_HOST_NAME="$BAAS_HOST_NAME"
-        export GITHUB_KNOWN_HOSTS="github.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SJMy/BCZfxd1nWzAOxSDPgVsmerOBYfNqltV9/hWCqBywINIR+5dIg6JTJ72pcEpEjcYgXkE2YEFXV1JHnsKgbLWNlhScqb2UmyRkQyytRLtL+38TGxkxCflmO+5Z8CSSNY7GidjMIZ7Q4zMjA2n1nGrlTDkzwDCsw+wqFPGQA179cnfGWOWRVruj16z6XyvxvjJwbz0wQZ75XK5tKSb7FNyeIEs4TT4jk+S4dhPeAUC5y+bDYirYgM4GC7uEnztnZyaVWQ7B381AK4Qdrwt51ZqExKbQpTUNn+EjqoTwvqNj4kqx5QUCI0ThS/YkOxJCXmPUWZbhjpCg56i+2aB6CmK2JGhn57K5mj0MNdBXA4/WnwH6XoPWJzK5Nyu2zB3nAZp+S5hpQs+p1vN1/wsjk="
-        EOF
-
-        chmod 700 baas_host_vars.sh
-        echo "baas remote host created: $BAAS_HOST_NAME"
-
-  - command: shell.exec
-    params:
-      working_dir: realm-core
-      shell: bash
-      background: true
-      script: |-
-        set -o errexit
-        set -o pipefail
-        set -o verbose
-
-        if [[ -n "${disable_tests_against_baas|}" ]]; then
-          exit 0
-        fi
-
-        BAAS_USER=ubuntu
-
-        OPT_BAAS_BRANCH=
-        OPT_BAAS_PROXY=
-        OPT_BAAS_DIRECT=
-
-        if [ -n "${baas_branch}" ]; then
-            OPT_BAAS_BRANCH="-b ${baas_branch}"
-        fi
-        if [ -n "${baas_proxy}" ]; then
-            OPT_BAAS_PROXY="-t"
-            if [ -n "${baas_admin_port}" ]; then
-                OPT_BAAS_DIRECT="-d ${baas_admin_port}"
-            fi
-        fi
-
-        # Run the setup_baas_host_local.sh script to configure and run baas on the remote host
-        # Add -v to this command for verbose script logging
-        ./evergreen/setup_baas_host_local.sh -w ./baas-work-dir -u $BAAS_USER $OPT_BAAS_BRANCH $OPT_BAAS_PROXY \
-            $OPT_BAAS_DIRECT -i ./.baas_ssh_key ./baas_host_vars.sh 2>&1 | tee install_baas_output.log
-
-  "wait for baas to start":
-  - command: shell.exec
-    params:
-      working_dir: realm-core
-      shell: bash
-      script: |-
-        set -o errexit
-        set -o verbose
-
-        if [[ -n "${disable_tests_against_baas|}" ]]; then
-          exit 0
-        fi
-
-        # Don't print out the tail of the log file
-        ./evergreen/wait_for_baas.sh -s -w ./baas-work-dir -l ""
-
-        echo "Baas is started!"
-
-  "wait for remote baas to start":
-  - command: shell.exec
-    params:
-      working_dir: realm-core
-      shell: bash
-      script: |-
-        set -o errexit
-        set -o verbose
-
-        if [[ -n "${disable_tests_against_baas|}" ]]; then
-          exit 0
-        fi
-
-        # Don't print out the tail of the log file
-        ./evergreen/wait_for_remote_baas.sh -i ./.baas_ssh_key ./baas_host_vars.sh  ./.baas_ssh_key
-
-        echo "Baas is started!"
-
-  "setup proxy parameters":
-  - command: shell.exec
-    params:
-      working_dir: realm-core
-      shell: bash
-      script: |-
-        set -o errexit
-        set -o pipefail
-        set -o verbose
-
-        if [[ -n "${disable_tests_against_baas|}" ]]; then
-          echo "Error: Baas is disabled for network tests"
-          exit 1
-        fi
-
-        if [[ -z "${proxy_toxics_file|}" ]]; then
-          echo "Error: Baas proxy toxics config file was not provided"
-          exit 1
-        fi
-
-        if [[ -n "${proxy_toxics_randoms|}" ]]; then
-          PROXY_RANDOMS="-r ${proxy_toxics_randoms}"
-        fi
-
-        # Configure the toxics for the baas proxy
-        evergreen/configure_baas_proxy.sh $PROXY_RANDOMS "${proxy_toxics_file}"
-        # Display the list of configured toxics
-        curl --silent http://localhost:8474/proxies/baas_proxy/toxics
 
   "check branch state":
   - command: shell.exec
@@ -953,30 +650,6 @@ tasks:
       test_filter: CoreTests
       test_executable_name: "realm-tests"
 
-- name: benchmark-common-tasks
-  exec_timeout_secs: 1800
-  tags: [ "benchmark" ]
-  commands:
-  - func: "run benchmark"
-    vars:
-      benchmark_name: common-tasks
-
-- name: benchmark-crud
-  exec_timeout_secs: 1800
-  tags: [ "benchmark" ]
-  commands:
-  - func: "run benchmark"
-    vars:
-      benchmark_name: crud
-
-- name: benchmark-sync
-  exec_timeout_secs: 1800
-  tags: [ "benchmark" ]
-  commands:
-  - func: "run benchmark"
-    vars:
-      benchmark_name: sync
-
 - name: sync-tests
   tags: [ "test_suite", "for_pull_requests" ]
   exec_timeout_secs: 1800
@@ -1013,31 +686,6 @@ tasks:
   - func: "compile"
     vars:
       target_to_build: ObjectStoreTests
-  - func: "run tests"
-    vars:
-      test_label: objstore-baas
-      test_executable_name: "realm-object-store-tests"
-      verbose_test_output: true
-  - func: "check branch state"
-
-- name: baas-network-tests
-  # Uncomment once tests are passing
-  tags: [ "disabled" ]
-  # tags: [ "for_nightly_tests" ]
-  # These tests can be manually requested for patches and pull requests
-  allowed_requesters: [ "ad_hoc", "patch", "github_pr" ]
-  # The network tests can take a really long time, so we give the test up to 4
-  # hours to complete
-  exec_timeout_secs: 14400
-  commands:
-  - func: "launch remote baas"
-    vars:
-      baas_proxy: On
-  - func: "compile"
-    vars:
-      target_to_build: ObjectStoreTests
-  - func: "wait for baas to start"
-  - func: "setup proxy parameters"
   - func: "run tests"
     vars:
       test_label: objstore-baas
@@ -1190,16 +838,6 @@ tasks:
         echo "COMMAND: git clang-format -f --commit $format_ref"
         exit 1
 
-- name: fuzzer
-  tags: [ "for_nightly_tests" ]
-  allowed_requesters: [ "ad_hoc", "patch" ]
-  commands:
-  - command: shell.exec
-    params:
-      working_dir: realm-core/build/test/realm-fuzzer
-      shell: /bin/bash
-      script: |-
-        ${cmake_build_type|Debug}/realm-libfuzz -rss_limit_mb=0 -max_total_time=3600
 
 - name: combined-tests-ios-simulator
   tags: [ "for_pull_requests" ]
@@ -1236,56 +874,6 @@ tasks:
             ./build/test/${cmake_build_type|Debug}-iphonesimulator/realm-combined-tests.app \
             'io.realm.CombinedTests' \
             $TEST_RESULTS_FILE
-
-- name: generate-sync-corpus
-  tags: [ "for_nightly_tests" ]
-  exec_timeout_secs: 1800
-  commands:
-  - func: "fetch source"
-  - func: "fetch binaries"
-  - func: "compile"
-    vars:
-      target_to_build: "SyncTests"
-  - command: shell.exec
-    params:
-      working_dir: realm-core
-      shell: bash
-      script: |-
-          set -o errexit
-          set -o verbose
-
-          if [[ -n "${c_compiler}" && "$(basename ${c_compiler})" = "clang" && -f "$(dirname ${c_compiler})/llvm-symbolizer" ]]; then
-              LLVM_SYMBOLIZER="$(dirname ${c_compiler})/llvm-symbolizer"
-              export ASAN_SYMBOLIZER_PATH="$(./evergreen/abspath.sh $LLVM_SYMBOLIZER)"
-              export TSAN_OPTIONS="external_symbolizer_path=$(./evergreen/abspath.sh $LLVM_SYMBOLIZER)"
-          fi
-
-          export UNITTEST_EVERGREEN_TEST_RESULTS="$(./evergreen/abspath.sh ${task_name}_results.json)"
-          if [[ -n "$UNITTEST_EVERGREEN_TEST_RESULTS" && -f "$UNITTEST_EVERGREEN_TEST_RESULTS" ]]; then
-              rm "$UNITTEST_EVERGREEN_TEST_RESULTS"
-          fi
-          export UNITTEST_PROGRESS=1
-          export UNITTEST_FILTER="Array_Example Transform_* EmbeddedObjects_*"
-          export UNITTEST_DUMP_TRANSFORM="changeset_dump"
-
-          export TSAN_OPTIONS="suppressions=$(pwd)/test/tsan.suppress history_size=4 $TSAN_OPTIONS"
-          export UBSAN_OPTIONS="print_stacktrace=1"
-
-          ./build/test/${cmake_build_type}/realm-sync-tests
-
-          CHANGESET_DUMP_DIR="$(find . -type d -name changeset_dump -print -quit)"
-          mv "$CHANGESET_DUMP_DIR" changeset_dump
-          tar -czvf changeset_dump.tgz changeset_dump
-  - command: s3.put
-    params:
-      aws_key: '${artifacts_aws_access_key}'
-      aws_secret: '${artifacts_aws_secret_key}'
-      local_file: 'realm-core/changeset_dump.tgz'
-      remote_file: 'realm-core-stable/${branch_name}/${task_id}/${execution}/changeset_dump.tgz'
-      bucket: mciuploads
-      permissions: public-read
-      content_type: application/gzip
-      display_name: changeset dump tarball
 
 task_groups:
 - name: core_tests_group
@@ -1371,21 +959,6 @@ task_groups:
   tasks:
   - compile-emscripten
 
-# Runs object-store-tests against baas running on remote host and runs
-# the network simulation tests as a separate task for nightly builds
-- name: network_tests
-  max_hosts: 1
-  setup_group_can_fail_task: true
-  setup_group:
-  - func: "fetch source"
-  - func: "fetch binaries"
-  teardown_task:
-  - func: "upload test results"
-  - func: "upload baas artifacts"
-  timeout:
-  - func: "run hang analyzer"
-  tasks:
-  - baas-network-tests
 
 # Runs object-store-tests against baas running on remote host
 - name: compile_test_coverage
@@ -1404,18 +977,6 @@ task_groups:
   - .test_suite
   - process_coverage_data
 
-- name: benchmarks
-  setup_group_can_fail_task: true
-  setup_group:
-  - func: "fetch source"
-  - func: "fetch binaries"
-  - func: "compile"
-    vars:
-      target_to_build: "benchmarks"
-  timeout:
-  - func: "run hang analyzer"
-  tasks:
-  - .benchmark
 
 - name: long-running-tests
   setup_group_can_fail_task: true
@@ -1433,18 +994,6 @@ task_groups:
   tasks:
   - long-running-core-tests
 
-- name: fuzzer-tests
-  setup_group_can_fail_task: true
-  setup_group:
-  - func: "fetch source"
-  - func: "fetch binaries"
-  - func: "compile"
-    vars:
-      target_to_build: realm-libfuzz
-  teardown_task:
-  - func: "upload fuzzer results"
-  tasks:
-  - fuzzer
 
 - name: ios-simulator-tests
   max_hosts: 1
@@ -1592,11 +1141,8 @@ buildvariants:
   tasks:
   - name: core_tests_group
 
-# TODO RCORE-2085 ubuntu2004-release/ubuntu2004-arm64 build variants are here until we've established
-# a new baseline for the updated ubuntu 2204/clang 18 builders and to generate artifacts for the baas
-# team.
 - name: ubuntu2004-release
-  display_name: "Ubuntu 20.04 x86_64 (Clang 11 release benchmarks/baas artifacts)"
+  display_name: "Ubuntu 20.04 x86_64 (Clang 11 release baas artifacts)"
   run_on: ubuntu2004-large
   expansions:
     clang_url: "https://s3.amazonaws.com/static.realm.io/evergreen-assets/clang%2Bllvm-11.0.0-x86_64-linux-gnu-ubuntu-20.04.tar.xz"
@@ -1610,36 +1156,6 @@ buildvariants:
     python3: /opt/mongodbtoolchain/v3/bin/python3
   tasks:
   - name: compile_test_and_package
-  - name: benchmarks
-  - name: generate-sync-corpus
-
-- name: ubuntu2004-arm64
-  display_name: "Ubuntu 20.04 ARM64 (GCC 9 release benchmarks)"
-  run_on: ubuntu2004-arm64-large
-  expansions:
-    cmake_url: "https://s3.amazonaws.com/static.realm.io/evergreen-assets/cmake-3.26.3-linux-aarch64.tar.gz"
-    cmake_bindir: "./cmake_binaries/bin"
-    python3: "/opt/mongodbtoolchain/v3/bin/python3"
-    use_system_openssl: On
-    fetch_missing_dependencies: On
-    cmake_build_type: RelWithDebInfo
-  tasks:
-  - name: benchmarks
-
-- name: ubuntu-x86_64-benchmarks
-  display_name: "Ubuntu x86_64 benchmarks"
-  run_on: ubuntu2204-large
-  expansions:
-    fetch_missing_dependencies: On
-    cmake_url: "https://s3.amazonaws.com/static.realm.io/evergreen-assets/cmake-3.26.3-linux-x86_64.tar.gz"
-    cmake_bindir: "./cmake_binaries/bin"
-    clang_url: "https://s3.amazonaws.com/static.realm.io/evergreen-assets/clang%2Bllvm-18.1.2-x86_64-linux-gnu.tar.xz"
-    clang_sha256_sum: "feab4b0f5fba325bfe0f4245710fd19fd74f813f44b5e81eda794f4f75bca343"
-    c_compiler: "./clang_binaries/bin/clang"
-    cxx_compiler: "./clang_binaries/bin/clang++"
-    cmake_build_type: RelWithDebInfo
-  tasks:
-  - name: benchmarks
 
 - name: ubuntu-release
   display_name: "Ubuntu (Release build)"
@@ -1652,7 +1168,6 @@ buildvariants:
     python3: /opt/mongodbtoolchain/v3/bin/python3
   tasks:
   - name: compile_test_and_package
-  - name: benchmarks
   - name: long-running-tests
 
 - name: ubuntu-asan
@@ -1708,20 +1223,6 @@ buildvariants:
   tasks:
   - name: compile_test
 
-- name: ubuntu-fuzzer
-  display_name: "Ubuntu (Fuzzer)"
-  run_on: ubuntu2204-arm64-large
-  expansions:
-    fetch_missing_dependencies: On
-    enable_ubsan: On
-    c_compiler: "/opt/clang+llvm/bin/clang"
-    cxx_compiler: "/opt/clang+llvm/bin/clang++"
-    cmake_build_type: RelWithDebInfo
-    run_with_encryption: 1
-    enable_fuzzer: On
-  tasks:
-  - name: fuzzer-tests
-
 - name: ubuntu-emscripten
   display_name: "Ubuntu (Emscripten x86_64)"
   run_on: ubuntu2204-large
@@ -1742,52 +1243,6 @@ buildvariants:
     emsdk_version: "3.1.37"
   tasks:
   - name: compile_emscripten
-
-# disable these builders since there are constantly failing and not yet ready for nightly builds
-# - name: ubuntu2004-network-nonideal
-#   display_name: "Ubuntu 20.04 x86_64 (Utunbu2004 - nonideal transfer)"
-#   run_on: ubuntu2004-large
-#   expansions:
-#     clang_url: "https://s3.amazonaws.com/static.realm.io/evergreen-assets/clang%2Bllvm-11.0.0-x86_64-linux-gnu-ubuntu-20.04.tar.xz"
-#     cmake_url: "https://s3.amazonaws.com/static.realm.io/evergreen-assets/cmake-3.26.3-linux-x86_64.tar.gz"
-#     cmake_bindir: "./cmake_binaries/bin"
-#     fetch_missing_dependencies: On
-#     c_compiler: "./clang_binaries/bin/clang"
-#     cxx_compiler: "./clang_binaries/bin/clang++"
-#     cmake_build_type: RelWithDebInfo
-#     run_with_encryption: On
-#     baas_admin_port: 9098
-#     test_logging_level: debug
-#     test_timeout_extra: 60
-#     proxy_toxics_file: evergreen/proxy-nonideal-transfer.toxics
-#     # RANDOM1: bandwidth-upstream limited to between 10-50 KB/s from the client to the server
-#     # RANDOM2: bandwidth-downstream limited to between 10-50 KB/s from the server to the client
-#     proxy_toxics_randoms: "10:50|10:50"
-#   tasks:
-#   - name: network_tests
-#
-# - name: ubuntu2004-network-faulty
-#   display_name: "Ubuntu 20.04 x86_64 (Utunbu2004 - network faults)"
-#   run_on: ubuntu2004-large
-#   expansions:
-#     clang_url: "https://s3.amazonaws.com/static.realm.io/evergreen-assets/clang%2Bllvm-11.0.0-x86_64-linux-gnu-ubuntu-20.04.tar.xz"
-#     cmake_url: "https://s3.amazonaws.com/static.realm.io/evergreen-assets/cmake-3.26.3-linux-x86_64.tar.gz"
-#     cmake_bindir: "./cmake_binaries/bin"
-#     fetch_missing_dependencies: On
-#     c_compiler: "./clang_binaries/bin/clang"
-#     cxx_compiler: "./clang_binaries/bin/clang++"
-#     cmake_build_type: RelWithDebInfo
-#     run_with_encryption: On
-#     baas_admin_port: 9098
-#     test_logging_level: debug
-#     proxy_toxics_file: evergreen/proxy-network-faults.toxics
-#     # RANDOM1: limit-data-upstream to close connection after between 1000-3000 bytes have been sent
-#     # RANDOM2: limit-data-downstream to close connection after between 1000-3000 bytes have been received
-#     # RANDOM3: slow-close-upstream to keep connection to server open after 1000-1500 milliseconds after being closed
-#     # RANDOM4: reset-peer-upstream after 50-200 seconds to force close the connection to the server
-#     proxy_toxics_randoms: "1000:3000|1000:3000|1000:1500|50:200"
-#   tasks:
-#   - name: network_tests
 
 - name: ubuntu-valgrind
   display_name: "Ubuntu 22.04 x86_64 (Valgrind)"
@@ -1848,34 +1303,18 @@ buildvariants:
   - name: core_tests_group
 
 - name: macos-release
-  display_name: "MacOS 11.0 x86_64 (Release build)"
-  run_on: macos-1100
+  display_name: "MacOS 13.0 arm64 (Release build)"
+  run_on: macos-13-arm64
   expansions:
     cmake_url: "https://s3.amazonaws.com/static.realm.io/evergreen-assets/cmake-3.26.3-macos-universal.tar.gz"
     cmake_bindir: "./cmake_binaries/CMake.app/Contents/bin"
     cmake_generator: Xcode
     max_jobs: $(sysctl -n hw.logicalcpu)
     cmake_build_type: Release
-    xcode_developer_dir: /Applications/Xcode13.1.app/Contents/Developer
+    xcode_developer_dir: /Applications/Xcode.app/Contents/Developer
     extra_flags: -DREALM_ENABLE_ASSERTIONS=ON
   tasks:
-  - name: benchmarks
-  - name: compile_test
   - name: test-on-exfat
-
-- name: macos-1100-arm64-release
-  display_name: "MacOS 11 arm64 (Release benchmarks)"
-  run_on: macos-1100-arm64
-  expansions:
-    cmake_url: "https://s3.amazonaws.com/static.realm.io/evergreen-assets/cmake-3.26.3-macos-universal.tar.gz"
-    cmake_bindir: "./cmake_binaries/CMake.app/Contents/bin"
-    cmake_generator: Xcode
-    max_jobs: $(sysctl -n hw.logicalcpu)
-    cmake_build_type: Release
-    xcode_developer_dir: /Applications/Xcode13.1.app/Contents/Developer
-    extra_flags: -DREALM_ENABLE_ASSERTIONS=ON
-  tasks:
-  - name: benchmarks
 
 - name: macos
   display_name: "MacOS 14 arm64"
@@ -1907,8 +1346,6 @@ buildvariants:
     extra_flags: -DCMAKE_SYSTEM_NAME=Darwin -DCMAKE_OSX_ARCHITECTURES=arm64
   tasks:
   - name: compile_test_and_package
-  # benchmarks are disabled for now because of perf problems on AWS macos instances.
-  # - name: benchmarks
   - name: long-running-tests
   - name: swift-build-and-test
 
@@ -2107,9 +1544,8 @@ buildvariants:
   expansions:
     cmake_bindir: "/cygdrive/c/Program Files/CMake/bin/"
     cmake_generator: "Visual Studio 16 2019"
-    extra_flags: "-A x64"
     cmake_build_type: "Debug"
-    extra_flags: -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0
+    extra_flags: -A x64 -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0
     max_jobs: $(($(grep -c proc /proc/cpuinfo) / 2))
     fetch_missing_dependencies: On
     python3: "/cygdrive/c/python/python37/python.exe"


### PR DESCRIPTION
## What, How & Why?
Removes a bunch of evergreen tasks that are no longer relevant after the deprecation.

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed
* [ ] `bindgen/spec.yml`, if public C++ API changed
