### PR TITLE
fix: add missing cstdlib header in cli_args.cpp

### DIFF
--- a/src/realm/util/cli_args.cpp
+++ b/src/realm/util/cli_args.cpp
@@ -1,6 +1,7 @@
 #include "realm/util/cli_args.hpp"
 
 #include <algorithm>
+#include <cstdlib>
 #include <cerrno>
 #include <cstdint>
 #include <string>


### PR DESCRIPTION
## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->
<!-- Please read CONTRIBUTING.md -->

Fix compilation issue by adding missing cstdlib header in cli_args.cpp. This resolves a build compatibility problem where `std::strtol` function was used without including the proper header declaration, causing compilation failures in some environments.

The fix ensures the code compiles correctly across different platforms and compiler versions by providing the proper declaration for the `std::strtol` function used on line 67.

This closes #8088

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [x] 🚦 Tests
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [x] 💥 `Breaking` label has been applied or is not necessary
* [ ] 🔔 Mention `@realm/devdocs` if documentation changes are needed