### PR TITLE
RCORE-2264: Skip backup files when scanning for audit Realms to upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* The events library would attempt to upload backup files created as part of file format upgrades, causing backup copies of those backups to be made, looping until the maximum file name size was reached (since v11.17.0).
+* The events library would attempt to upload backup files created as part of file format upgrades, causing backup copies of those backups to be made, looping until the maximum file name size was reached ([#8040](https://github.com/realm/realm-core/issues/8040), since v11.17.0).
 
 ### Breaking changes
 * None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* The events library would attempt to upload backup files created as part of file format upgrades, causing backup copies of those backups to be made, looping until the maximum file name size was reached (since v11.17.0).
 
 ### Breaking changes
 * None.

--- a/src/realm/backup_restore.cpp
+++ b/src/realm/backup_restore.cpp
@@ -80,6 +80,11 @@ BackupHandler::BackupHandler(const std::string& path, const VersionList& accepte
     m_delete_versions = to_be_deleted;
 }
 
+std::string BackupHandler::get_prefix() const
+{
+    return m_prefix;
+}
+
 bool BackupHandler::must_restore_from_backup(int current_file_format_version) const
 {
     if (current_file_format_version == 0)

--- a/src/realm/backup_restore.hpp
+++ b/src/realm/backup_restore.hpp
@@ -34,7 +34,7 @@ public:
     void restore_from_backup();
     void cleanup_backups();
     void backup_realm_if_needed(int current_file_format_version, int target_file_format_version);
-    std::string get_prefix();
+    std::string get_prefix() const;
 
     static std::string get_prefix_from_path(const std::string& path);
     // default lists of accepted versions and backups to delete when they get old enough


### PR DESCRIPTION
Backup realms from file format upgrades are placed next to the original file, so the audit realm pool will find the backup and attempt to upload it, triggering another upgrade and backup until the filename becomes too long and it crashes instead. It needs to instead skip the backup files and delete any lingering backups of Realms which have already been uploaded.

Fixes #8040 