### PR TITLE
Do not set primary key column before migration function is called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,7 @@
 * None.
 
 ### Fixed
-* <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Changing type of primary key column crashes if more than one object ([#8056](https://github.com/realm/realm-core/issues/8056), since v14.13.2)
 
 ### Breaking changes
 * None.
@@ -28,7 +27,6 @@
 
 ### Fixed
 * Migrating primary key to a new type without migration function would cause an assertion to fail. ([#8045](https://github.com/realm/realm-core/issues/8045), since v10.0.0)
-* None.
 
 ### Breaking changes
 * None.

--- a/src/realm/object-store/object_store.cpp
+++ b/src/realm/object-store/object_store.cpp
@@ -140,9 +140,7 @@ ColKey add_column(Group& group, Table& table, Property const& property)
     else {
         auto key =
             table.add_column(to_core_type(property.type), property.name, is_nullable(property.type), collection_type);
-        if (property.is_primary)
-            table.set_primary_key_column(key); // You can end here if this is a migration
-        else if (property.requires_index())
+        if (property.requires_index())
             table.add_search_index(key);
         else if (property.requires_fulltext_index())
             table.add_fulltext_index(key);
@@ -833,7 +831,12 @@ static void apply_post_migration_changes(Group& group, std::vector<SchemaChange>
                                             handle_backlinks_automatically);
         }
         void operator()(RemoveTable) {}
-        void operator()(ChangePropertyType) {}
+        void operator()(ChangePropertyType op)
+        {
+            if (op.new_property->is_primary) {
+                set_primary_key(table(op.object), op.new_property);
+            }
+        }
         void operator()(MakePropertyNullable) {}
         void operator()(MakePropertyRequired) {}
         void operator()(AddProperty) {}


### PR DESCRIPTION
This is fixing a regression introduced by f7c8e97. The change done in this commit is reverted. Instead the primary key column is set in the post migration changes.

## What, How & Why?
Fixes #8056 

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [x] C-API, if public C++ API changed
* [x] `bindgen/spec.yml`, if public C++ API changed
