### PR TITLE
Fix Xcode 27 Build error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Fix compilation with Xcode 27 ([PR #8096](https://github.com/realm/realm-core/pull/8096))
 
 ### Breaking changes
 * None.

--- a/src/external/s2/s2polyline.cc
+++ b/src/external/s2/s2polyline.cc
@@ -438,26 +438,21 @@ struct SearchState {
   inline SearchState(int i_val, int j_val, bool i_in_progress_val)
       : i(i_val), j(j_val), i_in_progress(i_in_progress_val) {}
 
+  // This operator is needed for storing SearchStates in a set.  The ordering
+  // chosen has no special meaning.
+  inline bool operator<(SearchState const& rhs) const {
+    if (i < rhs.i) return true;
+    if (i > rhs.i) return false;
+    if (j < rhs.j) return true;
+    if (j > rhs.j) return false;
+    return !i_in_progress && rhs.i_in_progress;
+  }
+
   int i;
   int j;
   bool i_in_progress;
 };
 }  // namespace
-
-namespace std {
-template<>
-struct less<SearchState> {
-  // This operator is needed for storing SearchStates in a set.  The ordering
-  // chosen has no special meaning.
-  inline bool operator()(SearchState const& lhs, SearchState const& rhs) const {
-    if (lhs.i < rhs.i) return true;
-    if (lhs.i > rhs.i) return false;
-    if (lhs.j < rhs.j) return true;
-    if (lhs.j > rhs.j) return false;
-    return !lhs.i_in_progress && rhs.i_in_progress;
-  }
-};
-}  // namespace std
 
 bool S2Polyline::NearlyCoversPolyline(S2Polyline const& covered,
                                       S1Angle const& max_error) const {


### PR DESCRIPTION
## What, How & Why?
Xcode 27 doesn't compile currently. 
First reported in [realm-swift](https://github.com/realm/realm-swift/issues/8827) 

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed
* [ ] `bindgen/spec.yml`, if public C++ API changed
