### PR TITLE
RCORE:2259: Fix comparison function for ConditionType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * None.
 
 ### Fixed
-* <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
+* Having a query with a number of predicates ORed together may result in a crash on some platforms (strict weak ordering check failing on iphone) ([#8028](https://github.com/realm/realm-core/issues/8028), since v14.6.0)
 * None.
 
 ### Breaking changes

--- a/src/realm/query_engine.hpp
+++ b/src/realm/query_engine.hpp
@@ -2268,7 +2268,7 @@ private:
         std::type_index m_type;
         bool operator<(const ConditionType& other) const
         {
-            return this->m_col < other.m_col && this->m_type < other.m_type;
+            return (this->m_col == other.m_col) ? this->m_type < other.m_type : this->m_col < other.m_col;
         }
         bool operator!=(const ConditionType& other) const
         {


### PR DESCRIPTION
The function should ensure strict weak ordering. According to the current one
 {1, 0} == {0, 1} and {0, 1} == {2, 1}
but
 {1, 0} < {2, 1}

It is not possible to construct a failing test as the outcome very much depends on how the runtime types are laid out.

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- Link to relevant issue this fixes -->
Fixes #8028 

## ☑️ ToDos
* [x] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [x] C-API, if public C++ API changed
* [x] `bindgen/spec.yml`, if public C++ API changed
