### PR TITLE
Reuse transaction when refreshing subscriptions after commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,7 @@
 * None.
 
 ### Fixed
-* <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Committing a subscription set prematurely released a read lock, which may have caused a BadVersion exception with an error like `Unable to lock version XX as it does not exist or has been cleaned up` while changing subscriptions. ([PR #8086](https://github.com/realm/realm-core/pull/8068), since v14.12.0)
 
 ### Breaking changes
 * None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * None.
 
 ### Fixed
-* Committing a subscription set prematurely released a read lock, which may have caused a BadVersion exception with an error like `Unable to lock version XX as it does not exist or has been cleaned up` while changing subscriptions. ([PR #8086](https://github.com/realm/realm-core/pull/8068), since v14.12.0)
+* Committing a subscription set prematurely released a read lock, which may have caused a BadVersion exception with an error like `Unable to lock version XX as it does not exist or has been cleaned up` while changing subscriptions. ([PR #8068](https://github.com/realm/realm-core/pull/8068), since v14.12.0)
 
 ### Breaking changes
 * None.

--- a/src/realm/sync/subscriptions.hpp
+++ b/src/realm/sync/subscriptions.hpp
@@ -420,7 +420,7 @@ private:
     };
 
     Obj get_active(const Transaction& tr);
-    SubscriptionSet get_refreshed(ObjKey, int64_t flx_version, std::optional<TransactionRef> tr = util::none);
+    SubscriptionSet get_refreshed(ObjKey, int64_t flx_version, TransactionRef tr);
     MutableSubscriptionSet make_mutable_copy(const SubscriptionSet& set);
 
     // Ensure the subscriptions table is properly initialized. No-op if already initialized.

--- a/src/realm/sync/subscriptions.hpp
+++ b/src/realm/sync/subscriptions.hpp
@@ -420,7 +420,7 @@ private:
     };
 
     Obj get_active(const Transaction& tr);
-    SubscriptionSet get_refreshed(ObjKey, int64_t flx_version, std::optional<DB::VersionID> version = util::none);
+    SubscriptionSet get_refreshed(ObjKey, int64_t flx_version, std::optional<TransactionRef> tr = util::none);
     MutableSubscriptionSet make_mutable_copy(const SubscriptionSet& set);
 
     // Ensure the subscriptions table is properly initialized. No-op if already initialized.


### PR DESCRIPTION
## What, How & Why?
Instead of throwing the read transaction away after committing subscription changes and then opening a new frozen transaction at the committed transaction's version - we should just re-use the read transaction.

## ☑️ ToDos
* [x] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed
* [ ] `bindgen/spec.yml`, if public C++ API changed
