### PR TITLE
fix: add missing cstdlib header in cli_args.cpp (community branch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Added missing cstdlib header in cli_args.cpp. (PR [#8091](https://github.com/realm/realm-core/pull/8091))
 
 ### Breaking changes
 * None.

--- a/src/realm/util/cli_args.cpp
+++ b/src/realm/util/cli_args.cpp
@@ -1,6 +1,7 @@
 #include "realm/util/cli_args.hpp"
 
 #include <algorithm>
+#include <cstdlib>
 #include <cerrno>
 #include <cstdint>
 #include <string>


### PR DESCRIPTION
Cherry picks https://github.com/realm/realm-core/pull/8089 into the community branch