### PR TITLE
Switch to run against stable baasaas branch

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -2,7 +2,6 @@ PACKAGE_NAME: realm-core
 VERSION: 14.13.0
 OPENSSL_VERSION: 3.3.1
 ZLIB_VERSION: 1.2.13
-# https://github.com/10gen/baas/commits
-# 04e3f27ad0e is 2024 Sep 8th
-BAAS_VERSION: 04e3f27ad0eb9154bc4e3b631d179d702ac05215
-BAAS_VERSION_TYPE: githash
+# Set to track a release branch on 10/9/24.
+BAAS_VERSION: v20241002
+BAAS_VERSION_TYPE: branch


### PR DESCRIPTION
## What, How & Why?
This switches baasaas to test against a stable branch of baas rather than a pinned githash.

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed
* [ ] `bindgen/spec.yml`, if public C++ API changed
