### PR TITLE
Sync access token refreshes shouldn't extend SyncSession lifetime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,7 @@
 * None.
 
 ### Fixed
-* <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* If you open a synchronized realm and it needs to refresh its access token, and that refresh operation doesn't complete before the realm is closed, the lifetime of the sync session will be extended until the refresh is complete. If you open the realm again before that refresh is complete, then you'll have two sync sessions both try to start synchronizing the realm when the refreshes do complete, and that will crash the process with a MultipleSyncAgents exception. ([PR #8064](https://github.com/realm/realm-core/pull/8064))
 
 ### Breaking changes
 * None.

--- a/src/realm/object-store/sync/sync_session.cpp
+++ b/src/realm/object-store/sync/sync_session.cpp
@@ -291,7 +291,13 @@ static bool check_for_redirect_response(const app::AppError& error)
 util::UniqueFunction<void(std::optional<app::AppError>)>
 SyncSession::handle_refresh(const std::shared_ptr<SyncSession>& session, bool restart_session)
 {
-    return [session, restart_session](std::optional<app::AppError> error) {
+    auto weak_session = session->weak_from_this();
+    return [weak_session, restart_session](std::optional<app::AppError> error) {
+        auto session = weak_session.lock();
+        if (!session) {
+            return;
+        }
+
         auto session_user = session->user();
         if (!session_user) {
             util::CheckedUniqueLock lock(session->m_state_mutex);

--- a/src/realm/object-store/sync/sync_session.hpp
+++ b/src/realm/object-store/sync/sync_session.hpp
@@ -340,6 +340,11 @@ public:
             return session.m_db;
         }
 
+        static std::weak_ptr<SyncSession> weak_from_session(const std::shared_ptr<SyncSession>& sess)
+        {
+            return sess->weak_from_this();
+        }
+
         static std::string get_appservices_connection_id(SyncSession& session)
         {
             return session.get_appservices_connection_id();

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -3300,6 +3300,7 @@ TEST_CASE("app: sync session refreshes end with sync session lifetime", "[sync][
 
     REQUIRE(user);
     sync::AccessToken token = [&] {
+        sync::AccessToken token;
         sync::AccessToken::ParseError error_state = sync::AccessToken::ParseError::none;
         REQUIRE(sync::AccessToken::parse(user->access_token(), token, error_state, nullptr));
         auto now = std::chrono::system_clock::now();

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -3248,6 +3248,90 @@ TEST_CASE("app: sync integration", "[sync][pbs][app][baas]") {
     }
 }
 
+class BlockingTransport : public SynchronousTestTransport {
+public:
+    void send_request_to_server(const app::Request& request,
+                                util::UniqueFunction<void(const app::Response&)>&& completion) override
+    {
+        if (is_blocking) {
+            pending_requests.push_back(std::make_pair(request, std::move(completion)));
+            return;
+        }
+        SynchronousTestTransport::send_request_to_server(request, [&](app::Response response) mutable {
+            completion(response);
+        });
+    }
+
+    void unblock()
+    {
+        is_blocking = false;
+        while (!pending_requests.empty()) {
+            auto& pending = pending_requests.front();
+            SynchronousTestTransport::send_request_to_server(pending.first, [&](app::Response response) mutable {
+                pending.second(response);
+            });
+            pending_requests.pop_front();
+        }
+    }
+
+    bool is_blocking = false;
+    std::deque<std::pair<app::Request, util::UniqueFunction<void(const app::Response&)>>> pending_requests;
+};
+
+TEST_CASE("app: sync session refreshes end with sync session lifetime", "[sync][app][baas]") {
+    const Schema schema{ObjectSchema{
+        "user",
+        {{"_id", PropertyType::ObjectId | PropertyType::Nullable, Property::IsPrimary{true}}},
+    }};
+    auto app_session_config = minimal_app_config("HELP-67254", schema);
+    auto app_session = create_app(app_session_config);
+
+    auto transport = std::make_shared<BlockingTransport>();
+    TestAppSession session(app_session, {transport});
+
+    const auto partition = random_string(100);
+    auto app = session.app();
+    create_user_and_log_in(app);
+    auto user = app->current_user();
+
+    SyncTestFile config(app->current_user(), partition, schema);
+    successfully_async_open_realm(config);
+    app->sync_manager()->wait_for_sessions_to_terminate();
+
+    REQUIRE(user);
+    sync::AccessToken token = [&] {
+        sync::AccessToken::ParseError error_state = sync::AccessToken::ParseError::none;
+        REQUIRE(sync::AccessToken::parse(user->access_token(), token, error_state, nullptr));
+        auto now = std::chrono::system_clock::now();
+        token.expires = std::chrono::system_clock::to_time_t(now - 30s);
+        REQUIRE(token.expired(now));
+        return token;
+    }();
+
+    REQUIRE(!user->access_token_refresh_required());
+    transport->is_blocking = true;
+    // Set a bad access token, with an expired time. This will trigger a refresh initiated by the client.
+    user->update_data_for_testing([&token](UserData& data) {
+        data.access_token = RealmJWT(encode_fake_jwt("fake_access_token", token.expires, token.timestamp));
+    });
+    REQUIRE(user->access_token_refresh_required());
+
+    auto weak_session = [&] {
+        auto realm = Realm::get_shared_realm(config);
+        auto weak_session = SyncSession::OnlyForTesting::weak_from_session(realm->sync_session());
+        REQUIRE(!weak_session.expired());
+        return weak_session;
+    }();
+    REQUIRE(transport->pending_requests.size() == 1);
+    REQUIRE(weak_session.expired());
+
+    auto realm = Realm::get_shared_realm(config);
+    REQUIRE(transport->pending_requests.size() > 1);
+
+    transport->unblock();
+    wait_for_download(*realm);
+}
+
 TEST_CASE("app: sync logs contain baas coid", "[sync][app][baas]") {
     class InMemoryLogger : public util::Logger {
     public:


### PR DESCRIPTION
## What, How & Why?
This fixes an issue discovered in a HELP ticket. If you open a synchronized realm and it needs to refresh its access token, and that refresh operation doesn't complete before the realm is closed, the lifetime of the sync session will be extended until the refresh is complete. If you open the realm again before that refresh is complete, then you'll have two sync sessions both try to start synchronizing the realm when the refreshes do complete, and that will crash the process with a MultipleSyncAgents exception.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed
* [ ] `bindgen/spec.yml`, if public C++ API changed
